### PR TITLE
Allow event managers to send up to 100 emails per day

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
@@ -15,8 +15,14 @@
  */
 package uk.ac.cam.cl.dtg.segue.api;
 
-import java.util.Arrays;
-import java.util.Collections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
+import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
+import uk.ac.cam.cl.dtg.segue.dos.users.Role;
+import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -24,16 +30,8 @@ import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
-import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
-import uk.ac.cam.cl.dtg.segue.dos.users.Role;
-import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
-import uk.ac.cam.cl.dtg.util.PropertiesLoader;
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * An abstract representation of a Segue CMS facade.
@@ -215,6 +213,38 @@ public abstract class AbstractSegueFacade {
             throws NoUserLoggedInException {
         return userManager.checkUserRole(userDTO, Collections.singletonList(Role.ADMIN));
     }
+
+    /**
+     * Is the current user in an event manager role.
+     *
+     * @param userManager
+     *            - Instance of User Manager
+     * @param request
+     *            - with session information
+     * @return true if user is logged in as an event manager, false otherwise.
+     * @throws NoUserLoggedInException
+     *             - if we are unable to tell because they are not logged in.
+     */
+    public static boolean isUserAnEventManager(final UserAccountManager userManager,
+                                                      final HttpServletRequest request) throws NoUserLoggedInException {
+        return userManager.checkUserRole(request, Collections.singletonList(Role.EVENT_MANAGER));
+    }
+
+    /**
+     * Is the current user in an event manager role.
+     *
+     * @param userManager
+     *            - Instance of User Manager
+     * @param userDTO
+     *            - for the user of interest
+     * @return true if user is logged in as an event manager, false otherwise.
+     * @throws NoUserLoggedInException
+     *             - if we are unable to tell because they are not logged in.
+     */
+    public static boolean isUserAnEventManager(final UserAccountManager userManager,
+                                                      final RegisteredUserDTO userDTO) throws NoUserLoggedInException {
+        return userManager.checkUserRole(userDTO, Collections.singletonList(Role.EVENT_MANAGER));
+    }
     
     /**
      * Is the current user in an admin or event manager role.
@@ -223,7 +253,7 @@ public abstract class AbstractSegueFacade {
      *            - Instance of User Manager
      * @param request
      *            - with session information
-     * @return true if user is logged in as an admin, false otherwise.
+     * @return true if user is logged in as an admin or event manager, false otherwise.
      * @throws NoUserLoggedInException
      *             - if we are unable to tell because they are not logged in.
      */
@@ -239,7 +269,7 @@ public abstract class AbstractSegueFacade {
      *            - Instance of User Manager
      * @param userDTO
      *            - for the user of interest
-     * @return true if user is logged in as an admin, false otherwise.
+     * @return true if user is logged in as an admin or event manager, false otherwise.
      * @throws NoUserLoggedInException
      *             - if we are unable to tell because they are not logged in.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -32,6 +32,7 @@ import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.monitors.EmailVerificationMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.EmailVerificationRequestMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.IMisuseMonitor;
+import uk.ac.cam.cl.dtg.segue.api.monitors.SendEmailMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidTokenException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.MissingRequiredFieldException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
@@ -488,8 +489,23 @@ public class EmailFacade extends AbstractSegueFacade {
 
         try {
             RegisteredUserDTO sender = this.userManager.getCurrentRegisteredUser(request);
-            if (!isUserAnAdmin(userManager, sender)) {
+            if (!isUserAnAdminOrEventManager(userManager, sender)) {
                 return SegueErrorResponse.getIncorrectRoleResponse();
+            }
+
+            if (isUserAnEventManager(userManager, sender)) {
+                if (!emailType.equals(EmailType.EVENTS)) {
+                    return new SegueErrorResponse(Status.FORBIDDEN,
+                            "Event managers can only send event emails.").toResponse();
+                }
+                if (misuseMonitor.willHaveMisused(sender.getId().toString(),
+                        SendEmailMisuseHandler.class.getSimpleName(), userIds.size())) {
+                    return SegueErrorResponse
+                            .getRateThrottledResponse("You would have exceeded the number of emails you are allowed to send per day." +
+                                    " No emails have been sent.");
+                }
+                misuseMonitor.notifyEvent(sender.getId().toString(),
+                        SendEmailMisuseHandler.class.getSimpleName(), userIds.size());
             }
 
             for (Long userId : userIds) {
@@ -530,6 +546,9 @@ public class EmailFacade extends AbstractSegueFacade {
             log.debug(error.getErrorMessage());
         } catch (NoUserLoggedInException e2) {
             return SegueErrorResponse.getNotLoggedInResponse();
+        } catch (SegueResourceMisuseException e) {
+            return SegueErrorResponse
+                    .getRateThrottledResponse("You have exceeded the number of emails you are allowed to send per day.");
         }
 
         return Response.ok().build();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseMonitor.java
@@ -65,6 +65,21 @@ public interface IMisuseMonitor {
     boolean hasMisused(String agentIdentifier, String eventToCheck);
 
     /**
+     * Allows inspection of internal state such that we can give early warning as to whether user will have reached threshold
+     * before an event notification / exception takes place.
+     *
+     * @param agentIdentifier
+     *            - unique identifier for user.
+     * @param eventToCheck
+     *            - the identifier of the event we are interested in.
+     * @param adjustmentValue
+     *            - Weight of the action.
+     * @return true if the user will have reached the hard limit defined and they would trigger an exception if they used
+     *         notifyEvent with the provided adjustment value.
+     */
+    boolean willHaveMisused(String agentIdentifier, String eventToCheck, Integer adjustmentValue);
+
+    /**
      * Only one handler is allowed per event string and subsequent calls to this method with the same event will replace
      * the handler.
      * 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InMemoryMisuseMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InMemoryMisuseMonitor.java
@@ -144,7 +144,7 @@ public class InMemoryMisuseMonitor implements IMisuseMonitor {
         IMisuseHandler handler = handlerMap.get(eventToCheck);
 
         return isCountStillFresh(entry.getKey(), handler.getAccountingIntervalInSeconds())
-                && entry.getValue() + adjustmentValue > handler.getHardThreshold();
+                && entry.getValue() + adjustmentValue >= handler.getHardThreshold();
     }
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InMemoryMisuseMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InMemoryMisuseMonitor.java
@@ -144,7 +144,7 @@ public class InMemoryMisuseMonitor implements IMisuseMonitor {
         IMisuseHandler handler = handlerMap.get(eventToCheck);
 
         return isCountStillFresh(entry.getKey(), handler.getAccountingIntervalInSeconds())
-                && entry.getValue() + adjustmentValue >= handler.getHardThreshold();
+                && entry.getValue() + adjustmentValue > handler.getHardThreshold();
     }
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SendEmailMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SendEmailMisuseHandler.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2020 Connor Holloway
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.api.monitors;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
+
+/**
+ * Handler to deal with sending email requests.
+ *
+ * Preventing users from overusing this endpoint is important as only limited email sending capacity exists
+ *
+ * @author Connor Holloway
+ *
+ */
+public class SendEmailMisuseHandler implements IMisuseHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(SendEmailMisuseHandler.class);
+
+    private static final Integer SOFT_THRESHOLD = 100;
+    private static final Integer HARD_THRESHOLD = 100;
+    private static final Integer ACCOUNTING_INTERVAL = NUMBER_SECONDS_IN_ONE_DAY;
+
+    @Inject
+    public SendEmailMisuseHandler() {}
+
+    @Override
+    public Integer getSoftThreshold() {
+        return SOFT_THRESHOLD;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see uk.ac.cam.cl.dtg.segue.api.managers.IMisuseEvent#getHardThreshold()
+     */
+    @Override
+    public Integer getHardThreshold() {
+        return HARD_THRESHOLD;
+    }
+
+    @Override
+    public Integer getAccountingIntervalInSeconds() {
+        return ACCOUNTING_INTERVAL;
+    }
+
+    @Override
+    public void executeSoftThresholdAction(final String message) {
+        log.warn("Soft threshold limit: " + message);
+    }
+
+    @Override
+    public void executeHardThresholdAction(final String message) {
+        log.error("Hard threshold limit: " + message);
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SendEmailMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SendEmailMisuseHandler.java
@@ -33,8 +33,8 @@ public class SendEmailMisuseHandler implements IMisuseHandler {
 
     private static final Logger log = LoggerFactory.getLogger(SendEmailMisuseHandler.class);
 
-    private static final Integer SOFT_THRESHOLD = 100;
-    private static final Integer HARD_THRESHOLD = 100;
+    private static final Integer SOFT_THRESHOLD = 101;
+    private static final Integer HARD_THRESHOLD = 101;
     private static final Integer ACCOUNTING_INTERVAL = NUMBER_SECONDS_IN_ONE_DAY;
 
     @Inject

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -712,6 +712,9 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
 
             misuseMonitor.registerHandler(UserSearchMisuseHandler.class.getSimpleName(),
                     new UserSearchMisuseHandler());
+
+            misuseMonitor.registerHandler(SendEmailMisuseHandler.class.getSimpleName(),
+                    new SendEmailMisuseHandler());
         }
 
         return misuseMonitor;


### PR DESCRIPTION
- Add SendMailMisuseHandler
- Only allow event managers to send event emails
- Add new misuse handler method `willHaveMisused` to check if adding a number of events would cause a misuse exception.
  This is used to detect if the user would exceed the hard limit when sending the emails without adding them to the misuse monitor.
  This prevents a large batch of emails being counted by the misuse monitor without actually being sent.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
