### PR TITLE
Upgrade elasticsearch

### DIFF
--- a/compose-api-deps.yml
+++ b/compose-api-deps.yml
@@ -24,10 +24,12 @@ services:
     environment:
       - cluster.name=isaac-phy-live-search
       - "network.host=${LOCAL_PHY_ELASTICSEARCH_IP}"
-      - "discovery.zen.ping.unicast.hosts=${REMOTE_PHY_ELASTICSEARCH_IP},${LOCAL_PHY_ELASTICSEARCH_IP}"
       - "discovery.seed_hosts=${REMOTE_PHY_ELASTICSEARCH_IP},${LOCAL_PHY_ELASTICSEARCH_IP}" # master-eligible nodes
       - "ES_JAVA_OPTS=-Xms6g -Xmx6g"
       - bootstrap.memory_lock=true # part of disabling swap
+      # VV UN-COMMENT FOR BOOTSTRAP VV #
+      # - "node.name=master"
+      # - "cluster.initial_master_nodes=master"
     ulimits:
       memlock: -1 # part of disabling swap
       nproc: -1 # doc suggestion: at least 2,048 our docker default is unlimited
@@ -46,10 +48,12 @@ services:
     environment:
       - cluster.name=isaac-cs-live-search
       - "network.host=${LOCAL_CS_ELASTICSEARCH_IP}"
-      - "discovery.zen.ping.unicast.hosts=${REMOTE_CS_ELASTICSEARCH_IP},${LOCAL_CS_ELASTICSEARCH_IP}"
       - "discovery.seed_hosts=${REMOTE_CS_ELASTICSEARCH_IP},${LOCAL_CS_ELASTICSEARCH_IP}" # master-eligible nodes
       - "ES_JAVA_OPTS=-Xms6g -Xmx6g"
       - bootstrap.memory_lock=true # part of disabling swap
+      # VV UN-COMMENT FOR BOOTSTRAP VV #
+      # - "node.name=master"
+      # - "cluster.initial_master_nodes=master"
     ulimits:
       memlock: -1 # part of disabling swap
       nproc: -1 # doc suggestion: at least 2,048 our docker default is unlimited

--- a/compose-api-deps.yml
+++ b/compose-api-deps.yml
@@ -20,11 +20,12 @@ services:
   phy-elasticsearch-live:
     # container configuration https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
     container_name: phy-elasticsearch-live
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.0
     environment:
       - cluster.name=isaac-phy-live-search
       - "network.host=${LOCAL_PHY_ELASTICSEARCH_IP}"
       - "discovery.zen.ping.unicast.hosts=${REMOTE_PHY_ELASTICSEARCH_IP},${LOCAL_PHY_ELASTICSEARCH_IP}"
+      - "discovery.seed_hosts=${REMOTE_PHY_ELASTICSEARCH_IP},${LOCAL_PHY_ELASTICSEARCH_IP}" # master-eligible nodes
       - "ES_JAVA_OPTS=-Xms6g -Xmx6g"
       - bootstrap.memory_lock=true # part of disabling swap
     ulimits:
@@ -41,12 +42,12 @@ services:
   cs-elasticsearch-live:
     # container configuration https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
     container_name: cs-elasticsearch-live
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.0
     environment:
       - cluster.name=isaac-cs-live-search
       - "network.host=${LOCAL_CS_ELASTICSEARCH_IP}"
-      - "discovery.zen.ping.unicast.hosts=${LOCAL_CS_ELASTICSEARCH_IP}"
       - "discovery.zen.ping.unicast.hosts=${REMOTE_CS_ELASTICSEARCH_IP},${LOCAL_CS_ELASTICSEARCH_IP}"
+      - "discovery.seed_hosts=${REMOTE_CS_ELASTICSEARCH_IP},${LOCAL_CS_ELASTICSEARCH_IP}" # master-eligible nodes
       - "ES_JAVA_OPTS=-Xms6g -Xmx6g"
       - bootstrap.memory_lock=true # part of disabling swap
     ulimits:

--- a/compose-local-deps.yml
+++ b/compose-local-deps.yml
@@ -20,20 +20,24 @@ services:
   elasticsearch:
     network_mode: bridge
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.0
     environment:
       - cluster.name=isaac
       - "network.host=0.0.0.0"
+      - node.name=localhost
+      - cluster.initial_master_nodes=localhost
     ports:
       - "9200:9200"
       - "9300:9300"
   cs-elasticsearch:
     network_mode: bridge
     container_name: cs-elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.0
     environment:
       - cluster.name=cs-isaac
       - "network.host=0.0.0.0"
+      - node.name=localhost
+      - cluster.initial_master_nodes=localhost
     ports:
       - "9201:9200"
       - "9301:9300"

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
-            <version>6.4.1</version>
+            <version>7.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.opencsv</groupId>

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -513,7 +513,7 @@ public class GitContentManager implements IContentManager {
         }
         SearchResponse r =  searchProvider.getAllByType(globalProperties.getProperty(Constants.CONTENT_INDEX), unitType);
         SearchHits hits = r.getHits();
-        ArrayList<String> units = new ArrayList<>((int) hits.getTotalHits());
+        ArrayList<String> units = new ArrayList<>((int) hits.getTotalHits().value);
         for (SearchHit hit : hits) {
             units.add((String) hit.getSourceAsMap().get("unit"));
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
@@ -540,7 +540,7 @@ public class ElasticSearchProvider implements ISearchProvider {
                 resultList.add(item.getSourceAsString());
             }
 
-            return new ResultsWrapper<>(resultList, response.getHits().getTotalHits());
+            return new ResultsWrapper<>(resultList, response.getHits().getTotalHits().value);
         } catch (ElasticsearchException e) {
             throw new SegueSearchException("Error while trying to search", e);
         }


### PR DESCRIPTION
So our existing clustering settings `discovery.zen.ping.unicast.hosts` is deprecated but it is a straight swap with `discovery.seed_hosts`.

That would be all... but as we will be creating a new cluster we also need to set `cluster.initial_master_nodes` for the very first election (cluster bootstrapping).
I have been able to get bootstrapping working locally by specifying `node.name` and `cluster.initial_master_nodes` to be that one node's name (one node is fine for our use case).
I have included those properties in the compose file commented out. On first running, un-comment them, after that you can comment them out again or delete them.

I feel Ian might have a nicer way of doing this perhaps passing in the one-off properties into a docker run command.

Relevant docs:
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-settings.html
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-bootstrap-cluster.html