### PR TITLE
Avoid unnecessary database lookups when loading current assignments

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
@@ -110,7 +110,7 @@ public class AssignmentManager implements IGroupObserver {
      *             - if we cannot complete a required database operation.
      */
     public Collection<AssignmentDTO> getAssignments(final RegisteredUserDTO user) throws SegueDatabaseException {
-        List<UserGroupDTO> groups = groupManager.getGroupMembershipList(user);
+        List<UserGroupDTO> groups = groupManager.getGroupMembershipList(user, false);
 
         if (groups.size() == 0) {
             log.debug(String.format("User (%s) does not have any groups", user.getId()));


### PR DESCRIPTION
The facade looks up the owner of each assignment but did not cache the values; if the same teacher sets most of your assignments (the common case) this is a lot of duplicated work.
The AssignmentManager also loaded owner and manager information for every group, only to immediately discard this information and extract just the group IDs. The GroupManager now supports skipping this augmentation, but leaves default methods with the old signatures that do augment.

May be easier to view changes ignoring whitespace: https://github.com/isaacphysics/isaac-api/pull/269/files?w=1