### PR TITLE
Add a topic summary page type

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -39,6 +39,7 @@ public final class Constants {
     public static final String POD_FRAGMENT_TYPE = "isaacPod";
     public static final String PAGE_TYPE = "page";
     public static final String QUESTIONS_PAGE_TYPE = "questionsPage";
+    public static final String TOPIC_SUMMARY_PAGE_TYPE = "isaacTopicSummaryPage";
     public static final String EVENT_TYPE = "isaacEventPage";
 
     public static final String RELATED_CONTENT_FIELDNAME = "relatedContent";
@@ -125,6 +126,7 @@ public final class Constants {
         VIEW_PAGE,
         VIEW_PAGE_FRAGMENT,
         VIEW_QUESTION,
+        VIEW_TOPIC_SUMMARY_PAGE,
         VIEW_USER_PROGRESS
     }
     public static final Set<String> ISAAC_LOG_TYPES = Arrays.stream(IsaacLogType.values()).map(IsaacLogType::name).collect(Collectors.toSet());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -551,7 +551,7 @@ public class PagesFacade extends AbstractIsaacFacade {
      * @return A Response object containing a page object or containing a SegueErrorResponse.
      */
     @GET
-    @Path("topic/{topic_id}")
+    @Path("topics/{topic_id}")
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
     @ApiOperation(value = "Get a topic summary with a list of related material.")
@@ -565,7 +565,7 @@ public class PagesFacade extends AbstractIsaacFacade {
             return cachedResponse;
         }
 
-        // Topic summary pahes have the ID convention "topic_summary_[tag_name]"
+        // Topic summary pages have the ID convention "topic_summary_[tag_name]"
         String summaryPageId = String.format("topic_summary_%s", topicId);
 
         // Load the summary page:

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -28,10 +28,12 @@ import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.URIManager;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuestionSummaryPage;
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacTopicSummaryPage;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardItem;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuestionPageDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuestionSummaryPageDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacTopicSummaryPageDTO;
 import uk.ac.cam.cl.dtg.segue.api.SegueContentFacade;
 import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
@@ -66,6 +68,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -533,6 +536,58 @@ public class PagesFacade extends AbstractIsaacFacade {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
                     "Unable to retrieve Content requested due to an internal server error.", e).toResponse();
         }
+    }
+
+
+    /**
+     *  Get and augment a topic summary.
+     *
+     * @param request
+     *            - so we can deal with caching.
+     * @param httpServletRequest
+     *            - so that we can extract user information.
+     * @param topicId
+     *            as a string
+     * @return A Response object containing a page object or containing a SegueErrorResponse.
+     */
+    @GET
+    @Path("topic/{topic_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @GZIP
+    @ApiOperation(value = "Get a topic summary with a list of related material.")
+    public final Response getTopicSummaryPage(@Context final Request request,
+                                                 @Context final HttpServletRequest httpServletRequest, @PathParam("topic_id") final String topicId) {
+        // Calculate the ETag on current live version of the content
+        // NOTE: Assumes that the latest version of the content is being used.
+        EntityTag etag = new EntityTag(this.contentManager.getCurrentContentSHA().hashCode() + topicId.hashCode() + "");
+        Response cachedResponse = generateCachedResponse(request, etag);
+        if (cachedResponse != null) {
+            return cachedResponse;
+        }
+
+        // Topic summary pahes have the ID convention "topic_summary_[tag_name]"
+        String summaryPageId = String.format("topic_summary_%s", topicId);
+
+        // Load the summary page:
+        Map<String, List<String>> fieldsToMatch = Maps.newHashMap();
+        fieldsToMatch.put(TYPE_FIELDNAME, Collections.singletonList(TOPIC_SUMMARY_PAGE_TYPE));
+        if (null != summaryPageId) {
+            fieldsToMatch.put(ID_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, Collections.singletonList(summaryPageId));
+        }
+        Response result = this.findSingleResult(fieldsToMatch);
+
+        // If we have a topic summary, log the request:
+        if (result.getEntity() instanceof IsaacTopicSummaryPageDTO) {
+            ImmutableMap<String, String> logEntry = new ImmutableMap.Builder<String, String>()
+                    .put(PAGE_ID_LOG_FIELDNAME, summaryPageId)
+                    .put(CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA()).build();
+
+            getLogManager().logEvent(userManager.getCurrentUser(httpServletRequest), httpServletRequest,
+                    IsaacLogType.VIEW_TOPIC_SUMMARY_PAGE, logEntry);
+        }
+
+        return Response.status(result.getStatus()).entity(result.getEntity())
+                .cacheControl(getCacheControl(NUMBER_SECONDS_IN_ONE_HOUR, true)).tag(etag).build();
     }
     
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacTopicSummaryPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacTopicSummaryPage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.dos;
+
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacTopicSummaryPageDTO;
+import uk.ac.cam.cl.dtg.segue.dos.content.DTOMapping;
+import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.segue.dos.content.SeguePage;
+
+/**
+ * Isaac Topic Summary Page DO.
+ *
+ * Provide a summary of a topic with a list of relevant questions and concepts.
+ * It is a separate type to a standard page to ensure that only pages that are
+ * meant to be topic indices can be loaded as such.
+ */
+@DTOMapping(IsaacTopicSummaryPageDTO.class)
+@JsonContentType("isaacTopicSummaryPage")
+public class IsaacTopicSummaryPage extends SeguePage {
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacTopicSummaryPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacTopicSummaryPageDTO.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.dto;
+
+import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.segue.dto.content.SeguePageDTO;
+
+/**
+ * Isaac Topic Summary Page DTO.
+ *
+ * Provide a summary of a topic with a list of relevant questions and concepts.
+ * It is a separate type to a standard page to ensure that only pages that are
+ * meant to be topic indices can be loaded as such.
+ */
+@JsonContentType("isaacTopicSummaryPage")
+public class IsaacTopicSummaryPageDTO extends SeguePageDTO {
+}


### PR DESCRIPTION
This will need changes to the editor to allow this page type to be created, but it has no functionality beyond pages. It exists as a separate type to ensure only pages that are meant to be summary pages can be used as such, and may be modified in future.

---

**Pull Request Check List**
- [x] Added enough Logging to monitor expected behaviour change
