### PR TITLE
Fix uncaught runtime exception when quartz tries to start with readonly db

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
@@ -55,12 +55,18 @@ public class SegueJobService implements ServletContextListener {
         try {
             scheduler = stdSchedulerFactory.getScheduler();
 
+        } catch (SchedulerException e) {
+            throw new RuntimeException("Unable to initialise the scheduler", e);
+        }
+
+        // try to schedule / reschedule jobs
+        try {
             // register statically configured jobs
             this.registerScheduledJobs(staticallyConfiguredScheduledJobs);
 
             scheduler.start();
         } catch (SchedulerException e) {
-            throw new RuntimeException("Unable to initialise the scheduler", e);
+            log.error("Scheduler ERROR - Unable to to schedule quartz jobs or start scheduler on this API instance. Aborting...", e);
         }
     }
 


### PR DESCRIPTION
Fix uncaught runtime exception which is triggered when db is in read only mode. This fix will mean we have to restart the API after initialisation if we see this error. We can improve this later.

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [ ] Peer-Reviewed
