### PR TITLE
Make it possible for upper level topics to link to a different topic at lower level

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -62,12 +62,12 @@ public final class Constants {
         CORRECT, INCORRECT, NOT_ATTEMPTED;
     }
 
-    public enum FastTrackConceptState {
+    public enum FASTTRACK_LEVEL {
         ft_top_ten,
         ft_upper,
         ft_lower;
-        public static FastTrackConceptState getStateFromTags(Set<String> tags) {
-            FastTrackConceptState state = null;
+        public static FASTTRACK_LEVEL getStateFromTags(Set<String> tags) {
+            FASTTRACK_LEVEL state = null;
             if (tags.contains("ft_top_ten")) {
                 state = ft_top_ten;
             } else if (tags.contains("ft_upper")) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -342,7 +342,8 @@ public class GameboardsFacade extends AbstractIsaacFacade {
      * @param request usually used for caching.
      * @param httpServletRequest so that we can extract the users session information if available.
      * @param gameboardId the unique id of the FastTrack gameboard which links the questions.
-     * @param history the list of questions that were traversed to get to the current question.
+     * @param upper the latest upper level question that is in the history.
+     * @param conceptTitle the concept title that the user is currently working on.
      * @return a Response containing a list of augmented gameboard items for the gamebaord-concept pair or an error.
      */
     @GET

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -343,7 +343,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
      * @param httpServletRequest so that we can extract the users session information if available.
      * @param gameboardId the unique id of the FastTrack gameboard which links the questions.
      * @param upper the latest upper level question that is in the history.
-     * @param conceptTitle the concept title that the user is currently working on.
+     * @param currentConceptTitle the concept title that the user is currently working on.
      * @return a Response containing a list of augmented gameboard items for the gamebaord-concept pair or an error.
      */
     @GET

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -304,7 +304,6 @@ public class GameboardsFacade extends AbstractIsaacFacade {
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
     @ApiOperation(value = "Get the progress of the current user at a FastTrack gameboard.")
-    @Deprecated // See below
     public final Response getFastTrackConceptProgress(@Context final Request request,
                                                       @Context final HttpServletRequest httpServletRequest,
                                                       @PathParam("gameboard_id") final String gameboardId,
@@ -347,23 +346,19 @@ public class GameboardsFacade extends AbstractIsaacFacade {
      * @return a Response containing a list of augmented gameboard items for the gamebaord-concept pair or an error.
      */
     @GET
-    @Path("fasttrack/{gameboard_id}/concepts_from_history/")
+    @Path("fasttrack/{gameboard_id}/concepts_with_upper/")
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
     @ApiOperation(value = "Get the progress of the current user at a FastTrack gameboard.")
     public final Response getFastTrackConceptFromHistory(@Context final Request request,
                                                          @Context final HttpServletRequest httpServletRequest,
                                                          @PathParam("gameboard_id") final String gameboardId,
-                                                         @QueryParam("history") final String history) {
+                                                         @QueryParam("upper") final String upper) {
 
         try {
-            List<String> historyList = Arrays.asList(history.split(","));
-            List<String> uppers = historyList.stream().filter(q -> q.contains("upper")).collect(Collectors.toList());
-            String lastUpper = uppers.get(uppers.size()-1);
-
             Map<String, List<String>> fieldsToMatch = Maps.newHashMap();
             fieldsToMatch.put(TYPE_FIELDNAME, Arrays.asList(FAST_TRACK_QUESTION_TYPE));
-            fieldsToMatch.put(ID_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, Arrays.asList(lastUpper));
+            fieldsToMatch.put(ID_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, Arrays.asList(upper));
             ResultsWrapper<ContentDTO> resultsList = this.api.findMatchingContent(this.contentIndex,
                     SegueContentFacade.generateDefaultFieldToMatch(fieldsToMatch), null, null);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -44,6 +44,7 @@ import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.segue.dto.SegueErrorResponse;
@@ -97,7 +98,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
 
     private final String contentIndex;
 
-    private final SegueContentFacade api;
+    private final IContentManager contentManager;
 
     /**
      * GamesFacade. For management of gameboards etc.
@@ -118,13 +119,13 @@ public class GameboardsFacade extends AbstractIsaacFacade {
      *            - for updating badge information.
      */
     @Inject
-    public GameboardsFacade(final SegueContentFacade api, final PropertiesLoader properties, final ILogManager logManager,
+    public GameboardsFacade(final IContentManager contentManager, final PropertiesLoader properties, final ILogManager logManager,
                             final GameManager gameManager, final QuestionManager questionManager,
                             final UserAccountManager userManager, final UserAssociationManager associationManager,
                             final UserBadgeManager userBadgeManager, @Named(CONTENT_INDEX) final String contentIndex) {
         super(properties, logManager);
 
-        this.api = api;
+        this.contentManager = contentManager;
         this.userBadgeManager = userBadgeManager;
         this.gameManager = gameManager;
         this.questionManager = questionManager;
@@ -324,8 +325,8 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             Map<String, List<String>> fieldsToMatch = Maps.newHashMap();
             fieldsToMatch.put(TYPE_FIELDNAME, Arrays.asList(FAST_TRACK_QUESTION_TYPE));
             fieldsToMatch.put(ID_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, Arrays.asList(upperQuestionId));
-            ResultsWrapper<ContentDTO> resultsList = this.api.findMatchingContent(this.contentIndex,
-                    SegueContentFacade.generateDefaultFieldToMatch(fieldsToMatch), null, null);
+            ResultsWrapper<ContentDTO> resultsList = this.contentManager.findByFieldNames(this.contentIndex,
+                    SegueContentFacade.generateDefaultFieldToMatch(fieldsToMatch), 0, DEFAULT_RESULTS_LIMIT);
 
             if (upperQuestionId.isEmpty()) {
                 // attempt to augment the gameboard with user information.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/FastTrackManger.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/FastTrackManger.java
@@ -39,7 +39,7 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.UNPROCESSED_SEARCH_FIELD_SUFF
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_GAMEBOARD_WHITELIST;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_LEVEL;
 
-public class FastTrackManger extends AbstractIsaacFacade {
+public class FastTrackManger {
     private static final Logger log = LoggerFactory.getLogger(FastTrackManger.class);
 
     private final String contentIndex;
@@ -58,15 +58,13 @@ public class FastTrackManger extends AbstractIsaacFacade {
      *            - the current content index of interest.
      */
     @Inject
-    public FastTrackManger(final PropertiesLoader properties, final ILogManager logManager,
-                           final IContentManager contentManager, final GameManager gameboardManager,
+    public FastTrackManger(final PropertiesLoader properties, final IContentManager contentManager, final GameManager gameboardManager,
                            @Named(CONTENT_INDEX) final String contentIndex) {
-        super(properties, logManager);
 
         this.contentManager = contentManager;
         this.contentIndex = contentIndex;
         this.gameboardManager = gameboardManager;
-        String commaSeparatedIds = this.getProperties().getProperty(FASTTRACK_GAMEBOARD_WHITELIST);
+        String commaSeparatedIds = properties.getProperty(FASTTRACK_GAMEBOARD_WHITELIST);
         this.fastTrackGamebaordIds = new HashSet<>(Arrays.asList(commaSeparatedIds.split(",")));
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/FastTrackManger.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/FastTrackManger.java
@@ -1,0 +1,150 @@
+package uk.ac.cam.cl.dtg.isaac.api.managers;
+
+import com.google.api.client.util.Maps;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.api.AbstractIsaacFacade;
+import uk.ac.cam.cl.dtg.isaac.dto.GameboardItem;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.api.SegueContentFacade;
+import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
+import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
+import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.util.PropertiesLoader;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Maps.immutableEntry;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.FAST_TRACK_QUESTION_TYPE;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.QUESTION_TYPE;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.SEARCH_MAX_WINDOW_SIZE;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_RESULTS_LIMIT;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.ID_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TAGS_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TITLE_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_GAMEBOARD_WHITELIST;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_LEVEL;
+
+public class FastTrackManger extends AbstractIsaacFacade {
+    private static final Logger log = LoggerFactory.getLogger(FastTrackManger.class);
+
+    private final String contentIndex;
+    private final IContentManager contentManager;
+    private final GameManager gameboardManager;
+    private final Set<String> fastTrackGamebaordIds;
+
+    /**
+     * Creates a game manager that operates using the provided api.
+     *
+     * @param contentManager
+     *            - so we can augment game objects with actual detailed content
+     * @param gameboardManager
+     *            - a gamebaord manager that deals with storing and retrieving gameboards.
+     * @param contentIndex
+     *            - the current content index of interest.
+     */
+    @Inject
+    public FastTrackManger(final PropertiesLoader properties, final ILogManager logManager,
+                           final IContentManager contentManager, final GameManager gameboardManager,
+                           @Named(CONTENT_INDEX) final String contentIndex) {
+        super(properties, logManager);
+
+        this.contentManager = contentManager;
+        this.contentIndex = contentIndex;
+        this.gameboardManager = gameboardManager;
+        String commaSeparatedIds = this.getProperties().getProperty(FASTTRACK_GAMEBOARD_WHITELIST);
+        this.fastTrackGamebaordIds = new HashSet<>(Arrays.asList(commaSeparatedIds.split(",")));
+    }
+
+    /**
+     * Cheacks if a gameboard ID is a valid fasttrack gameboard ID
+     * @param gameboardId to check.
+     * @return whether or not it is a valid fasttrack gameboard.
+     */
+    public final boolean isValidFasTrackGameboardId(final String gameboardId) {
+        return fastTrackGamebaordIds.contains(gameboardId);
+    }
+
+    /**
+     * Returns the concept name for a given question ID
+     * @param questionId the question ID for which you want to find its fasttrack concept.
+     * @return the concept string.
+     * @throws ContentManagerException if content cant be found which matches the question ID.
+     */
+    public final String getConceptFromQuestionId(final String questionId) throws ContentManagerException {
+        Map<String, List<String>> fieldsToMatch = Maps.newHashMap();
+        fieldsToMatch.put(TYPE_FIELDNAME, Arrays.asList(FAST_TRACK_QUESTION_TYPE));
+        fieldsToMatch.put(ID_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, Arrays.asList(questionId));
+        ResultsWrapper<ContentDTO> resultsList = contentManager.findByFieldNames(contentIndex,
+                SegueContentFacade.generateDefaultFieldToMatch(fieldsToMatch), 0, DEFAULT_RESULTS_LIMIT);
+
+        String upperConceptTitle = "";
+        if (resultsList.getTotalResults() == 1) {
+            upperConceptTitle = resultsList.getResults().get(0).getTitle();
+        }
+        return upperConceptTitle;
+    }
+
+    /**
+     * Retrieve fasttrack concept progress
+     *
+     * @param gameboardId to look up.
+     * @param conceptTitle concept title.
+     * @param userQuestionAttempts - the map of user's question attempts.
+     * @return list of gameboard items.
+     * @throws ContentManagerException if there is a problem retrieving the content.
+     */
+    public final List<GameboardItem> getConceptProgress(
+            final String gameboardId, final List<FASTTRACK_LEVEL> levelFilters, final String conceptTitle,
+            final Map<String, Map<String, List<QuestionValidationResponse>>> userQuestionAttempts
+    ) throws ContentManagerException {
+        List<ContentDTO> fastTrackAssociatedQuestions =
+                this.getFastTrackConceptQuestions(gameboardId, levelFilters, conceptTitle);
+        return gameboardManager.getGameboardItemProgress(fastTrackAssociatedQuestions, userQuestionAttempts);
+    }
+
+    /**
+     * Queries the search provider for questions tagged with this board name and concept title.
+     * The result is returned sorted.
+     *
+     * @param boardTag the tag which marks question's association with a certain board - the board's ID.
+     * @param conceptTitle the title of the concept which is being searched for.
+     * @return ordered list of concept questions associated with the board.
+     * @throws ContentManagerException if there is a problem with the content manager (i.e. Elasticsearch)
+     */
+    private List<ContentDTO> getFastTrackConceptQuestions(
+            final String boardTag, final List<FASTTRACK_LEVEL> levelFilters, final String conceptTitle
+    ) throws ContentManagerException {
+        List<String> stringLevelFilters = levelFilters.stream().map(FASTTRACK_LEVEL::name).collect(Collectors.toList());
+
+        Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMap = Maps.newHashMap();
+        fieldsToMap.put(immutableEntry(
+                Constants.BooleanOperator.OR, TYPE_FIELDNAME), Arrays.asList(QUESTION_TYPE, FAST_TRACK_QUESTION_TYPE));
+        fieldsToMap.put(immutableEntry(
+                Constants.BooleanOperator.AND, TITLE_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX), Collections.singletonList(conceptTitle));
+        fieldsToMap.put(immutableEntry(
+                Constants.BooleanOperator.AND, TAGS_FIELDNAME), Collections.singletonList(boardTag));
+        fieldsToMap.put(immutableEntry(
+                Constants.BooleanOperator.OR, TAGS_FIELDNAME), stringLevelFilters);
+
+        Map<String, Constants.SortOrder> sortInstructions = Maps.newHashMap();
+        sortInstructions.put(ID_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, Constants.SortOrder.ASC);
+
+        return this.contentManager.findByFieldNames(
+                this.contentIndex, fieldsToMap, 0, SEARCH_MAX_WINDOW_SIZE, sortInstructions).getResults();
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -332,22 +332,6 @@ public class GameManager {
     }
 
     /**
-     * getFastTrackConceptProgress.
-     *
-     * @param gameboardId to look up.
-     * @param conceptTitle concept title.
-     * @param userQuestionAttempts - the map of user's question attempts.
-     * @return list of gameboard items.
-     * @throws ContentManagerException if there is a problem retrieving the content.
-     */
-    public final List<GameboardItem> getFastTrackConceptProgress(final String gameboardId, final String conceptTitle,
-             final Map<String, Map<String, List<QuestionValidationResponse>>> userQuestionAttempts)
-            throws ContentManagerException {
-        List<ContentDTO> fastTrackAssociatedQuestions = this.getFastTrackConceptQuestions(gameboardId, conceptTitle);
-        return this.getGameboardItemProgress(fastTrackAssociatedQuestions, userQuestionAttempts);
-    }
-
-    /**
      * Lookup gameboards belonging to a current user.
      * 
      * @param user
@@ -759,7 +743,7 @@ public class GameManager {
      * @param userQuestionAttempts the user's question attempt history.
      * @return list of augmented gameboard items.
      */
-    private List<GameboardItem> getGameboardItemProgress(List<ContentDTO> questions,
+    public List<GameboardItem> getGameboardItemProgress(List<ContentDTO> questions,
                                                          final Map<String, Map<String, List<QuestionValidationResponse>>> userQuestionAttempts) {
 
         return questions.stream()
@@ -925,33 +909,6 @@ public class GameManager {
         Collections.shuffle(gameboardQuestionList);
 
         return gameboardQuestionList;
-    }
-
-    /**
-     * Queries the search provider for questions tagged with this board name and concept title.
-     * The result is returned sorted.
-     *
-     * @param boardTag the tag which marks question's association with a certain board - the board's ID.
-     * @param conceptTitle the title of the concept which is being searched for.
-     * @return ordered list of concept questions associated with the board.
-     * @throws ContentManagerException if there is a problem with the content manager (i.e. Elasticsearch)
-     */
-    private List<ContentDTO> getFastTrackConceptQuestions(final String boardTag, final String conceptTitle)
-            throws ContentManagerException {
-        Map<Map.Entry<BooleanOperator, String>, List<String>> fieldsToMap = Maps.newHashMap();
-
-        fieldsToMap.put(immutableEntry(
-                BooleanOperator.OR, TYPE_FIELDNAME), Arrays.asList(QUESTION_TYPE, FAST_TRACK_QUESTION_TYPE));
-        fieldsToMap.put(immutableEntry(
-                BooleanOperator.AND, TITLE_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX), Collections.singletonList(conceptTitle));
-        fieldsToMap.put(immutableEntry(
-                BooleanOperator.AND, TAGS_FIELDNAME), Collections.singletonList(boardTag));
-
-        Map<String, SortOrder> sortInstructions = Maps.newHashMap();
-        sortInstructions.put(ID_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, SortOrder.ASC);
-
-        return this.contentManager.findByFieldNames(
-                this.contentIndex, fieldsToMap, 0, SEARCH_MAX_WINDOW_SIZE, sortInstructions).getResults();
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionPartConceptDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionPartConceptDTO.java
@@ -16,7 +16,7 @@
 package uk.ac.cam.cl.dtg.isaac.dto;
 
 import com.google.api.client.util.Lists;
-import uk.ac.cam.cl.dtg.isaac.api.Constants.FastTrackConceptState;
+import uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_LEVEL;
 
 import java.util.List;
 
@@ -25,7 +25,7 @@ import java.util.List;
  */
 public class QuestionPartConceptDTO {
     private String title;
-    private FastTrackConceptState bestLevel;
+    private FASTTRACK_LEVEL bestLevel;
     private List<GameboardItem> upperQuestions;
     private List<GameboardItem> lowerQuestions;
 
@@ -71,7 +71,7 @@ public class QuestionPartConceptDTO {
      *
      * @return the best level.
      */
-    public final FastTrackConceptState getBestLevel() {
+    public final FASTTRACK_LEVEL getBestLevel() {
         return this.bestLevel;
     }
 
@@ -81,7 +81,7 @@ public class QuestionPartConceptDTO {
      * @param bestLevel
      *            to set for this concept.
      */
-    public final void setBestLevel(FastTrackConceptState bestLevel) {
+    public final void setBestLevel(FASTTRACK_LEVEL bestLevel) {
         this.bestLevel = bestLevel;
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
@@ -70,7 +70,7 @@ public class GameboardsFacadeTest {
 	 */
 	@Before
 	public final void setUp() throws Exception {
-		this.dummyAPI = createMock(SegueDefaultFacade.class);
+		this.dummyAPI = createMock(SegueContentFacade.class);
 		this.dummyPropertiesLoader = createMock(PropertiesLoader.class);
 		this.dummyGameManager = createMock(GameManager.class);
 		this.dummyLogManager = createMock(ILogManager.class);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
@@ -43,6 +43,7 @@ import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
 import uk.ac.cam.cl.dtg.segue.dto.users.AbstractSegueUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
@@ -53,7 +54,7 @@ import uk.ac.cam.cl.dtg.util.PropertiesLoader;
  */
 public class GameboardsFacadeTest {
 
-	private SegueContentFacade dummyAPI = null;
+	private IContentManager dummyContentManager = null;
 	private PropertiesLoader dummyPropertiesLoader = null;
 	private GameManager dummyGameManager = null;
 	private ILogManager dummyLogManager = null;
@@ -70,7 +71,7 @@ public class GameboardsFacadeTest {
 	 */
 	@Before
 	public final void setUp() throws Exception {
-		this.dummyAPI = createMock(SegueContentFacade.class);
+		this.dummyContentManager = createMock(IContentManager.class);
 		this.dummyPropertiesLoader = createMock(PropertiesLoader.class);
 		this.dummyGameManager = createMock(GameManager.class);
 		this.dummyLogManager = createMock(ILogManager.class);
@@ -94,7 +95,7 @@ public class GameboardsFacadeTest {
 	public final void isaacEndPoint_checkEmptyGameboardCausesErrorNoUser_SegueErrorResponseShouldBeReturned()
 			throws NoWildcardException, SegueDatabaseException, NoUserLoggedInException,
 			ContentManagerException {
-		GameboardsFacade gameboardFacade = new GameboardsFacade(dummyAPI, dummyPropertiesLoader, dummyLogManager,
+		GameboardsFacade gameboardFacade = new GameboardsFacade(dummyContentManager, dummyPropertiesLoader, dummyLogManager,
 				dummyGameManager, questionManager, userManager, userAssociationManager, userBadgeManager, "latest");
 
 		HttpServletRequest dummyRequest = createMock(HttpServletRequest.class);
@@ -116,12 +117,12 @@ public class GameboardsFacadeTest {
 				.atLeastOnce();
 
 		replay(dummyGameManager);
-		replay(dummyAPI);
+		replay(dummyContentManager);
 
 		Response r = gameboardFacade.generateTemporaryGameboard(dummyRequest, title, subjects, fields, topics,
 				levels, concepts);
 
 		assertTrue(r.getStatus() == Status.NO_CONTENT.getStatusCode());
-		verify(dummyAPI, dummyGameManager);
+		verify(dummyContentManager, dummyGameManager);
 	}
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
@@ -31,6 +31,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import uk.ac.cam.cl.dtg.isaac.api.Constants;
 import uk.ac.cam.cl.dtg.isaac.api.GameboardsFacade;
+import uk.ac.cam.cl.dtg.isaac.api.managers.FastTrackManger;
 import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.NoWildcardException;
 import uk.ac.cam.cl.dtg.segue.api.SegueContentFacade;
@@ -54,7 +55,6 @@ import uk.ac.cam.cl.dtg.util.PropertiesLoader;
  */
 public class GameboardsFacadeTest {
 
-	private IContentManager dummyContentManager = null;
 	private PropertiesLoader dummyPropertiesLoader = null;
 	private GameManager dummyGameManager = null;
 	private ILogManager dummyLogManager = null;
@@ -62,6 +62,7 @@ public class GameboardsFacadeTest {
 	private UserAssociationManager userAssociationManager;
     private QuestionManager questionManager;
     private UserBadgeManager userBadgeManager;
+	private FastTrackManger fastTrackManager;
 
 	/**
 	 * Initial configuration of tests.
@@ -71,7 +72,6 @@ public class GameboardsFacadeTest {
 	 */
 	@Before
 	public final void setUp() throws Exception {
-		this.dummyContentManager = createMock(IContentManager.class);
 		this.dummyPropertiesLoader = createMock(PropertiesLoader.class);
 		this.dummyGameManager = createMock(GameManager.class);
 		this.dummyLogManager = createMock(ILogManager.class);
@@ -79,6 +79,7 @@ public class GameboardsFacadeTest {
 	    this.questionManager = createMock(QuestionManager.class);
 		this.userAssociationManager = createMock(UserAssociationManager.class);
 		this.userBadgeManager = createMock(UserBadgeManager.class);
+		this.fastTrackManager = createMock(FastTrackManger.class);
 		expect(this.dummyPropertiesLoader.getProperty(Constants.FASTTRACK_GAMEBOARD_WHITELIST))
 				.andReturn("ft_board_1,ft_board_2").anyTimes();
 		replay(this.dummyPropertiesLoader);
@@ -95,8 +96,9 @@ public class GameboardsFacadeTest {
 	public final void isaacEndPoint_checkEmptyGameboardCausesErrorNoUser_SegueErrorResponseShouldBeReturned()
 			throws NoWildcardException, SegueDatabaseException, NoUserLoggedInException,
 			ContentManagerException {
-		GameboardsFacade gameboardFacade = new GameboardsFacade(dummyContentManager, dummyPropertiesLoader, dummyLogManager,
-				dummyGameManager, questionManager, userManager, userAssociationManager, userBadgeManager, "latest");
+		GameboardsFacade gameboardFacade = new GameboardsFacade(
+				dummyPropertiesLoader, dummyLogManager, dummyGameManager, questionManager,
+				userManager, userAssociationManager, userBadgeManager, fastTrackManager);
 
 		HttpServletRequest dummyRequest = createMock(HttpServletRequest.class);
 		String subjects = "physics";
@@ -117,12 +119,11 @@ public class GameboardsFacadeTest {
 				.atLeastOnce();
 
 		replay(dummyGameManager);
-		replay(dummyContentManager);
 
 		Response r = gameboardFacade.generateTemporaryGameboard(dummyRequest, title, subjects, fields, topics,
 				levels, concepts);
 
 		assertTrue(r.getStatus() == Status.NO_CONTENT.getStatusCode());
-		verify(dummyContentManager, dummyGameManager);
+		verify(dummyGameManager);
 	}
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
@@ -33,6 +33,7 @@ import uk.ac.cam.cl.dtg.isaac.api.Constants;
 import uk.ac.cam.cl.dtg.isaac.api.GameboardsFacade;
 import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.NoWildcardException;
+import uk.ac.cam.cl.dtg.segue.api.SegueContentFacade;
 import uk.ac.cam.cl.dtg.segue.api.SegueDefaultFacade;
 import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
@@ -52,7 +53,7 @@ import uk.ac.cam.cl.dtg.util.PropertiesLoader;
  */
 public class GameboardsFacadeTest {
 
-	private SegueDefaultFacade dummyAPI = null;
+	private SegueContentFacade dummyAPI = null;
 	private PropertiesLoader dummyPropertiesLoader = null;
 	private GameManager dummyGameManager = null;
 	private ILogManager dummyLogManager = null;
@@ -93,8 +94,8 @@ public class GameboardsFacadeTest {
 	public final void isaacEndPoint_checkEmptyGameboardCausesErrorNoUser_SegueErrorResponseShouldBeReturned()
 			throws NoWildcardException, SegueDatabaseException, NoUserLoggedInException,
 			ContentManagerException {
-		GameboardsFacade gameboardFacade = new GameboardsFacade(dummyPropertiesLoader, dummyLogManager,
-				dummyGameManager, questionManager, userManager, userAssociationManager, userBadgeManager);
+		GameboardsFacade gameboardFacade = new GameboardsFacade(dummyAPI, dummyPropertiesLoader, dummyLogManager,
+				dummyGameManager, questionManager, userManager, userAssociationManager, userBadgeManager, "latest");
 
 		HttpServletRequest dummyRequest = createMock(HttpServletRequest.class);
 		String subjects = "physics";


### PR DESCRIPTION
Make it possible for upper level topics to link to a different topic at lower level
https://trello.com/c/nPErBHqh

* 5221f47a Fix javadoc comment for new endpoint.
* 8c8cae99 *Actually* fix test for GameboardsFacade
* ce21ae2c Fix test for GameboardsFacade
* 2f009869 Retrieve the progress of the correct set of questions for fast track
* 091729ad Move top/upper logic to front-end, unbreak some things that got broken in  the last commit.
* 1a4bce75 Retrieve the relevant upper concept based on the history of questions viewed so far

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed