### PR TITLE
Add session expiry information as current user request header

### DIFF
--- a/override-api-web.xml
+++ b/override-api-web.xml
@@ -34,6 +34,10 @@
             <param-name>allowedOrigins</param-name>
             <param-value>(https://*.isaac(physics|computerscience).org|http://localhost:800[01234])</param-value>
         </init-param>
+        <init-param>
+            <param-name>exposedHeaders</param-name>
+            <param-value>X-Session-Expires</param-value>
+        </init-param>
     </filter>
     <filter-mapping>
         <filter-name>cross-origin</filter-name>

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -534,6 +534,18 @@ public class UserAccountManager implements IUserAccountManager {
     }
 
     /**
+     * Extract the session expiry time from a request.
+     *
+     * Does not check session validity.
+     *
+     * @param request The request to extract the session information from
+     * @return The session expiry as a Date
+     */
+    public Date getSessionExpiry(final HttpServletRequest request) {
+        return userAuthenticationManager.getSessionExpiry(request);
+    }
+
+    /**
      * Get the authentication settings of particular user
      *
      * @param user

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -378,6 +378,30 @@ public class UserAuthenticationManager {
     }
 
     /**
+     * Extract the session expiry time from a request.
+     *
+     * Does not check session validity.
+     *
+     * @param request The request to extract the session information from
+     * @return The session expiry as a Date
+     */
+    public Date getSessionExpiry(final HttpServletRequest request) {
+        try {
+            Map<String, String> currentSessionInformation = getSegueSessionFromRequest(request);
+            if (currentSessionInformation.containsKey(DATE_EXPIRES)) {
+                SimpleDateFormat sessionDateFormat = new SimpleDateFormat(DEFAULT_DATE_FORMAT);
+                return sessionDateFormat.parse(currentSessionInformation.get(DATE_EXPIRES));
+            } else {
+                return null;
+            }
+        } catch (InvalidSessionException | ParseException | IOException e) {
+            log.debug("Error extracting session expiry from session information.", e);
+            return null;
+        }
+    }
+
+
+    /**
      * This method tries to address some of the duplication when extracting a user from a request.
      *
      * Note: This method has an important security enforcing function. Users who haven't completed MFA will have a cookie


### PR DESCRIPTION
Since the client can't read the cookie, it does not know how long until the session expires. Add the information in a header, and ensure it can be accessed by browsers using the CORS exposedHeaders parameter.
The date is provided in HTTP-Date format.