### PR TITLE
Add a filter to respond to any invalid sessions with 412 Precondition failed

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
@@ -27,6 +27,7 @@ import uk.ac.cam.cl.dtg.isaac.api.IsaacController;
 import uk.ac.cam.cl.dtg.isaac.api.PagesFacade;
 import uk.ac.cam.cl.dtg.segue.api.*;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserBadgeManager;
+import uk.ac.cam.cl.dtg.segue.api.monitors.InvalidSessionFilter;
 import uk.ac.cam.cl.dtg.segue.api.monitors.PerformanceMonitor;
 import uk.ac.cam.cl.dtg.segue.configuration.SegueGuiceConfigurationModule;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
@@ -99,6 +100,7 @@ public class IsaacApplicationRegister extends Application {
             this.singletons.add(injector.getInstance(AssignmentFacade.class));
             this.singletons.add(injector.getInstance(GroupsFacade.class));
             this.singletons.add(injector.getInstance(GlossaryFacade.class));
+            this.singletons.add(injector.getInstance(InvalidSessionFilter.class));
             
             // initialise isaac specific facades
             this.singletons.add(injector.getInstance(GameboardsFacade.class));

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -415,6 +415,39 @@ public class UserAuthenticationManager {
             return null;
         }
     }
+
+    /**
+     * Determines the Date when the session expires
+     * @param request The request to extract the session information from
+     * @return The Date the session expires
+     * @throws NoUserLoggedInException Thrown when the session information doesn't contain the expiry date
+     * @throws ParseException Thrown when the expiry date could not be parsed
+     * @throws InvalidSessionException Thrown when the session is invalid
+     * @throws IOException Thrown when failed to read the session from the request
+     */
+    public Date getTimeToSessionExpiry(final HttpServletRequest request) throws ParseException, IOException, InvalidSessionException, NoUserLoggedInException {
+        Map<String, String> currentSessionInformation = getSegueSessionFromRequest(request);
+        if (currentSessionInformation.containsKey(DATE_EXPIRES)) {
+            SimpleDateFormat sessionDateFormat = new SimpleDateFormat(DEFAULT_DATE_FORMAT);
+            return sessionDateFormat.parse(currentSessionInformation.get(DATE_EXPIRES));
+        } else {
+            throw new NoUserLoggedInException();
+        }
+    }
+
+    /**
+     * Determines if the request has a segue auth cookie attached, valid or invalid.
+     * @param request The request to check for the cookie
+     * @return if the request has a segue auth cookie
+     */
+    public boolean hasAuthCookie(final HttpServletRequest request) {
+        try {
+            Map<String, String> currentSessionInformation = getSegueSessionFromRequest(request);
+            return currentSessionInformation != null;
+        } catch (IOException | InvalidSessionException e) {
+            return false;
+        }
+    }
     
     /**
      * Create a signed session based on the user DO provided and the http request and response.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InvalidSessionFilter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InvalidSessionFilter.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2015 Stephen Cummins
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.api.monitors;
+
+import com.google.inject.Inject;
+import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
+import uk.ac.cam.cl.dtg.segue.api.managers.UserAuthenticationManager;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Filters out requests which have a segue auth cookie but requesting the user throws a NoUserLoggedInException.
+ *
+ */
+@Provider
+public class InvalidSessionFilter implements ContainerRequestFilter {
+    private final UserAccountManager userAccountManager;
+    private final UserAuthenticationManager userAuthenticationManager;
+
+    @Context
+    private HttpServletRequest request;
+
+    /**
+     * InvalidSessionFilter.
+     */
+    @Inject
+    public InvalidSessionFilter(final UserAccountManager userAccountManager, final UserAuthenticationManager userAuthenticationManager) {
+        this.userAccountManager = userAccountManager;
+        this.userAuthenticationManager = userAuthenticationManager;
+    }
+
+    @Override
+    public void filter(final ContainerRequestContext requestContext) {
+        boolean hasAuthCookie = userAuthenticationManager.hasAuthCookie(request);
+        if (hasAuthCookie) {
+            try {
+                if (!(requestContext.getUriInfo().getPath()).equals("/auth/logout")) {
+                    userAccountManager.getCurrentRegisteredUser(request);
+                }
+            } catch (NoUserLoggedInException e) {
+                // Has an auth cookie but no user is logged in -> cookie is invalid
+                requestContext.abortWith(Response
+                        .status(Response.Status.PRECONDITION_FAILED)
+                        .entity("Auth cookie is invalid")
+                        .build());
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Requires an extra database lookup for each request from a logged in user. User must be requested in order to fetch the current session token.
- If the segue auth cookie is present but a NoUserLoggedInException is thrown when requesting the user the request is aborted and a 412 is sent as a response.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
