### PR TITLE
Allow emails to be sent with a custom From address

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/GroupManagerLookupMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/GroupManagerLookupMisuseHandler.java
@@ -80,9 +80,8 @@ public class GroupManagerLookupMisuseHandler implements IMisuseHandler {
     @Override
     public void executeSoftThresholdAction(final String message) {
         final String subject = "Soft Threshold limit reached for GroupManagerLookup endpoint";
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
+        EmailCommunicationMessage e = new EmailCommunicationMessage(properties.getProperty(Constants.SERVER_ADMIN_ADDRESS),
+                                                subject, message, message, EmailType.ADMIN);
         try {
             emailManager.addSystemEmailToQueue(e);
         } catch (SegueDatabaseException e1) {
@@ -97,9 +96,8 @@ public class GroupManagerLookupMisuseHandler implements IMisuseHandler {
     public void executeHardThresholdAction(final String message) {
         final String subject = "HARD Threshold limit reached for GroupManagerLookup endpoint";
 
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
+        EmailCommunicationMessage e = new EmailCommunicationMessage(properties.getProperty(Constants.SERVER_ADMIN_ADDRESS),
+                subject, message, message, EmailType.ADMIN);
         try {
             emailManager.addSystemEmailToQueue(e);
         } catch (SegueDatabaseException e1) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IPQuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IPQuestionAttemptMisuseHandler.java
@@ -71,9 +71,8 @@ public class IPQuestionAttemptMisuseHandler implements IMisuseHandler {
     @Override
     public void executeHardThresholdAction(final String message) {
         final String subject = "HARD Threshold limit reached for IP Address based Question Attempts!";
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
+        EmailCommunicationMessage e = new EmailCommunicationMessage(properties.getProperty(Constants.SERVER_ADMIN_ADDRESS),
+                subject, message, message, EmailType.ADMIN);
         try {
             emailManager.addSystemEmailToQueue(e);
         } catch (SegueDatabaseException e1) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/LogEventMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/LogEventMisuseHandler.java
@@ -79,9 +79,8 @@ public class LogEventMisuseHandler implements IMisuseHandler {
     public void executeHardThresholdAction(final String message) {
         final String subject = "HARD Threshold limit reached for: LogEventMisuseHandler -- Log Data Requests too large";
 
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
+        EmailCommunicationMessage e = new EmailCommunicationMessage(properties.getProperty(Constants.SERVER_ADMIN_ADDRESS),
+                subject, message, message, EmailType.ADMIN);
 
         try {
 			emailManager.addSystemEmailToQueue(e);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/RegistrationMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/RegistrationMisuseHandler.java
@@ -80,9 +80,8 @@ public class RegistrationMisuseHandler implements IMisuseHandler {
     @Override
     public void executeSoftThresholdAction(final String message) {
         final String subject = "Soft Threshold limit reached for Registration endpoint";
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
+        EmailCommunicationMessage e = new EmailCommunicationMessage(properties.getProperty(Constants.SERVER_ADMIN_ADDRESS),
+                subject, message, message, EmailType.ADMIN);
         try {
             emailManager.addSystemEmailToQueue(e);
         } catch (SegueDatabaseException e1) {
@@ -97,9 +96,8 @@ public class RegistrationMisuseHandler implements IMisuseHandler {
     public void executeHardThresholdAction(final String message) {
         final String subject = "HARD Threshold limit reached for Registration endpoint";
 
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
+        EmailCommunicationMessage e = new EmailCommunicationMessage(properties.getProperty(Constants.SERVER_ADMIN_ADDRESS),
+                subject, message, message, EmailType.ADMIN);
         try {
             emailManager.addSystemEmailToQueue(e);
         } catch (SegueDatabaseException e1) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TokenOwnerLookupMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TokenOwnerLookupMisuseHandler.java
@@ -81,9 +81,8 @@ public class TokenOwnerLookupMisuseHandler implements IMisuseHandler {
     @Override
     public void executeSoftThresholdAction(final String message) {
         final String subject = "Soft Threshold limit reached for TokenOwnershipRequest endpoint";
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
+        EmailCommunicationMessage e = new EmailCommunicationMessage(properties.getProperty(Constants.SERVER_ADMIN_ADDRESS),
+                subject, message, message, EmailType.ADMIN);
         try {
 			emailManager.addSystemEmailToQueue(e);
 		} catch (SegueDatabaseException e1) {
@@ -98,9 +97,8 @@ public class TokenOwnerLookupMisuseHandler implements IMisuseHandler {
     public void executeHardThresholdAction(final String message) {
         final String subject = "HARD Threshold limit reached for TokenOwnershipRequest endpoint";
 
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
+        EmailCommunicationMessage e = new EmailCommunicationMessage(properties.getProperty(Constants.SERVER_ADMIN_ADDRESS),
+                subject, message, message, EmailType.ADMIN);
         try {
 			emailManager.addSystemEmailToQueue(e);
 		} catch (SegueDatabaseException e1) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailCommunicationMessage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailCommunicationMessage.java
@@ -35,6 +35,10 @@ public class EmailCommunicationMessage implements ICommunicationMessage {
 
     private final String htmlMessage;
 
+    private final String overrideFromAddress;
+
+    private final String overrideFromName;
+
     private final String replyToAddress;
 
     private final String replyToName;
@@ -48,6 +52,8 @@ public class EmailCommunicationMessage implements ICommunicationMessage {
      * @param recipientAddress address of user
      * @param subject subject of email
      * @param plainTextMessage message in email
+     * @param overrideFromAddress an override from address
+     * @param overrideFromName an override of the from name
      * @param htmlMessage html message in email
      * @param emailType the type of the message
      * @param replyToAddress (nullable) the preferred reply to address.
@@ -58,6 +64,7 @@ public class EmailCommunicationMessage implements ICommunicationMessage {
     public EmailCommunicationMessage(@Nullable final Long userId, final String recipientAddress,
                                      final String subject, final String plainTextMessage,
                                      final String htmlMessage, final EmailType emailType,
+                                     @Nullable final String overrideFromAddress, @Nullable final String overrideFromName,
                                      @Nullable final String replyToAddress, @Nullable final String replyToName,
                                      @Nullable final List<EmailAttachment> attachments) {
         this.userId = userId;
@@ -65,10 +72,35 @@ public class EmailCommunicationMessage implements ICommunicationMessage {
         this.recipientAddress = recipientAddress;
         this.subject = subject;
         this.htmlMessage = htmlMessage;
+        this.overrideFromAddress = overrideFromAddress;
+        this.overrideFromName = overrideFromName;
         this.replyToAddress = replyToAddress;
         this.replyToName = replyToName;
         this.emailType = emailType;
         this.attachments = attachments;
+    }
+
+    /**
+     * @param recipientAddress address of user
+     * @param subject subject of email
+     * @param plainTextMessage message in email
+     * @param htmlMessage html message in email
+     * @param emailType the type of the message
+     *
+     */
+    public EmailCommunicationMessage(final String recipientAddress, final String subject, final String plainTextMessage,
+                                     final String htmlMessage, final EmailType emailType) {
+        this.userId = null;
+        this.plainTextMessage = plainTextMessage;
+        this.recipientAddress = recipientAddress;
+        this.subject = subject;
+        this.htmlMessage = htmlMessage;
+        this.overrideFromAddress = null;
+        this.overrideFromName = null;
+        this.replyToAddress = null;
+        this.replyToName = null;
+        this.emailType = emailType;
+        this.attachments = null;
     }
 
     /**
@@ -105,7 +137,20 @@ public class EmailCommunicationMessage implements ICommunicationMessage {
     public String getSubject() {
         return subject;
     }
-    
+
+    /**
+     * @return overrideFromAddress if set.
+     */
+    public String getOverrideFromAddress() {
+        return overrideFromAddress;
+    }
+
+    /**
+     * @return overrideFromName if set.
+     */
+    public String getOverrideFromName() {
+        return overrideFromName;
+    }
     /**
      * @return replyToAddress if set.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailCommunicator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailCommunicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +15,13 @@
  */
 package uk.ac.cam.cl.dtg.segue.comm;
 
-import javax.mail.MessagingException;
-
-import com.google.api.client.util.Lists;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import org.apache.commons.lang3.Validate;
-
-import org.elasticsearch.common.recycler.Recycler;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.util.Mailer;
 
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
-
+import javax.mail.MessagingException;
 import java.io.UnsupportedEncodingException;
 
 /**
@@ -34,7 +29,8 @@ import java.io.UnsupportedEncodingException;
  */
 public class EmailCommunicator implements ICommunicator<EmailCommunicationMessage> {
 	private Mailer mailer;
-	private String fromAddress;
+	private String defaultFromAddress;
+	private String mailName;
 
 	/**
 	 * Creates an instance of an email communicator that can send e-mails.
@@ -42,46 +38,56 @@ public class EmailCommunicator implements ICommunicator<EmailCommunicationMessag
 	 * @param smtpAddress
 	 *            the smtp server to use to send e-mails. Must be open for this
 	 *            implementation.
-	 * @param fromAddress
+	 * @param defaultFromAddress
 	 *            - The email address to show as the from address.
 	 * @param mailName
 	 *            - The name email will be sent from.
 	 */
 	@Inject
 	public EmailCommunicator(@Named(Constants.MAILER_SMTP_SERVER) final String smtpAddress,
-							 @Named(Constants.MAIL_FROM_ADDRESS) final String fromAddress,
+							 @Named(Constants.MAIL_FROM_ADDRESS) final String defaultFromAddress,
 							 @Named(Constants.MAIL_NAME) final String mailName) {
 		Validate.notNull(smtpAddress);
-		Validate.notNull(fromAddress);
+		Validate.notNull(defaultFromAddress);
 
-		this.fromAddress = fromAddress;
+		this.defaultFromAddress = defaultFromAddress;
+		this.mailName = mailName;
 
 		// Construct a new instance of the mailer object
-		this.mailer = new Mailer(smtpAddress, fromAddress, mailName);
+		this.mailer = new Mailer(smtpAddress, defaultFromAddress);
 	}
 
     /**
      * @param email
      *            - message to be sent. Will be plain text if no HTML is provided
      * @throws CommunicationException
+     *            - if email fails to be created and added to queue
      */
 	@Override
-	public void sendMessage(final EmailCommunicationMessage email)
-			throws CommunicationException {
+	public void sendMessage(final EmailCommunicationMessage email) throws CommunicationException {
+	    String fromAddress = this.defaultFromAddress;
+	    String fromName = this.mailName;
+
+	    // If override "From" details specified, use them:
+	    if (email.getOverrideFromAddress() != null && !email.getOverrideFromAddress().isEmpty()) {
+	        fromAddress = email.getOverrideFromAddress();
+        }
+	    if (email.getOverrideFromName() != null && !email.getOverrideFromName().isEmpty()) {
+	        fromName = email.getOverrideFromName();
+        }
+
         try {
             if (email.getHTMLMessage() == null) {
-                mailer.sendPlainTextMail(new String[] { email.getRecipientAddress() }, this.fromAddress,
+                mailer.sendPlainTextMail(new String[] { email.getRecipientAddress() }, fromAddress, fromName,
                         email.getReplyToAddress(), email.getReplyToName(), email.getSubject(),
                         email.getPlainTextMessage());
             } else {
-                mailer.sendMultiPartMail(new String[] { email.getRecipientAddress() }, this.fromAddress,
+                mailer.sendMultiPartMail(new String[] { email.getRecipientAddress() }, fromAddress, fromName,
                         email.getReplyToAddress(), email.getReplyToName(), email.getSubject(),
                         email.getPlainTextMessage(), email.getHTMLMessage(), email.getAttachments());
             }
-        } catch (MessagingException e) {
+        } catch (MessagingException | UnsupportedEncodingException e) {
             throw new CommunicationException(e);
-        } catch (UnsupportedEncodingException e) {
-			throw new CommunicationException(e);
-		}
-	}
+        }
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -36,7 +36,6 @@ import uk.ac.cam.cl.dtg.segue.dos.AbstractUserPreferenceManager;
 import uk.ac.cam.cl.dtg.segue.dos.UserPreference;
 import uk.ac.cam.cl.dtg.segue.dos.content.ExternalReference;
 import uk.ac.cam.cl.dtg.segue.dos.users.EmailVerificationStatus;
-import uk.ac.cam.cl.dtg.segue.dos.users.RegisteredUser;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.dto.content.EmailTemplateDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
@@ -45,16 +44,18 @@ import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 import javax.annotation.Nullable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_VERSION_FIELDNAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_TIME_LOCALITY;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueLogType;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueUserPreferences;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.USER_ID_LIST_FKEY_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics.QUEUED_EMAIL;
 
 /**
@@ -547,6 +548,9 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
         String plainTextContent = completeTemplateWithProperties(emailContent.getPlainTextContent(), contentPropertiesToUse);
         String HTMLContent = completeTemplateWithProperties(emailContent.getHtmlContent(), contentPropertiesToUse, true);
 
+        // Extract from address and reply to addresses:
+        String overrideFromAddress = emailContent.getOverrideFromAddress();
+        String overrideFromName = emailContent.getOverrideFromName();
         String replyToAddress = emailContent.getReplyToEmailAddress();
         String replyToName = emailContent.getReplyToName();
         if (replyToAddress == null || replyToAddress.isEmpty()) {
@@ -555,7 +559,6 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
         if (replyToName == null || replyToName.isEmpty()) {
             replyToName = globalProperties.getProperty(Constants.MAIL_NAME);
         }
-
         ContentDTO htmlTemplate = getContentDTO("email-template-html");
         ContentDTO plainTextTemplate = getContentDTO("email-template-ascii");
 
@@ -575,8 +578,8 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
                 plainTextTemplateProperties);
 
         return new EmailCommunicationMessage(userId, userEmail, emailContent.getSubject(),
-                plainTextMessage,
-                htmlMessage, emailType, replyToAddress, replyToName, attachments);
+                plainTextMessage, htmlMessage, emailType,
+                overrideFromAddress, overrideFromName, replyToAddress, replyToName, attachments);
 
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/EmailTemplate.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/EmailTemplate.java
@@ -15,10 +15,10 @@
  */
 package uk.ac.cam.cl.dtg.segue.dos.content;
 
+import uk.ac.cam.cl.dtg.segue.dto.content.EmailTemplateDTO;
+
 import java.util.List;
 import java.util.Set;
-
-import uk.ac.cam.cl.dtg.segue.dto.content.EmailTemplateDTO;
 
 /**
  * EmailTemplate DTO.
@@ -30,6 +30,8 @@ public class EmailTemplate extends Content {
     private String subject;
     private String plainTextContent;
     private String htmlContent;
+    private String overrideFromAddress;
+    private String overrideFromName;
     private String replyToEmailAddress;
     private String replyToName;
 
@@ -122,6 +124,38 @@ public class EmailTemplate extends Content {
      */
     public void setHtmlContent(final String htmlContent) {
         this.htmlContent = htmlContent;
+    }
+
+    /**
+     * Gets the overrideFromAddress.
+     * @return the overrideFromAddress
+     */
+    public String getOverrideFromAddress() {
+        return overrideFromAddress;
+    }
+
+    /**
+     * Sets the overrideFromAddress.
+     * @param overrideFromAddress the overrideFromAddress to set
+     */
+    public void setOverrideFromAddress(final String overrideFromAddress) {
+        this.overrideFromAddress = overrideFromAddress;
+    }
+
+    /**
+     * Gets the overrideFromName.
+     * @return the overrideFromName
+     */
+    public String getOverrideFromName() {
+        return overrideFromName;
+    }
+
+    /**
+     * Sets the overrideFromName.
+     * @param overrideFromName the overrideFromName to set
+     */
+    public void setOverrideFromName(final String overrideFromName) {
+        this.overrideFromName = overrideFromName;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/EmailTemplateDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/EmailTemplateDTO.java
@@ -15,22 +15,22 @@
  */
 package uk.ac.cam.cl.dtg.segue.dto.content;
 
+import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
+
 import java.util.List;
 import java.util.Set;
-
-import uk.ac.cam.cl.dtg.segue.dos.content.DTOMapping;
-import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
 
 /**
  * EmailTemplate.
  * 
  */
-@DTOMapping(EmailTemplateDTO.class)
 @JsonContentType("emailTemplate")
 public class EmailTemplateDTO extends ContentDTO {
     private String subject;
     private String plainTextContent;
     private String htmlContent;
+    private String overrideFromAddress;
+    private String overrideFromName;
     private String replyToEmailAddress;
     private String replyToName;
     
@@ -124,6 +124,36 @@ public class EmailTemplateDTO extends ContentDTO {
      */
     public void setHtmlContent(final String htmlContent) {
         this.htmlContent = htmlContent;
+    }
+
+    /**
+     * Gets the overrideFromAddress.
+     * @return the overrideFromAddress
+     */
+    public String getOverrideFromAddress() {
+        return overrideFromAddress;
+    }
+
+    /**
+     * Sets the overrideFromAddress.
+     * @param overrideFromAddress the overrideFromAddress to set
+     */
+    public void setOverrideFromAddress(final String overrideFromAddress) {
+        this.overrideFromAddress = overrideFromAddress;
+    }
+    /**
+     * Gets the overrideFromName.
+     * @return the overrideFromName
+     */
+    public String getOverrideFromName() {
+        return overrideFromName;
+    }
+    /**
+     * Sets the overrideFromName.
+     * @param overrideFromName the overrideFromName to set
+     */
+    public void setOverrideFromName(final String overrideFromName) {
+        this.overrideFromName = overrideFromName;
     }
 
     /**


### PR DESCRIPTION
This allows templates to specify an override From email address and name, without changing the Envelope-From address used for bounce messages.
It also removes unused configuration from the Mailer class; the `sender` array was never used and so the `mailName` property is now unnecessary.
It also adds a new constructor for EmailCommunicationMessages to remove the need for specifying so many null properties when sending admin email.

I am not sure if the handling of Reply-To and From address overrides should be in two different files (EmailManager and EmailCommunicator respectively) and this may want refactoring?