### PR TITLE
Add linked gameboards to topic summary pages

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -514,18 +514,20 @@ public class PagesFacade extends AbstractIsaacFacade {
             // Augment linked gameboards using the list in the DO:
             // FIXME: this requires loading both the DO and DTO separately, since augmenting things is hard right now.
             ArrayList<GameboardDTO> linkedGameboards = new ArrayList<>();
-            for (String linkedGameboardId : topicSummaryDO.getLinkedGameboards()) {
-                try {
-                    GameboardDTO liteGameboard = this.gameManager.getLiteGameboard(linkedGameboardId);
-                    if (liteGameboard != null) {
-                        linkedGameboards.add(liteGameboard);
-                    } else {
-                        log.error(String.format("Unable to locate gameboard (%s) for topic summary page (%s)!",
-                                linkedGameboardId, topicId));
-                    }
+            if (null != topicSummaryDO.getLinkedGameboards()) {
+                for (String linkedGameboardId : topicSummaryDO.getLinkedGameboards()) {
+                    try {
+                        GameboardDTO liteGameboard = this.gameManager.getLiteGameboard(linkedGameboardId);
+                        if (liteGameboard != null) {
+                            linkedGameboards.add(liteGameboard);
+                        } else {
+                            log.error(String.format("Unable to locate gameboard (%s) for topic summary page (%s)!",
+                                    linkedGameboardId, topicId));
+                        }
 
-                } catch (SegueDatabaseException e) {
-                    log.info(String.format("Problem with retrieving gameboard: %s", linkedGameboardId));
+                    } catch (SegueDatabaseException e) {
+                        log.info(String.format("Problem with retrieving gameboard: %s", linkedGameboardId));
+                    }
                 }
             }
             topicSummaryDTO.setLinkedGameboards(linkedGameboards);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacTopicSummaryPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacTopicSummaryPage.java
@@ -20,6 +20,8 @@ import uk.ac.cam.cl.dtg.segue.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.segue.dos.content.SeguePage;
 
+import java.util.List;
+
 /**
  * Isaac Topic Summary Page DO.
  *
@@ -30,4 +32,23 @@ import uk.ac.cam.cl.dtg.segue.dos.content.SeguePage;
 @DTOMapping(IsaacTopicSummaryPageDTO.class)
 @JsonContentType("isaacTopicSummaryPage")
 public class IsaacTopicSummaryPage extends SeguePage {
+
+    private List<String> linkedGameboards;
+
+    /**
+     * Gets the list of linked gameboard IDs.
+     * @return the linked gameboard IDs
+     */
+    public List<String> getLinkedGameboards() {
+        return linkedGameboards;
+    }
+
+    /**
+     * Sets the list of linked gameboard IDs.
+     * @param linkedGameboards the linked gameboard IDs to set
+     */
+    public void setLinkedGameboards(final List<String> linkedGameboards) {
+        this.linkedGameboards = linkedGameboards;
+    }
+
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacTopicSummaryPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacTopicSummaryPageDTO.java
@@ -18,6 +18,8 @@ package uk.ac.cam.cl.dtg.isaac.dto;
 import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.segue.dto.content.SeguePageDTO;
 
+import java.util.List;
+
 /**
  * Isaac Topic Summary Page DTO.
  *
@@ -27,4 +29,23 @@ import uk.ac.cam.cl.dtg.segue.dto.content.SeguePageDTO;
  */
 @JsonContentType("isaacTopicSummaryPage")
 public class IsaacTopicSummaryPageDTO extends SeguePageDTO {
+
+    private List<GameboardDTO> linkedGameboards;
+
+    /**
+     * Gets the list of linked gameboard DTOs.
+     * @return the linked gameboard DTOs
+     */
+    public List<GameboardDTO> getLinkedGameboards() {
+        return linkedGameboards;
+    }
+
+    /**
+     * Sets the list of linked gameboard DTOs.
+     * @param linkedGameboards the linked gameboard DTOs to set
+     */
+    public void setLinkedGameboards(final List<GameboardDTO> linkedGameboards) {
+        this.linkedGameboards = linkedGameboards;
+    }
+
 }


### PR DESCRIPTION
This allows topic summary pages to have a list of linked gameboards specified, which gets augmented at request time. This augmentation isn't nice and requires loading both the DO and DTO separately from ElasticSearch. This is because the mapping at the Facade layer cannot cope with mapping lists of IDs into lists of objects with those IDs.


It is fully backwards compatible, so long the old ETL is used and nobody adds `linkedGameboards` to an existing topic summary until after the old API is gone.