### PR TITLE
Optimise teacher assignments endpoints

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -274,8 +274,11 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                         .getQuestionAttemptsByUser(currentlyLoggedInUser);
 
                 // we want to populate gameboard details for the assignment DTO.
+                List<String> gameboardIDs = allAssignmentsSetToGroup.stream().map(AssignmentDTO::getGameboardId).collect(Collectors.toList());
+                Map<String, GameboardDTO> gameboards = this.gameManager.getGameboards(gameboardIDs, currentlyLoggedInUser, userQuestionAttempts)
+                        .stream().collect(Collectors.toMap(GameboardDTO::getId, Function.identity()));
                 for (AssignmentDTO assignment : allAssignmentsSetToGroup) {
-                    assignment.setGameboard(this.gameManager.getGameboard(assignment.getGameboardId(), currentlyLoggedInUser, userQuestionAttempts));
+                    assignment.setGameboard(gameboards.get(assignment.getGameboardId()));
                 }
 
                 this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacLogType.VIEW_GROUPS_ASSIGNMENTS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -269,13 +269,14 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                 Collection<AssignmentDTO> allAssignmentsSetToGroup
                         = this.assignmentManager.getAssignmentsByGroup(group.getId());
 
-                // we currently need to use the currently logged in users information to as a parameter to get all the pass mark information.
-                Map<String, Map<String, List<QuestionValidationResponse>>> userQuestionAttempts = this.questionManager
-                        .getQuestionAttemptsByUser(currentlyLoggedInUser);
+                // In order to get all the information about gameboard items, we need to use the method which augments
+                // gameboards with user attempt information. But we don't _want_ this information for real, so we won't
+                // do the costly loading of the real attempt information from the database:
+                Map<String, Map<String, List<QuestionValidationResponse>>> fakeQuestionAttemptMap = new HashMap<>();
 
                 // we want to populate gameboard details for the assignment DTO.
                 List<String> gameboardIDs = allAssignmentsSetToGroup.stream().map(AssignmentDTO::getGameboardId).collect(Collectors.toList());
-                Map<String, GameboardDTO> gameboards = this.gameManager.getGameboards(gameboardIDs, currentlyLoggedInUser, userQuestionAttempts)
+                Map<String, GameboardDTO> gameboards = this.gameManager.getGameboards(gameboardIDs, currentlyLoggedInUser, fakeQuestionAttemptMap)
                         .stream().collect(Collectors.toMap(GameboardDTO::getId, Function.identity()));
                 for (AssignmentDTO assignment : allAssignmentsSetToGroup) {
                     assignment.setGameboard(gameboards.get(assignment.getGameboardId()));


### PR DESCRIPTION
**Lookup all gameboards used by assignments in one database query**. This same optimisation was used for the "getAssignments" endpoint some time in the past, too! It saves a database query per assignment!

**Skip loading user's question attempts on viewing group progress**. I _think_ this is safe; it leads to potentially confusing information (i.e. state shown as `NOT_ATTEMPTED` for questions you have definitely done) being sent to the frontend, but this endpoint is not about getting your own progress at gameboards you have assigned. All the uses of this data in the frontend do not use the actual progress, merely the metadata about how many parts etc.
This makes viewing assignments set to a group _significantly_ faster for users with many question attempts!

**Use UPSERT to avoid duplicate database check on saving boards**. This code was written before Postgres added UPSERT functionality via the (ON CONFLICT DO UPDATE) syntax. No need to check and then do either insert or update; instead attempt to insert and let Postgres update if necessary in an atomic operation.
This has the smallest impact, but I wanted to reduce the usages of `GameboardPersistenceManager::isBoardLinkedToUser` to the minimum poissible, since it is the most catastrophic method for site performance, doing a query per gameboard involved in almost every endpoint and accounting for a large fraction of all of our database traffic for common endpoints!


Again, hiding whitespace changes will make reviewing easier: https://github.com/isaacphysics/isaac-api/pull/270/files?w=1