### PR TITLE
Removes @JsonIgnore from individual questionDTOs

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFreeTextQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFreeTextQuestionDTO.java
@@ -30,16 +30,5 @@ import java.util.List;
 @JsonContentType("isaacFreeTextQuestion")
 @ValidatesWith(IsaacFreeTextValidator.class)
 public class IsaacFreeTextQuestionDTO extends IsaacQuestionBaseDTO {
-    @Override
-    public final List<ChoiceDTO> getChoices() {
-        // we do not want the choice list to be displayed to users.
-        return null;
-    }
 
-    // stop the answer being returned for this type of question
-    @JsonIgnore
-    @Override
-    public ContentBaseDTO getAnswer() {
-        return super.getAnswer();
-    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
@@ -29,10 +29,4 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 @JsonContentType("isaacGraphSketcherQuestion")
 @ValidatesWith(IsaacGraphSketcherValidator.class)
 public class IsaacGraphSketcherQuestionDTO extends IsaacSymbolicQuestionDTO {
-    // stop the answer being returned for this type of question
-    @JsonIgnore
-    @Override
-    public ContentBaseDTO getAnswer() {
-        return super.getAnswer();
-    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
@@ -31,7 +31,9 @@ public class IsaacMultiChoiceQuestionDTO extends IsaacQuestionBaseDTO {
 
     /**
      * Gets the choices.
-     * 
+     * Unignores getting the choices as they are required
+     * to be presented in multi-choice questions
+     *
      * @return the choices
      */
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
@@ -15,10 +15,12 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
-import uk.ac.cam.cl.dtg.segue.dto.content.ContentBaseDTO;
+import uk.ac.cam.cl.dtg.segue.dto.content.ChoiceDTO;
 
 /**
  * Content DO for isaacMultiChoiceQuestions.
@@ -27,9 +29,15 @@ import uk.ac.cam.cl.dtg.segue.dto.content.ContentBaseDTO;
 @JsonContentType("isaacMultiChoiceQuestion")
 public class IsaacMultiChoiceQuestionDTO extends IsaacQuestionBaseDTO {
 
-    @JsonIgnore
+    /**
+     * Gets the choices.
+     * 
+     * @return the choices
+     */
     @Override
-    public ContentBaseDTO getAnswer() {
-        return super.getAnswer();
+    @JsonIgnore(false)
+    public List<ChoiceDTO> getChoices() {
+        return choices;
     }
+
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
@@ -37,7 +37,7 @@ public class IsaacMultiChoiceQuestionDTO extends IsaacQuestionBaseDTO {
     @Override
     @JsonIgnore(false)
     public List<ChoiceDTO> getChoices() {
-        return choices;
+        return super.choices;
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
@@ -37,7 +37,7 @@ public class IsaacMultiChoiceQuestionDTO extends IsaacQuestionBaseDTO {
     @Override
     @JsonIgnore(false)
     public List<ChoiceDTO> getChoices() {
-        return super.choices;
+        return super.getChoices();
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
@@ -64,12 +64,6 @@ public class IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
         this.requireUnits = requireUnits;
     }
 
-    @Override
-    public final List<ChoiceDTO> getChoices() {
-        // we do not want the choice list to be displayed to users.
-        return null;
-    }
-
     /**
      * Gets the knownUnits.
      * 
@@ -150,10 +144,4 @@ public class IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
         this.significantFiguresMax = significantFigures;
     }
 
-    // stop the answer being returned for this type of question
-    @JsonIgnore
-    @Override
-    public ContentBaseDTO getAnswer() {
-        return super.getAnswer();
-    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuickQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuickQuestionDTO.java
@@ -15,7 +15,10 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.ac.cam.cl.dtg.segue.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
+
 
 /**
  * Quick Question DTO.
@@ -24,4 +27,9 @@ import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
 @JsonContentType("isaacQuestion")
 public class IsaacQuickQuestionDTO extends IsaacQuestionBaseDTO {
 
+    @Override
+    @JsonIgnore(false)
+    public ContentBaseDTO getAnswer() {
+        return super.getAnswer();
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuickQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuickQuestionDTO.java
@@ -26,7 +26,11 @@ import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
  */
 @JsonContentType("isaacQuestion")
 public class IsaacQuickQuestionDTO extends IsaacQuestionBaseDTO {
-
+    /**
+     * Unignores getting the answer as it is
+     * required to be shown in a quick question
+     * @return the answer
+     */
     @Override
     @JsonIgnore(false)
     public ContentBaseDTO getAnswer() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
@@ -33,19 +33,6 @@ import java.util.List;
 public class IsaacStringMatchQuestionDTO extends IsaacQuestionBaseDTO {
     private Boolean multiLineEntry;
 
-    @Override
-    public final List<ChoiceDTO> getChoices() {
-        // we do not want the choice list to be displayed to users.
-        return null;
-    }
-
-    // stop the answer being returned for this type of question
-    @JsonIgnore
-    @Override
-    public ContentBaseDTO getAnswer() {
-        return super.getAnswer();
-    }
-
     public Boolean getMultiLineEntry() {
         return multiLineEntry;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicChemistryQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicChemistryQuestionDTO.java
@@ -25,10 +25,4 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 @ValidatesWith(IsaacSymbolicChemistryValidator.class)
 public class IsaacSymbolicChemistryQuestionDTO extends IsaacSymbolicQuestionDTO {
 
-    // stop the answer being returned for this type of question
-    @JsonIgnore
-    @Override
-    public ContentBaseDTO getAnswer() {
-        return super.getAnswer();
-    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicLogicQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicLogicQuestionDTO.java
@@ -25,10 +25,4 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 @ValidatesWith(IsaacSymbolicLogicValidator.class)
 public class IsaacSymbolicLogicQuestionDTO extends IsaacSymbolicQuestionDTO {
 
-    // stop the answer being returned for this type of question
-    @JsonIgnore
-    @Override
-    public ContentBaseDTO getAnswer() {
-        return super.getAnswer();
-    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicQuestionDTO.java
@@ -51,10 +51,4 @@ public class IsaacSymbolicQuestionDTO extends IsaacQuestionBaseDTO {
         this.availableSymbols = availableSymbols;
     }
 
-    // stop the answer being returned for this type of question
-    @JsonIgnore
-    @Override
-    public ContentBaseDTO getAnswer() {
-        return super.getAnswer();
-    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/ChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/ChoiceQuestionDTO.java
@@ -18,6 +18,7 @@ package uk.ac.cam.cl.dtg.segue.dto.content;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.ac.cam.cl.dtg.segue.dto.content.ChoiceDTO;
 import uk.ac.cam.cl.dtg.segue.quiz.ChoiceQuestionValidator;
 import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 
@@ -39,10 +40,11 @@ public class ChoiceQuestionDTO extends QuestionDTO {
     }
 
     /**
-     * Gets the choices.
-     * 
+     * Gets the choices. Defaults to not return choices.
+     * Manually unignore, e.g. multi-choice questions
      * @return the choices
      */
+    @JsonIgnore
     public List<ChoiceDTO> getChoices() {
         return choices;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuestionDTO.java
@@ -15,8 +15,11 @@
  */
 package uk.ac.cam.cl.dtg.segue.dto.content;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.List;
 
+import uk.ac.cam.cl.dtg.segue.dto.content.ChoiceDTO;
 import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
 
 /**
@@ -39,10 +42,11 @@ public class QuestionDTO extends ContentDTO {
     }
 
     /**
-     * Gets the answer.
-     * 
+     * Gets the answer, defaults to not return to the user.
+     * Manually unignored e.g. quick questions
      * @return the answer
      */
+    @JsonIgnore
     public ContentBaseDTO getAnswer() {
         return answer;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuestionDTO.java
@@ -43,7 +43,8 @@ public class QuestionDTO extends ContentDTO {
 
     /**
      * Gets the answer, defaults to not return to the user.
-     * Manually unignored e.g. quick questions
+     * This is Manually unignored when the answer is required to
+     * be returned to the user e.g. quick questions
      * @return the answer
      */
     @JsonIgnore


### PR DESCRIPTION
@JsonIgnore added into parent DTOs for getAnswer() and getChoices() methods so they aren't accidentally passed through to new question types. Can be manually given with @JsonIgnore(false)

