### PR TITLE
Add TeacherPasswordResetMisuseMonitor

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -67,6 +67,7 @@ import uk.ac.cam.cl.dtg.segue.api.monitors.PasswordResetRequestMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.RegistrationMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.SegueLoginMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics;
+import uk.ac.cam.cl.dtg.segue.api.monitors.TeacherPasswordResetMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.auth.AuthenticationProvider;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticationProviderMappingException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.DuplicateAccountException;
@@ -354,7 +355,7 @@ public class UsersFacade extends AbstractSegueFacade {
                 return SegueErrorResponse.getIncorrectRoleResponse();
             }
 
-            misuseMonitor.notifyEvent(currentUser.getEmail() + "_group_member_reset", PasswordResetRequestMisuseHandler.class.getSimpleName());
+            misuseMonitor.notifyEvent(currentUser.getEmail(), TeacherPasswordResetMisuseHandler.class.getSimpleName());
             SegueMetrics.PASSWORD_RESET.inc();
             userManager.resetPasswordRequest(userOfInterest);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TeacherPasswordResetMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TeacherPasswordResetMisuseHandler.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2020 Connor Holloway
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.api.monitors;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
+
+/**
+ * Handler to deal with teacher password reset requests.
+ * 
+ * Separate from PasswordResetRequestMisuseHandler since teachers may need to reset the passwords of numerous
+ * students within a short period of time.
+ * 
+ * @author Connor Holloway
+ *
+ */
+public class TeacherPasswordResetMisuseHandler implements IMisuseHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(TeacherPasswordResetMisuseHandler.class);
+
+    private static final Integer SOFT_THRESHOLD = 15;
+    private static final Integer HARD_THRESHOLD = 30;
+    private static final Integer ACCOUNTING_INTERVAL = NUMBER_SECONDS_IN_ONE_HOUR;
+
+    /**
+     *
+     */
+    @Inject
+    public TeacherPasswordResetMisuseHandler() {
+
+    }
+    
+
+    @Override
+    public Integer getSoftThreshold() {
+        return SOFT_THRESHOLD;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see uk.ac.cam.cl.dtg.segue.api.managers.IMisuseEvent#getHardThreshold()
+     */
+    @Override
+    public Integer getHardThreshold() {
+        return HARD_THRESHOLD;
+    }
+
+    @Override
+    public Integer getAccountingIntervalInSeconds() {
+        return ACCOUNTING_INTERVAL;
+    }
+
+    @Override
+    public void executeSoftThresholdAction(final String message) {
+        log.warn("Soft threshold limit: " + message);
+    }
+
+    @Override
+    public void executeHardThresholdAction(final String message) {
+        log.error("Hard threshold limit: " + message);
+    }
+
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -692,6 +692,9 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
             misuseMonitor.registerHandler(PasswordResetRequestMisuseHandler.class.getSimpleName(),
                     new PasswordResetRequestMisuseHandler());
 
+            misuseMonitor.registerHandler(TeacherPasswordResetMisuseHandler.class.getSimpleName(),
+                    new TeacherPasswordResetMisuseHandler());
+
             misuseMonitor.registerHandler(RegistrationMisuseHandler.class.getSimpleName(),
                     new RegistrationMisuseHandler(emailManager, properties));
 


### PR DESCRIPTION
Adds a misuse monitor for the reset of passwords for other users in a group.
This prevents teachers running into the hard threshold if they have to reset passwords for a large portion of a class.
- Soft: 15, Hard: 30 per hour

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
