### PR TITLE
Strip whitespace by default when checking string match questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 @ValidatesWith(IsaacStringMatchValidator.class)
 public class IsaacStringMatchQuestion extends IsaacQuestionBase {
     private Boolean multiLineEntry;
+    private Boolean preserveWhitespace;
 
     public Boolean getMultiLineEntry() {
         return multiLineEntry;
@@ -37,5 +38,13 @@ public class IsaacStringMatchQuestion extends IsaacQuestionBase {
 
     public void setMultiLineEntry(final Boolean multiLineEntry) {
         this.multiLineEntry = multiLineEntry;
+    }
+
+    public Boolean getPreserveWhitespace() {
+        return preserveWhitespace;
+    }
+
+    public void setPreserveWhitespace(final Boolean preserveWhitespace) {
+        this.preserveWhitespace = preserveWhitespace;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
@@ -30,7 +30,7 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 @ValidatesWith(IsaacStringMatchValidator.class)
 public class IsaacStringMatchQuestion extends IsaacQuestionBase {
     private Boolean multiLineEntry;
-    private Boolean preserveWhitespace;
+    private Boolean preserveTrailingWhitespace;
 
     public Boolean getMultiLineEntry() {
         return multiLineEntry;
@@ -40,11 +40,11 @@ public class IsaacStringMatchQuestion extends IsaacQuestionBase {
         this.multiLineEntry = multiLineEntry;
     }
 
-    public Boolean getPreserveWhitespace() {
-        return preserveWhitespace;
+    public Boolean getPreserveTrailingWhitespace() {
+        return preserveTrailingWhitespace;
     }
 
-    public void setPreserveWhitespace(final Boolean preserveWhitespace) {
-        this.preserveWhitespace = preserveWhitespace;
+    public void setPreserveTrailingWhitespace(final Boolean preserveTrailingWhitespace) {
+        this.preserveTrailingWhitespace = preserveTrailingWhitespace;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
@@ -27,7 +27,7 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 @ValidatesWith(IsaacStringMatchValidator.class)
 public class IsaacStringMatchQuestionDTO extends IsaacQuestionBaseDTO {
     private Boolean multiLineEntry;
-    private Boolean preserveWhitespace;
+    private Boolean preserveTrailingWhitespace;
 
     public Boolean getMultiLineEntry() {
         return multiLineEntry;
@@ -37,11 +37,11 @@ public class IsaacStringMatchQuestionDTO extends IsaacQuestionBaseDTO {
         this.multiLineEntry = multiLineEntry;
     }
 
-    public Boolean getPreserveWhitespace() {
-        return preserveWhitespace;
+    public Boolean getPreserveTrailingWhitespace() {
+        return preserveTrailingWhitespace;
     }
 
-    public void setPreserveWhitespace(final Boolean preserveWhitespace) {
-        this.preserveWhitespace = preserveWhitespace;
+    public void setPreserveTrailingWhitespace(final Boolean preserveTrailingWhitespace) {
+        this.preserveTrailingWhitespace = preserveTrailingWhitespace;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,14 +15,9 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.ac.cam.cl.dtg.isaac.quiz.IsaacStringMatchValidator;
 import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
-import uk.ac.cam.cl.dtg.segue.dto.content.ChoiceDTO;
-import uk.ac.cam.cl.dtg.segue.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
-
-import java.util.List;
 
 /**
  * DTO for isaacStringMatchQuestion.
@@ -32,6 +27,7 @@ import java.util.List;
 @ValidatesWith(IsaacStringMatchValidator.class)
 public class IsaacStringMatchQuestionDTO extends IsaacQuestionBaseDTO {
     private Boolean multiLineEntry;
+    private Boolean preserveWhitespace;
 
     public Boolean getMultiLineEntry() {
         return multiLineEntry;
@@ -39,5 +35,13 @@ public class IsaacStringMatchQuestionDTO extends IsaacQuestionBaseDTO {
 
     public void setMultiLineEntry(final Boolean multiLineEntry) {
         this.multiLineEntry = multiLineEntry;
+    }
+
+    public Boolean getPreserveWhitespace() {
+        return preserveWhitespace;
+    }
+
+    public void setPreserveWhitespace(final Boolean preserveWhitespace) {
+        this.preserveWhitespace = preserveWhitespace;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
@@ -52,6 +52,8 @@ public class IsaacStringMatchValidator implements IValidator {
                     answer.getClass()));
         }
 
+        StringChoice userAnswer = (StringChoice) answer;
+
         IsaacStringMatchQuestion stringMatchQuestion = (IsaacStringMatchQuestion) question;
 
         // These variables store the important features of the response we'll send.
@@ -67,7 +69,7 @@ public class IsaacStringMatchValidator implements IValidator {
 
         // STEP 1: Did they provide an answer at all?
 
-        if (null == feedback && (null == answer.getValue() || answer.getValue().isEmpty())) {
+        if (null == feedback && (null == userAnswer.getValue() || userAnswer.getValue().isEmpty())) {
             feedback = new Content("You did not provide an answer");
         }
 
@@ -96,14 +98,14 @@ public class IsaacStringMatchValidator implements IValidator {
                 }
 
                 // ... check if they match the choice, ...
-                if (stringChoice.isCaseInsensitive()) {
-                    // ... allowing case-insensitive matching only if haven't already matched a correct answer ...
-                    if (stringChoice.getValue().toLowerCase().equals(answer.getValue().toLowerCase()) && !responseCorrect) {
-                        feedback = (Content) stringChoice.getExplanation();
-                        responseCorrect = stringChoice.isCorrect();
-                    }
-                } else {
-                    if (stringChoice.getValue().equals(answer.getValue())) {
+                if (valuesMatch(stringChoice, userAnswer, stringChoice.isCaseInsensitive(), stringMatchQuestion.getPreserveWhitespace())) {
+                    if (stringChoice.isCaseInsensitive()) {
+                        if (!responseCorrect) {
+                            // ... allowing case-insensitive matching only if haven't already matched a correct answer ...
+                            feedback = (Content) stringChoice.getExplanation();
+                            responseCorrect = stringChoice.isCorrect();
+                        }
+                    } else {
                         feedback = (Content) stringChoice.getExplanation();
                         responseCorrect = stringChoice.isCorrect();
                         // ... and taking exact case-sensitive matches to be the best possible and stopping if found.
@@ -113,7 +115,28 @@ public class IsaacStringMatchValidator implements IValidator {
             }
         }
 
-        return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
+        return new QuestionValidationResponse(question.getId(), userAnswer, responseCorrect, feedback, new Date());
     }
 
+    private boolean valuesMatch(final StringChoice trustedChoice, final StringChoice userChoice,
+                                final Boolean caseInsensitive, final Boolean preserveWhitespace) {
+        String trustedValue = trustedChoice.getValue();
+        String userValue = userChoice.getValue();
+
+        if (null == trustedValue || null == userValue) {
+            return false;
+        }
+
+        if (null != caseInsensitive && caseInsensitive) {
+            trustedValue = trustedValue.toLowerCase();
+            userValue = userValue.toLowerCase();
+        }
+        if (null == preserveWhitespace || !preserveWhitespace) {
+            // Strip whitespace by default:
+            trustedValue = trustedValue.trim();
+            userValue = userValue.trim();
+        }
+
+        return trustedValue.equals(userValue);
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
@@ -28,12 +28,14 @@ import uk.ac.cam.cl.dtg.segue.quiz.IValidator;
 
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Validator that only provides functionality to validate String Match questions.
  */
 public class IsaacStringMatchValidator implements IValidator {
     private static final Logger log = LoggerFactory.getLogger(IsaacStringMatchValidator.class);
+    private static final Pattern TRAILING_SPACES = Pattern.compile("\\s+$", Pattern.MULTILINE);
     
     @Override
     public final QuestionValidationResponse validateQuestionResponse(final Question question, final Choice answer) {
@@ -98,7 +100,7 @@ public class IsaacStringMatchValidator implements IValidator {
                 }
 
                 // ... check if they match the choice, ...
-                if (valuesMatch(stringChoice, userAnswer, stringChoice.isCaseInsensitive(), stringMatchQuestion.getPreserveWhitespace())) {
+                if (valuesMatch(stringChoice, userAnswer, stringChoice.isCaseInsensitive(), stringMatchQuestion.getPreserveTrailingWhitespace())) {
                     if (stringChoice.isCaseInsensitive()) {
                         if (!responseCorrect) {
                             // ... allowing case-insensitive matching only if haven't already matched a correct answer ...
@@ -119,7 +121,7 @@ public class IsaacStringMatchValidator implements IValidator {
     }
 
     private boolean valuesMatch(final StringChoice trustedChoice, final StringChoice userChoice,
-                                final Boolean caseInsensitive, final Boolean preserveWhitespace) {
+                                final Boolean caseInsensitive, final Boolean preserveTrailingWhitespace) {
         String trustedValue = trustedChoice.getValue();
         String userValue = userChoice.getValue();
 
@@ -131,10 +133,10 @@ public class IsaacStringMatchValidator implements IValidator {
             trustedValue = trustedValue.toLowerCase();
             userValue = userValue.toLowerCase();
         }
-        if (null == preserveWhitespace || !preserveWhitespace) {
-            // Strip whitespace by default:
-            trustedValue = trustedValue.trim();
-            userValue = userValue.trim();
+        if (null == preserveTrailingWhitespace || !preserveTrailingWhitespace) {
+            // Strip trailing whitespace by default:
+            trustedValue = TRAILING_SPACES.matcher(trustedValue).replaceAll("");
+            userValue = TRAILING_SPACES.matcher(userValue).replaceAll("");
         }
 
         return trustedValue.equals(userValue);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidatorTest.java
@@ -147,31 +147,66 @@ public class IsaacStringMatchValidatorTest {
     }
 
     /*
-       Test that incorrect case-sensitive match takes priority over case-insensitive correct match.
+       Test that the default behavior for String Match Questions trims trailing spaces.
     */
     @Test
-    public final void isaacStringMatchValidator_CaseSensitivePriority_IncorrectResponseShouldBeReturned() {
+    public final void isaacStringMatchValidator_CorrectWithTrailingSpaces_CorrectResponseShouldBeReturned() {
+        // Set up user answer:
+        StringChoice c = new StringChoice();
+        c.setValue(String.format("%s     ", caseSensitiveAnswer));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someStringMatchQuestion, c);
+        assertTrue(response.isCorrect());
+    }
+
+    /*
+       Test that trailing whitespace on multiple lines is removed before matching by default.
+    */
+    @Test
+    public final void isaacStringMatchValidator_TrailingSpacesMultiline_CorrectResponseShouldBeReturned() {
         // Set up the question object:
         IsaacStringMatchQuestion someStringMatchQuestion = new IsaacStringMatchQuestion();
 
         List<Choice> answerList = Lists.newArrayList();
         StringChoice someCorrectAnswer = new StringChoice();
-        someCorrectAnswer.setValue("testing123");
+        someCorrectAnswer.setValue("THIS\nIS\nA\nTEST\nMULTILINE\nVALUE");
         someCorrectAnswer.setCorrect(true);
         someCorrectAnswer.setCaseInsensitive(true);
         answerList.add(someCorrectAnswer);
 
-        StringChoice someIncorrectAnswer = new StringChoice();
-        someIncorrectAnswer.setValue("TESTing123");
-        someIncorrectAnswer.setCorrect(false);
-        someIncorrectAnswer.setCaseInsensitive(false);
-        answerList.add(someIncorrectAnswer);
+        someStringMatchQuestion.setChoices(answerList);
+
+        // Set up user answer, matches correct but with trailing spaces on each line:
+        StringChoice c = new StringChoice();
+        c.setValue("THIS  \nIS  \nA  \nTEST  \nMULTILINE  \nVALUE   ");
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someStringMatchQuestion, c);
+        assertTrue(response.isCorrect());
+    }
+
+    /*
+       Test that trailing whitespace on multiple lines is preserved when flag set.
+    */
+    @Test
+    public final void isaacStringMatchValidator_TrailingSpacesMultilinePreserved_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacStringMatchQuestion someStringMatchQuestion = new IsaacStringMatchQuestion();
+        someStringMatchQuestion.setPreserveTrailingWhitespace(true);
+
+        List<Choice> answerList = Lists.newArrayList();
+        StringChoice someCorrectAnswer = new StringChoice();
+        someCorrectAnswer.setValue("THIS\nIS\nA\nTEST\nMULTILINE\nVALUE");
+        someCorrectAnswer.setCorrect(true);
+        someCorrectAnswer.setCaseInsensitive(true);
+        answerList.add(someCorrectAnswer);
 
         someStringMatchQuestion.setChoices(answerList);
 
-        // Set up user answer, matches both correct and incorrect but incorrect answer more strongly:
+        // Set up user answer, matches correct but with trailing spaces on each line:
         StringChoice c = new StringChoice();
-        c.setValue("TESTing123");
+        c.setValue("THIS  \nIS  \nA  \nTEST  \nMULTILINE  \nVALUE   ");
 
         // Test response:
         QuestionValidationResponse response = validator.validateQuestionResponse(someStringMatchQuestion, c);
@@ -245,6 +280,40 @@ public class IsaacStringMatchValidatorTest {
         QuestionValidationResponse response = validator.validateQuestionResponse(someStringMatchQuestion, c);
         assertTrue(response.isCorrect());
     }
+
+
+    /*
+   Test that incorrect case-sensitive match takes priority over case-insensitive correct match.
+*/
+    @Test
+    public final void isaacStringMatchValidator_CaseSensitivePriority_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacStringMatchQuestion someStringMatchQuestion = new IsaacStringMatchQuestion();
+
+        List<Choice> answerList = Lists.newArrayList();
+        StringChoice someCorrectAnswer = new StringChoice();
+        someCorrectAnswer.setValue("testing123");
+        someCorrectAnswer.setCorrect(true);
+        someCorrectAnswer.setCaseInsensitive(true);
+        answerList.add(someCorrectAnswer);
+
+        StringChoice someIncorrectAnswer = new StringChoice();
+        someIncorrectAnswer.setValue("TESTing123");
+        someIncorrectAnswer.setCorrect(false);
+        someIncorrectAnswer.setCaseInsensitive(false);
+        answerList.add(someIncorrectAnswer);
+
+        someStringMatchQuestion.setChoices(answerList);
+
+        // Set up user answer, matches both correct and incorrect but incorrect answer more strongly:
+        StringChoice c = new StringChoice();
+        c.setValue("TESTing123");
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someStringMatchQuestion, c);
+        assertFalse(response.isCorrect());
+    }
+
 
     //  ---------- Tests from here test invalid questions themselves ----------
 


### PR DESCRIPTION
StringMatchQuestions now have a `preserveWhitespace` option, should checking of leading and trailing whitespace be important.