### PR TITLE
Add word proximity distance option to FreeTextRules

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
@@ -104,6 +104,7 @@ public class IsaacFreeTextValidator implements IValidator {
         if (rule.getAllowsMisspelling()) { result.append("m"); }
         if (rule.getAllowsAnyOrder()) { result.append("o"); }
         if (rule.getAllowsExtraWords()) { result.append("w"); }
+        if (rule.getWordProximity() != null) { result.append("p").append(rule.getWordProximity()); }
         return result.toString();
     }
 
@@ -120,8 +121,8 @@ public class IsaacFreeTextValidator implements IValidator {
                 String answerString = extractAnswerValue(answer, freeTextRule.isCaseInsensitive());
                 answerString = removeNonAlphanumericChars(answerString, freeTextRule.getValue());
                 PMatch questionAnswerMatcher = new PMatch(answerString);
-                String matchingParamaters = evaluateMatchingOptions(freeTextRule);
-                if (questionAnswerMatcher.match(matchingParamaters, extractRuleValue(freeTextRule))) {
+                String matchingParameters = evaluateMatchingOptions(freeTextRule);
+                if (questionAnswerMatcher.match(matchingParameters, extractRuleValue(freeTextRule))) {
                     isCorrectResponse = rule.isCorrect();
                     feedback = (Content) rule.getExplanation();
                     break; // on first matching rule

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/FreeTextRule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/FreeTextRule.java
@@ -24,6 +24,7 @@ public class FreeTextRule extends Choice {
     private boolean allowsAnyOrder;
     private boolean allowsExtraWords;
     private boolean allowsMisspelling;
+    private Integer proximityDistance;
 
     public FreeTextRule() {}
 
@@ -50,5 +51,11 @@ public class FreeTextRule extends Choice {
     }
     public boolean getAllowsMisspelling() {
         return this.allowsMisspelling;
+    }
+    public void setWordProximity(Integer proximityDistance) {
+        this.proximityDistance = proximityDistance;
+    }
+    public Integer getWordProximity() {
+        return this.proximityDistance;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/FreeTextRuleDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/FreeTextRuleDTO.java
@@ -20,6 +20,7 @@ public class FreeTextRuleDTO extends ChoiceDTO {
     private boolean allowsAnyOrder;
     private boolean allowsExtraWords;
     private boolean allowsMisspelling;
+    private Integer proximityDistance;
 
     public FreeTextRuleDTO() {}
 
@@ -34,5 +35,11 @@ public class FreeTextRuleDTO extends ChoiceDTO {
     }
     public void setAllowsMisspelling(final boolean allowsMisspelling) {
         this.allowsMisspelling = allowsMisspelling;
+    }
+    public void setWordProximity(Integer proximityDistance) {
+        this.proximityDistance = proximityDistance;
+    }
+    public Integer getWordProximity() {
+        return this.proximityDistance;
     }
 }


### PR DESCRIPTION
This PR allows the content team to define an extra option (proximity distance) to a matching rule which will tell OpenMark to make sure that the distance between words connected by an underscore, `_`, is restricted to being a certain distance away.
For example, a rule with p0 and value "constant_speed" would match "constant speed" but not match "constant accelerating speed".

https://editor.isaacphysics.org/#!/edit/master/content/featured_problems/force_concept_inventory/2020/quiz_1/fci_quiz1_6.json
uses this rule for the values "not_balanced" and "not_equal".

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [x] Peer-Reviewed
