### PR TITLE
User IDs in staff CSV exports

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -559,7 +559,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
             }
 
             rows.add(totalsRow.toArray(new String[0]));
-            String userInfoHeader = includeUserIDs ? "Last Name, First Name, User ID" : "Last Name,First Name";
+            String userInfoHeader = includeUserIDs ? "Last Name,First Name,User ID" : "Last Name,First Name";
             rows.add(userInfoHeader.split(","));
             rows.addAll(resultRows);
             csvWriter.writeAll(rows);
@@ -701,7 +701,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
 
             ArrayList<String> headerRow = Lists.newArrayList();
             if (includeUserIDs) {
-                Collections.addAll(headerRow, "Last Name,First Name, User ID,% Correct Overall".split(","));
+                Collections.addAll(headerRow, "Last Name,First Name,User ID,% Correct Overall".split(","));
             } else {
                 Collections.addAll(headerRow, "Last Name,First Name,% Correct Overall".split(","));
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
@@ -232,6 +232,22 @@ public abstract class AbstractSegueFacade {
     }
 
     /**
+     * Is the current user in an admin or event manager role.
+     *
+     * @param userManager
+     *            - Instance of User Manager
+     * @param userDTO
+     *            - for the user of interest
+     * @return true if user is logged in as an admin, false otherwise.
+     * @throws NoUserLoggedInException
+     *             - if we are unable to tell because they are not logged in.
+     */
+    public static boolean isUserAnAdminOrEventManager(final UserAccountManager userManager,
+                                                      final RegisteredUserDTO userDTO) throws NoUserLoggedInException {
+        return userManager.checkUserRole(userDTO, Arrays.asList(Role.ADMIN, Role.EVENT_MANAGER));
+    }
+
+    /**
      * Is the current user in a staff role.
      * 
      * @param userManager


### PR DESCRIPTION
One task I have to do often is produce lists of user IDs for competitions and other things where those who have completed a gameboard need to be emailed. This removes the need for database lookups, since all the required data is in the CSV file.

When you test this, please make sure there are at least two users in the group, one of which has revoked access to test the NOT_SHARING branch.

This also removes unnecessary database lookups by re-using the user object and not extracting it from the request twice in the same function! This needed `isUserAdminOrEventManager` to be consistent with `isUserAdmin` and `isUserStaff` and have two versions, one taking a request and one taking a user DTO; I don't know why it didn't already have this.