### PR TITLE
Include event additional information in user delete cleanup process.

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -742,6 +742,16 @@ public class EventBookingManager {
     }
 
     /**
+     * Expunge additional information fields for all of a given user's bookings i.e. to remove PII.
+     *
+     * @param user  - user to unbook
+     * @throws SegueDatabaseException - if an error occurs.
+     */
+    public void deleteUsersAdditionalInformationBooking(final RegisteredUserDTO user) throws SegueDatabaseException {
+        this.bookingPersistenceManager.deleteAdditionalInformation(user.getId());
+    }
+
+    /**
      * This method will attempt to resend the last email that a user booked on an event should have received.
      * E.g. if their status is confirmed it would be a welcome email, if cancelled it would be a cancellation one.
      *

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -210,6 +210,16 @@ public class EventBookingPersistenceManager {
     }
 
     /**
+     * @param userId
+     *            - user id
+     * @throws SegueDatabaseException
+     *             - if an error occurs.
+     */
+    public void deleteAdditionalInformation(final Long userId) throws SegueDatabaseException {
+        dao.deleteAdditionalInformation(userId);
+    }
+
+    /**
      * Acquire a globally unique database lock.
      *
      * This lock must be released manually.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -142,4 +142,11 @@ public interface EventBookings {
      *             - if an error occurs.
      */
     EventBooking findBookingByEventAndUser(String eventId, Long userId) throws SegueDatabaseException;
+
+    /**
+     * Expunge the additional information field for all bookings for a given user id.
+     *
+     * @param userId - user id
+     */
+    void deleteAdditionalInformation(Long userId) throws SegueDatabaseException;
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,6 +57,8 @@ public class PgEventBookings implements EventBookings {
      * 
      * @param ds
      *            connection to the database.
+     * @param mapper
+     *            object mapper
      */
     public PgEventBookings(final PostgresSqlDb ds, final ObjectMapper mapper) {
         this.ds = ds;
@@ -161,6 +163,22 @@ public class PgEventBookings implements EventBookings {
 
         } catch (SQLException e) {
             throw new SegueDatabaseException("Postgres exception while trying to delete event booking", e);
+        }
+    }
+
+    @Override
+    public void deleteAdditionalInformation(Long userId) throws SegueDatabaseException {
+        PreparedStatement pst;
+        try (Connection conn = ds.getDatabaseConnection()) {
+            pst = conn.prepareStatement("UPDATE event_bookings " +
+                    "SET additional_booking_information = null " +
+                    "WHERE user_id = ?;");
+
+            pst.setLong(1, userId);
+            pst.executeUpdate();
+
+        } catch (SQLException e) {
+            throw new SegueDatabaseException("Postgres exception while trying to expunge additional event information", e);
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -36,6 +36,7 @@ import org.jboss.resteasy.annotations.GZIP;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.api.managers.EventBookingManager;
 import uk.ac.cam.cl.dtg.segue.api.Constants.*;
 import uk.ac.cam.cl.dtg.segue.api.managers.StatisticsManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
@@ -126,6 +127,7 @@ public class AdminFacade extends AbstractSegueFacade {
     private final SchoolListReader schoolReader;
 
     private final AbstractUserPreferenceManager userPreferenceManager;
+    private final EventBookingManager eventBookingManager;
 
     /**
      * Create an instance of the administrators facade.
@@ -144,12 +146,15 @@ public class AdminFacade extends AbstractSegueFacade {
      *            - for geocoding if we need it.
      * @param schoolReader
      *            - for looking up school information
+     * @param eventBookingManager
+     *            - for using the event booking system
      */
     @Inject
     public AdminFacade(final PropertiesLoader properties, final UserAccountManager userManager,
                        final IContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex, final ILogManager logManager,
                        final StatisticsManager statsManager, final LocationManager locationManager,
-                       final SchoolListReader schoolReader, final AbstractUserPreferenceManager userPreferenceManager) {
+                       final SchoolListReader schoolReader, final AbstractUserPreferenceManager userPreferenceManager,
+                       final EventBookingManager eventBookingManager) {
         super(properties, logManager);
         this.userManager = userManager;
         this.contentManager = contentManager;
@@ -158,6 +163,7 @@ public class AdminFacade extends AbstractSegueFacade {
         this.locationManager = locationManager;
         this.schoolReader = schoolReader;
         this.userPreferenceManager = userPreferenceManager;
+        this.eventBookingManager = eventBookingManager;
     }
 
     /**
@@ -935,7 +941,7 @@ public class AdminFacade extends AbstractSegueFacade {
             RegisteredUserDTO userToDelete = this.userManager.getUserDTOById(userId);
             
             this.userManager.deleteUserAccount(userToDelete);
-            
+            this.eventBookingManager.deleteUsersAdditionalInformationBooking(userToDelete);
             getLogManager().logEvent(currentlyLoggedInUser, httpServletRequest, SegueLogType.DELETE_USER_ACCOUNT,
                     ImmutableMap.of(USER_ID_FKEY_FIELDNAME, userToDelete.getId()));
             


### PR DESCRIPTION
This should expunge additional information added to event bookings by users if an admin deletes them.

I chose to do it like this to preserve looser coupling between user deletion and the event management system at the expense of atomic transactions. We can revisit this decision if we want to later.

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [ ] Peer-Reviewed
