### PR TITLE
Add last updated timestamp to the user preferences table

### DIFF
--- a/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
+++ b/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
@@ -485,7 +485,8 @@ CREATE TABLE public.user_preferences (
     user_id integer NOT NULL,
     preference_type character varying(255) NOT NULL,
     preference_name character varying(255) NOT NULL,
-    preference_value boolean NOT NULL
+    preference_value boolean NOT NULL,
+    last_updated timestamp without time zone
 );
 
 

--- a/src/main/resources/db_scripts/user_preferences_last_updated_migration.sql
+++ b/src/main/resources/db_scripts/user_preferences_last_updated_migration.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE user_preferences ADD COLUMN last_updated timestamp without time zone;


### PR DESCRIPTION
The previous WHERE clause turns out to have been unnecessary, but the new one is required to prevent the last_updated date being set every time the user preferences are saved and to only update it when necessary.