### PR TITLE
Cache our requesting of the current SHA for a minute

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -74,6 +74,7 @@ public class GitContentManager implements IContentManager {
     private final Random randomNumberGenerator = new Random();
 
     private final Cache<Object, Object> cache;
+    private final Cache<String, GetResponse> contentShaCache;
 
 
     /**
@@ -103,6 +104,7 @@ public class GitContentManager implements IContentManager {
         }
 
         this.cache = CacheBuilder.newBuilder().softValues().expireAfterAccess(1, TimeUnit.DAYS).build();
+        this.contentShaCache = CacheBuilder.newBuilder().softValues().expireAfterWrite(1, TimeUnit.MINUTES).build();
     }
 
     /**
@@ -123,6 +125,7 @@ public class GitContentManager implements IContentManager {
         this.globalProperties = null;
         this.allowOnlyPublishedContent = false;
         this.cache = CacheBuilder.newBuilder().softValues().expireAfterAccess(1, TimeUnit.DAYS).build();
+        this.contentShaCache = CacheBuilder.newBuilder().softValues().expireAfterWrite(1, TimeUnit.MINUTES).build();
     }
 
     @Override
@@ -525,9 +528,16 @@ public class GitContentManager implements IContentManager {
 
     @Override
     public String getCurrentContentSHA() {
-        GetResponse r = searchProvider.getById(globalProperties.getProperty(Constants.CONTENT_INDEX),
-                Constants.CONTENT_INDEX_TYPE.METADATA.toString(), "general");
-        return (String) r.getSource().get("version");
+        String contentIndex = globalProperties.getProperty(Constants.CONTENT_INDEX);
+        GetResponse versionResponse = contentShaCache.getIfPresent(contentIndex);
+        if (null == versionResponse) {
+            versionResponse = searchProvider.getById(
+                    globalProperties.getProperty(Constants.CONTENT_INDEX),
+                    Constants.CONTENT_INDEX_TYPE.METADATA.toString(), "general"
+            );
+            contentShaCache.put(contentIndex, versionResponse);
+        }
+        return (String) versionResponse.getSource().get("version");
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -531,10 +531,8 @@ public class GitContentManager implements IContentManager {
         String contentIndex = globalProperties.getProperty(Constants.CONTENT_INDEX);
         GetResponse versionResponse = contentShaCache.getIfPresent(contentIndex);
         if (null == versionResponse) {
-            versionResponse = searchProvider.getById(
-                    globalProperties.getProperty(Constants.CONTENT_INDEX),
-                    Constants.CONTENT_INDEX_TYPE.METADATA.toString(), "general"
-            );
+            versionResponse =
+                    searchProvider.getById(contentIndex, Constants.CONTENT_INDEX_TYPE.METADATA.toString(), "general");
             contentShaCache.put(contentIndex, versionResponse);
         }
         return (String) versionResponse.getSource().get("version");


### PR DESCRIPTION
Previously we were making this request to elasticsearch for each question in each gamebaord.
If the user had many assignments/groups this could easily add about half a second to a request. Hopefully this will help contribute to the speeding up of requests.

---

**Pull Request Check List**
- Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- Added enough Logging to monitor expected behaviour change
- Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
