### PR TITLE
Add support for weekly streaks on the user progress endpoint

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -317,11 +317,15 @@ public class IsaacController extends AbstractIsaacFacade {
                         .getUserQuestionInformation(userOfInterestFull);
 
                 // augment details with user snapshot data (perhaps one day we will replace the entire endpoint with this call)
-                Map<String, Object> streakRecord = userStreaksManager.getCurrentStreakRecord(userOfInterestFull);
-                streakRecord.put("largestStreak", userStreaksManager.getLongestStreak(userOfInterestFull));
+                Map<String, Object> dailyStreakRecord = userStreaksManager.getCurrentStreakRecord(userOfInterestFull);
+                dailyStreakRecord.put("largestStreak", userStreaksManager.getLongestStreak(userOfInterestFull));
+
+                Map<String, Object> weeklyStreakRecord = userStreaksManager.getCurrentWeeklyStreakRecord(userOfInterestFull);
+                weeklyStreakRecord.put("largestStreak", userStreaksManager.getLongestWeeklyStreak(userOfInterestFull));
 
                 Map<String, Object> userSnapshot = ImmutableMap.of(
-                        "streakRecord", streakRecord,
+                        "dailyStreakRecord", dailyStreakRecord,
+                        "weeklyStreakRecord", weeklyStreakRecord,
                         "achievementsRecord", userBadgeManager.getAllUserBadges(userOfInterestFull)
                 );
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/IUserStreaksManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/IUserStreaksManager.java
@@ -28,6 +28,24 @@ public interface IUserStreaksManager {
     int getLongestStreak(RegisteredUserDTO user);
 
     /**
+     * This method will get the current weekly streak and current weekly streak progress for a registered user.
+     *
+     * @param user
+     *            - the registered user
+     * @return the current streak map object
+     */
+    Map<String, Object> getCurrentWeeklyStreakRecord(RegisteredUserDTO user);
+
+    /**
+     * This method will get the longest weekly streak a registered user has achieved.
+     *
+     * @param user
+     *            - the registered user
+     * @return the length of the longest streak
+     */
+    int getLongestWeeklyStreak(RegisteredUserDTO user);
+
+    /**
      * This method will notify a registered user that their streak has changed.
      *
      * @param user


### PR DESCRIPTION
We don't want to use these yet, but being able to access them on the site will be useful testing.