### PR TITLE
Feature/monitor log events

### DIFF
--- a/compose-local-monitor.yml
+++ b/compose-local-monitor.yml
@@ -2,44 +2,44 @@
 # docker-compose -f compose-local-deps.yml -f compose-local-monitor.yml up -d
 version: '2'
 services:
-  elasticsearch-exporter:
-    image: justwatch/elasticsearch_exporter:1.0.2
-    container_name: elasticsearch-exporter
-    command:
-     - '-es.uri=http://elasticsearch:9200'
-    network_mode: bridge
-    links:
-      - elasticsearch:elasticsearch
-    ports:
-      - 9108:9108
+#  elasticsearch-exporter:
+#    image: justwatch/elasticsearch_exporter:1.0.2
+#    container_name: elasticsearch-exporter
+#    command:
+#     - '-es.uri=http://elasticsearch:9200'
+#    network_mode: bridge
+#    links:
+#      - elasticsearch:elasticsearch
+#    ports:
+#      - 9108:9108
 
-  postgres-exporter:
-    # if this isn't working run ./initialise_local_environment.sh
-    network_mode: bridge
-    image: wrouesnel/postgres_exporter
-    container_name: postgres-exporter
-    environment:
-      - DATA_SOURCE_URI=postgres:5432/rutherford?sslmode=disable
-      - DATA_SOURCE_USER=$POSTGRES_DB_USER
-      - DATA_SOURCE_PASS=$POSTGRES_DB_PASSWORD
-    links:
-      - postgres:postgres
-    ports:
-      - 9187:9187
+#  postgres-exporter:
+#    # if this isn't working run ./initialise_local_environment.sh
+#    network_mode: bridge
+#    image: wrouesnel/postgres_exporter
+#    container_name: postgres-exporter
+#    environment:
+#      - DATA_SOURCE_URI=postgres:5432/rutherford?sslmode=disable
+#      - DATA_SOURCE_USER=$POSTGRES_DB_USER
+#      - DATA_SOURCE_PASS=$POSTGRES_DB_PASSWORD
+#    links:
+#      - postgres:postgres
+#    ports:
+#      - 9187:9187
 
   prometheus:
     image: prom/prometheus
     container_name: prometheus
     command:
-      - --storage.tsdb.retention=90d
+      - --storage.tsdb.retention=7d
       - --storage.tsdb.path=/prometheus/data
       - --config.file=/prometheus/prometheus.yml
     volumes:
       - ./prometheus:/prometheus
     network_mode: bridge
-    links:
-      - postgres-exporter:postgres-exporter
-      - elasticsearch-exporter:elasticsearch-exporter
+#    links:
+#      - postgres-exporter:postgres-exporter
+#      - elasticsearch-exporter:elasticsearch-exporter
     ports:
       - 9090:9090
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -286,7 +286,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                     assignment.setGameboard(gameboards.get(assignment.getGameboardId()));
                 }
 
-                this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacLogType.VIEW_GROUPS_ASSIGNMENTS,
+                this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacServerLogType.VIEW_GROUPS_ASSIGNMENTS,
                         ImmutableMap.of("groupId", group.getId()));
 
                 return Response.ok(allAssignmentsSetToGroup)
@@ -371,7 +371,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                 }
             }
 
-            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacLogType.VIEW_ASSIGNMENT_PROGRESS,
+            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacServerLogType.VIEW_ASSIGNMENT_PROGRESS,
                     ImmutableMap.of(ASSIGNMENT_FK, assignment.getId()));
 
             // get game manager completion information for this assignment.
@@ -563,7 +563,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                 Collections.addAll(resultRows, resultRow.toArray(new String[0]));
             }
 
-            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacLogType.DOWNLOAD_ASSIGNMENT_PROGRESS_CSV,
+            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacServerLogType.DOWNLOAD_ASSIGNMENT_PROGRESS_CSV,
                     ImmutableMap.of("assignmentId", assignmentId));
 
             // ignore name columns
@@ -877,7 +877,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                     .append(stringWriter.toString())
                     .append("\n\nN.B.\n\"The percentages are for question parts completed, not question pages.\"\n");
 
-            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacLogType.DOWNLOAD_GROUP_PROGRESS_CSV,
+            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacServerLogType.DOWNLOAD_GROUP_PROGRESS_CSV,
                     ImmutableMap.of("groupId", groupId));
 
             return Response.ok(headerBuilder.toString())
@@ -990,7 +990,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
             eventDetails.put(GROUP_FK, assignmentWithID.getGroupId());
             eventDetails.put(ASSIGNMENT_FK, assignmentWithID.getId());
             eventDetails.put(ASSIGNMENT_DUEDATE_FK, assignmentWithID.getDueDate());
-            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacLogType.SET_NEW_ASSIGNMENT, eventDetails);
+            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacServerLogType.SET_NEW_ASSIGNMENT, eventDetails);
 
             this.userBadgeManager.updateBadge(currentlyLoggedInUser,
                     UserBadgeManager.Badge.TEACHER_ASSIGNMENTS_SET, assignmentWithID.getId().toString());
@@ -1065,7 +1065,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
 
             this.assignmentManager.deleteAssignment(assignmentToDelete);
 
-            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacLogType.DELETE_ASSIGNMENT,
+            this.getLogManager().logEvent(currentlyLoggedInUser, request, IsaacServerLogType.DELETE_ASSIGNMENT,
                     ImmutableMap.of(ASSIGNMENT_FK, assignmentToDelete.getId()));
 
             return Response.noContent().build();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -18,8 +18,11 @@ package uk.ac.cam.cl.dtg.isaac.api;
 import uk.ac.cam.cl.dtg.segue.api.Constants.LogType;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static uk.ac.cam.cl.dtg.segue.api.Constants.SEGUE_SERVER_LOG_TYPES;
 
 /**
  * Utility class to provide common isaac-specific constants.
@@ -157,6 +160,12 @@ public final class Constants {
         CLIENT_SIDE_ERROR,
     }
     public static final Set<String> ISAAC_CLIENT_LOG_TYPES = Arrays.stream(IsaacClientLogType.values()).map(IsaacClientLogType::name).collect(Collectors.toSet());
+
+    public static final Set<String> ALL_ACCEPTED_LOG_TYPES = new HashSet<String>() {{
+        addAll(SEGUE_SERVER_LOG_TYPES);
+        addAll(ISAAC_SERVER_LOG_TYPES);
+        addAll(ISAAC_CLIENT_LOG_TYPES);
+    }};
 
     public enum IsaacUserPreferences {
         SUBJECT_INTEREST, BETA_FEATURE, EXAM_BOARD

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -114,7 +114,7 @@ public final class Constants {
     /**
      * Class to represent Isaac log types.
      */
-    public enum IsaacLogType implements LogType {
+    public enum IsaacServerLogType implements LogType {
         ADD_BOARD_TO_PROFILE,
         CREATE_GAMEBOARD,
         DELETE_ASSIGNMENT,
@@ -133,7 +133,7 @@ public final class Constants {
         VIEW_TOPIC_SUMMARY_PAGE,
         VIEW_USER_PROGRESS
     }
-    public static final Set<String> ISAAC_LOG_TYPES = Arrays.stream(IsaacLogType.values()).map(IsaacLogType::name).collect(Collectors.toSet());
+    public static final Set<String> ISAAC_SERVER_LOG_TYPES = Arrays.stream(IsaacServerLogType.values()).map(IsaacServerLogType::name).collect(Collectors.toSet());
 
     public enum IsaacUserPreferences {
         SUBJECT_INTEREST, BETA_FEATURE, EXAM_BOARD

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -135,6 +135,29 @@ public final class Constants {
     }
     public static final Set<String> ISAAC_SERVER_LOG_TYPES = Arrays.stream(IsaacServerLogType.values()).map(IsaacServerLogType::name).collect(Collectors.toSet());
 
+    public enum IsaacClientLogType implements LogType {
+        QUESTION_PART_OPEN,
+        CONCEPT_SECTION_OPEN,
+        ACCORDION_SECTION_OPEN,
+        VIDEO_PLAY,
+        VIDEO_PAUSE,
+        VIDEO_ENDED,
+        VIEW_SUPERSEDED_BY_QUESTION,
+        CLONE_GAMEBOARD,
+        VIEW_HINT,
+        QUICK_QUESTION_SHOW_ANSWER,
+        VIEW_RELATED_CONCEPT,
+        VIEW_RELATED_QUESTION,
+        VIEW_RELATED_PAGE,
+        VIEW_MY_ASSIGNMENTS,
+        VIEW_GAMEBOARD_BY_ID,
+        ACCEPT_COOKIES,
+        LEAVE_GAMEBOARD_BUILDER,
+        SAVE_GAMEBOARD,
+        CLIENT_SIDE_ERROR,
+    }
+    public static final Set<String> ISAAC_CLIENT_LOG_TYPES = Arrays.stream(IsaacClientLogType.values()).map(IsaacClientLogType::name).collect(Collectors.toSet());
+
     public enum IsaacUserPreferences {
         SUBJECT_INTEREST, BETA_FEATURE, EXAM_BOARD
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -54,7 +54,6 @@ import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
 import uk.ac.cam.cl.dtg.segue.dao.schools.SchoolListReader;
 import uk.ac.cam.cl.dtg.segue.dao.schools.UnableToIndexSchoolsException;
-import uk.ac.cam.cl.dtg.segue.dos.users.RegisteredUser;
 import uk.ac.cam.cl.dtg.segue.dos.users.Role;
 import uk.ac.cam.cl.dtg.segue.dos.users.School;
 import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
@@ -441,7 +440,7 @@ public class EventsFacade extends AbstractIsaacFacade {
                     = this.bookingManager.promoteToConfirmedBooking(event, userOfInterest);
 
             this.getLogManager().logEvent(currentUser, request,
-                    SegueLogType.ADMIN_EVENT_WAITING_LIST_PROMOTION, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId(),
+                    SegueServerLogType.ADMIN_EVENT_WAITING_LIST_PROMOTION, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId(),
                                                                          USER_ID_FKEY_FIELDNAME, userId));
             return Response.ok(eventBookingDTO).build();
         } catch (NoUserLoggedInException e) {
@@ -717,7 +716,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             EventBookingDTO booking = bookingManager.createBookingOrAddToWaitingList(event, bookedUser, additionalInformation);
             this.getLogManager().logEvent(currentUser, request,
-                    SegueLogType.ADMIN_EVENT_BOOKING_CREATED,
+                    SegueServerLogType.ADMIN_EVENT_BOOKING_CREATED,
                     ImmutableMap.of(
                         EVENT_ID_FKEY_FIELDNAME, event.getId(),
                         USER_ID_FKEY_FIELDNAME, userId,
@@ -799,7 +798,7 @@ public class EventsFacade extends AbstractIsaacFacade {
             List<EventBookingDTO> bookings = bookingManager.requestReservations(event, usersToReserve, reservingUser);
 
             this.getLogManager().logEvent(reservingUser, request,
-                    SegueLogType.EVENT_RESERVATIONS_CREATED,
+                    SegueServerLogType.EVENT_RESERVATIONS_CREATED,
                     ImmutableMap.of(
                             EVENT_ID_FKEY_FIELDNAME, event.getId(),
                             USER_ID_FKEY_FIELDNAME, reservingUser.getId(),
@@ -892,7 +891,7 @@ public class EventsFacade extends AbstractIsaacFacade {
             }
 
             this.getLogManager().logEvent(userLoggedIn, request,
-                    SegueLogType.EVENT_RESERVATIONS_CANCELLED,
+                    SegueServerLogType.EVENT_RESERVATIONS_CANCELLED,
                     ImmutableMap.of(
                             EVENT_ID_FKEY_FIELDNAME, event.getId(),
                             USER_ID_FKEY_FIELDNAME, userLoggedIn.getId(),
@@ -956,7 +955,7 @@ public class EventsFacade extends AbstractIsaacFacade {
             EventBookingDTO eventBookingDTO = bookingManager.requestBooking(event, user, additionalInformation);
 
             this.getLogManager().logEvent(userManager.getCurrentUser(request), request,
-                    SegueLogType.EVENT_BOOKING, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId()));
+                    SegueServerLogType.EVENT_BOOKING, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId()));
 
             return Response.ok(eventBookingDTO).build();
         } catch (NoUserLoggedInException e) {
@@ -1012,7 +1011,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             EventBookingDTO eventBookingDTO = bookingManager.requestWaitingListBooking(event, user, additionalInformation);
             this.getLogManager().logEvent(userManager.getCurrentUser(request), request,
-                    SegueLogType.EVENT_WAITING_LIST_BOOKING, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId()));
+                    SegueServerLogType.EVENT_WAITING_LIST_BOOKING, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId()));
 
             return Response.ok(eventBookingDTO).build();
         } catch (NoUserLoggedInException e) {
@@ -1117,10 +1116,10 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             if (!userOwningBooking.equals(userLoggedIn)) {
                 this.getLogManager().logEvent(userLoggedIn, request,
-                        SegueLogType.ADMIN_EVENT_BOOKING_CANCELLED, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId(), USER_ID_FKEY_FIELDNAME, userOwningBooking.getId()));
+                        SegueServerLogType.ADMIN_EVENT_BOOKING_CANCELLED, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId(), USER_ID_FKEY_FIELDNAME, userOwningBooking.getId()));
             } else {
                 this.getLogManager().logEvent(userLoggedIn, request,
-                        SegueLogType.EVENT_BOOKING_CANCELLED, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId()));
+                        SegueServerLogType.EVENT_BOOKING_CANCELLED, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId()));
             }
 
             return Response.noContent().build();
@@ -1227,7 +1226,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             bookingManager.deleteBooking(event, user);
 
-            this.getLogManager().logEvent(currentUser, request, SegueLogType.ADMIN_EVENT_BOOKING_DELETED,
+            this.getLogManager().logEvent(currentUser, request, SegueServerLogType.ADMIN_EVENT_BOOKING_DELETED,
                     ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, eventId, USER_ID_FKEY_FIELDNAME, userId));
 
             return Response.noContent().build();
@@ -1279,7 +1278,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             EventBookingDTO eventBookingDTO = this.bookingManager.recordAttendance(event, userOfInterest, attended);
             this.getLogManager().logEvent(currentUser, request,
-                    SegueLogType.ADMIN_EVENT_ATTENDANCE_RECORDED,
+                    SegueServerLogType.ADMIN_EVENT_ATTENDANCE_RECORDED,
                     ImmutableMap.of(
                         EVENT_ID_FKEY_FIELDNAME, event.getId(),
                         USER_ID_FKEY_FIELDNAME, userId,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -479,7 +479,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, message).toResponse();
         }
 
-        this.getLogManager().logEvent(user, request, IsaacLogType.CREATE_GAMEBOARD,
+        this.getLogManager().logEvent(user, request, IsaacServerLogType.CREATE_GAMEBOARD,
                 ImmutableMap.of(GAMEBOARD_ID_FKEY, persistedGameboard.getId()));
 
         return Response.ok(persistedGameboard).build();
@@ -549,7 +549,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
 
             // go ahead and persist the gameboard (if it is only temporary) / link it to the users my boards account
             gameManager.linkUserToGameboard(existingGameboard, user);
-            getLogManager().logEvent(user, request, IsaacLogType.ADD_BOARD_TO_PROFILE,
+            getLogManager().logEvent(user, request, IsaacServerLogType.ADD_BOARD_TO_PROFILE,
                     ImmutableMap.of(GAMEBOARD_ID_FKEY, existingGameboard.getId()));
 
         } catch (SegueDatabaseException e) {
@@ -704,7 +704,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
         getLogManager().logEvent(
                 currentUser,
                 request,
-                IsaacLogType.VIEW_MY_BOARDS_PAGE,
+                IsaacServerLogType.VIEW_MY_BOARDS_PAGE,
                 ImmutableMap.builder().put("totalBoards", gameboards.getTotalResults())
                         .put("notStartedTotal", gameboards.getTotalNotStarted())
                         .put("completedTotal", gameboards.getTotalCompleted())
@@ -754,7 +754,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
 
             // go ahead and persist the gameboard (if it is only temporary) / link it to the users my boards account
             gameManager.linkUserToGameboard(existingGameboard, user);
-            getLogManager().logEvent(user, request, IsaacLogType.ADD_BOARD_TO_PROFILE,
+            getLogManager().logEvent(user, request, IsaacServerLogType.ADD_BOARD_TO_PROFILE,
                     ImmutableMap.of(GAMEBOARD_ID_FKEY, existingGameboard.getId()));
 
         } catch (SegueDatabaseException e) {
@@ -791,7 +791,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
 
             this.gameManager.unlinkUserToGameboard(user, gameboardIdsForDeletion);
 
-            getLogManager().logEvent(user, request, IsaacLogType.DELETE_BOARD_FROM_PROFILE,
+            getLogManager().logEvent(user, request, IsaacServerLogType.DELETE_BOARD_FROM_PROFILE,
                     ImmutableMap.of(GAMEBOARD_ID_FKEYS, gameboardIdsForDeletion));
 
         } catch (SegueDatabaseException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -68,7 +68,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.IsaacLogType;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.IsaacServerLogType;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.PROXY_PATH;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
@@ -108,7 +108,7 @@ public class IsaacController extends AbstractIsaacFacade {
                 public void run() {
                     try {
                         log.info("Triggering question answer count query.");
-                        lastQuestionCount = statsManager.getLogCount(SegueLogType.ANSWER_QUESTION.name());
+                        lastQuestionCount = statsManager.getLogCount(SegueServerLogType.ANSWER_QUESTION.name());
                         log.info("Question answer count query complete.");
                     } catch (SegueDatabaseException e) {
                         lastQuestionCount = 0L;
@@ -217,7 +217,7 @@ public class IsaacController extends AbstractIsaacFacade {
                     .put(CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA()).build();
 
             getLogManager().logEvent(userManager.getCurrentUser(httpServletRequest), httpServletRequest,
-                    IsaacLogType.GLOBAL_SITE_SEARCH, logMap);
+                    IsaacServerLogType.GLOBAL_SITE_SEARCH, logMap);
 
             ResultsWrapper results = this.extractContentSummaryFromResultsWrapper(
                     searchResults, this.getProperties().getProperty(PROXY_PATH));
@@ -330,7 +330,7 @@ public class IsaacController extends AbstractIsaacFacade {
 
                 userProgressInformation.put("userSnapshot", userSnapshot);
 
-                this.getLogManager().logEvent(user, request, IsaacLogType.VIEW_USER_PROGRESS,
+                this.getLogManager().logEvent(user, request, IsaacServerLogType.VIEW_USER_PROGRESS,
                         ImmutableMap.of(USER_ID_FKEY_FIELDNAME, userOfInterestFull.getId()));
 
                 return Response.ok(userProgressInformation).build();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -253,7 +253,7 @@ public class PagesFacade extends AbstractIsaacFacade {
 
                 // the request log
                 getLogManager().logEvent(userManager.getCurrentUser(servletRequest), servletRequest,
-                        IsaacLogType.VIEW_CONCEPT, logEntry);
+                        IsaacServerLogType.VIEW_CONCEPT, logEntry);
             }
             Response cachableResult = Response.status(result.getStatus()).entity(result.getEntity())
                     .cacheControl(getCacheControl(NUMBER_SECONDS_IN_ONE_HOUR, true)).tag(etag).build();
@@ -442,7 +442,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                         userQuestionAttempts);
 
                 // the request log
-                getLogManager().logEvent(user, httpServletRequest, IsaacLogType.VIEW_QUESTION, logEntry);
+                getLogManager().logEvent(user, httpServletRequest, IsaacServerLogType.VIEW_QUESTION, logEntry);
 
                 // return augmented content.
                 return Response.ok(content)
@@ -536,7 +536,7 @@ public class PagesFacade extends AbstractIsaacFacade {
             ImmutableMap<String, String> logEntry = new ImmutableMap.Builder<String, String>()
                     .put(PAGE_ID_LOG_FIELDNAME, summaryPageId)
                     .put(CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA()).build();
-            getLogManager().logEvent(user, httpServletRequest, IsaacLogType.VIEW_TOPIC_SUMMARY_PAGE, logEntry);
+            getLogManager().logEvent(user, httpServletRequest, IsaacServerLogType.VIEW_TOPIC_SUMMARY_PAGE, logEntry);
 
             return Response.status(Status.OK).entity(topicSummaryDTO)
                     .cacheControl(getCacheControl(NUMBER_SECONDS_IN_ONE_HOUR, true)).tag(etag).build();
@@ -600,7 +600,7 @@ public class PagesFacade extends AbstractIsaacFacade {
 
                 // the request log
                 getLogManager().logEvent(userManager.getCurrentUser(httpServletRequest), httpServletRequest,
-                        IsaacLogType.VIEW_PAGE, logEntry);
+                        IsaacServerLogType.VIEW_PAGE, logEntry);
             }
 
             Response cachableResult = Response.status(result.getStatus()).entity(result.getEntity())
@@ -648,7 +648,7 @@ public class PagesFacade extends AbstractIsaacFacade {
             Response result = this.findSingleResult(fieldsToMatch);
 
             getLogManager().logEvent(userManager.getCurrentUser(httpServletRequest), httpServletRequest,
-                    IsaacLogType.VIEW_PAGE_FRAGMENT, ImmutableMap.of(
+                    IsaacServerLogType.VIEW_PAGE_FRAGMENT, ImmutableMap.of(
                             FRAGMENT_ID_LOG_FIELDNAME, fragmentId,
                             CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA()
                     ));

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -423,7 +423,7 @@ public class AdminFacade extends AbstractSegueFacade {
                 RegisteredUserDTO user = this.userManager.getUserDTOById(userid);
                 Role oldRole = user.getRole();
                 this.userManager.updateUserRole(userid, requestedRole);
-                this.getLogManager().logEvent(requestingUser, request, SegueLogType.CHANGE_USER_ROLE,
+                this.getLogManager().logEvent(requestingUser, request, SegueServerLogType.CHANGE_USER_ROLE,
                         ImmutableMap.of(USER_ID_FKEY_FIELDNAME, user.getId(),
                                         "oldRole", oldRole,
                                         "newRole", requestedRole));
@@ -1017,7 +1017,7 @@ public class AdminFacade extends AbstractSegueFacade {
             
             this.userManager.deleteUserAccount(userToDelete);
             this.eventBookingManager.deleteUsersAdditionalInformationBooking(userToDelete);
-            getLogManager().logEvent(currentlyLoggedInUser, httpServletRequest, SegueLogType.DELETE_USER_ACCOUNT,
+            getLogManager().logEvent(currentlyLoggedInUser, httpServletRequest, SegueServerLogType.DELETE_USER_ACCOUNT,
                     ImmutableMap.of(USER_ID_FKEY_FIELDNAME, userToDelete.getId()));
             
             log.info("Admin User: " + currentlyLoggedInUser.getEmail() + " has just deleted the user account with id: "
@@ -1067,7 +1067,7 @@ public class AdminFacade extends AbstractSegueFacade {
             RegisteredUserDTO sourceUser = this.userManager.getUserDTOById(userIdMergeDTO.getSourceId());
 
             this.userManager.mergeUserAccounts(targetUser, sourceUser);
-            getLogManager().logEvent(currentlyLoggedInUser, httpServletRequest, SegueLogType.ADMIN_MERGE_USER,
+            getLogManager().logEvent(currentlyLoggedInUser, httpServletRequest, SegueServerLogType.ADMIN_MERGE_USER,
                     ImmutableMap.of(USER_ID_FKEY_FIELDNAME, targetUser.getId(), OLD_USER_ID_FKEY_FIELDNAME, sourceUser.getId()));
 
             log.info("Admin User: " + currentlyLoggedInUser.getEmail() + " has just merged the target user account with id: " + userIdMergeDTO.getTargetId() +

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
@@ -297,7 +297,7 @@ public class AuthenticationFacade extends AbstractSegueFacade {
         try {
             // TODO - review if rememberMe should default to true for SSO logins:
             RegisteredUserDTO userToReturn = userManager.authenticateCallback(request, response, signinProvider, true);
-            this.getLogManager().logEvent(userToReturn, request, SegueLogType.LOG_IN, Maps.newHashMap());
+            this.getLogManager().logEvent(userToReturn, request, SegueServerLogType.LOG_IN, Maps.newHashMap());
             return Response.ok(userToReturn).build();
         } catch (IOException e) {
             SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
@@ -383,7 +383,7 @@ public class AuthenticationFacade extends AbstractSegueFacade {
         try {
             RegisteredUserDTO userToReturn = userManager.authenticateWithCredentials(request, response, signinProvider, email, password, rememberMe);
 
-            this.getLogManager().logEvent(userToReturn, request, SegueLogType.LOG_IN, Maps.newHashMap());
+            this.getLogManager().logEvent(userToReturn, request, SegueServerLogType.LOG_IN, Maps.newHashMap());
             SegueMetrics.LOG_IN.inc();
 
             return Response.ok(userToReturn).build();
@@ -428,7 +428,7 @@ public class AuthenticationFacade extends AbstractSegueFacade {
     public final Response userLogout(@Context final HttpServletRequest request,
             @Context final HttpServletResponse response) {
         try {
-            this.getLogManager().logEvent(this.userManager.getCurrentUser(request), request, SegueLogType.LOG_OUT,
+            this.getLogManager().logEvent(this.userManager.getCurrentUser(request), request, SegueServerLogType.LOG_OUT,
                     Maps.newHashMap());
             SegueMetrics.LOG_OUT.inc();
 
@@ -462,7 +462,7 @@ public class AuthenticationFacade extends AbstractSegueFacade {
             AbstractSegueUserDTO user = this.userManager.getCurrentUser(request);
             userManager.logoutEverywhere(request, response);
 
-            this.getLogManager().logEvent(user, request, SegueLogType.LOG_OUT_EVERYWHERE, Maps.newHashMap());
+            this.getLogManager().logEvent(user, request, SegueServerLogType.LOG_OUT_EVERYWHERE, Maps.newHashMap());
             SegueMetrics.LOG_OUT_EVERYWHERE.inc();
 
             return Response.ok().build();
@@ -509,7 +509,7 @@ public class AuthenticationFacade extends AbstractSegueFacade {
 
             RegisteredUserDTO userToReturn = this.userManager.authenticateMFA(request, response, verificationCode, mfaResponse.getRememberMe());
 
-            this.getLogManager().logEvent(userToReturn, request, SegueLogType.LOG_IN, Maps.newHashMap());
+            this.getLogManager().logEvent(userToReturn, request, SegueServerLogType.LOG_IN, Maps.newHashMap());
             SegueMetrics.LOG_IN.inc();
 
             return Response.ok(userToReturn).build();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
@@ -197,7 +197,7 @@ public class AuthorisationFacade extends AbstractSegueFacade {
             RegisteredUserDTO userToRevoke = userManager.getUserDTOById(userIdToRevoke);
             associationManager.revokeAssociation(user, userToRevoke);
 
-            this.getLogManager().logEvent(user, request, SegueLogType.REVOKE_USER_ASSOCIATION,
+            this.getLogManager().logEvent(user, request, SegueServerLogType.REVOKE_USER_ASSOCIATION,
                     ImmutableMap.of(USER_ID_LIST_FKEY_FIELDNAME, Collections.singletonList(userIdToRevoke)));
 
             return Response.status(Status.NO_CONTENT).build();
@@ -234,7 +234,7 @@ public class AuthorisationFacade extends AbstractSegueFacade {
 
             associationManager.revokeAllAssociationsByOwnerUser(user);
 
-            this.getLogManager().logEvent(user, request, SegueLogType.REVOKE_USER_ASSOCIATION,
+            this.getLogManager().logEvent(user, request, SegueServerLogType.REVOKE_USER_ASSOCIATION,
                     ImmutableMap.of(USER_ID_LIST_FKEY_FIELDNAME, userIdsWithAccess));
 
             return Response.status(Status.NO_CONTENT).build();
@@ -275,7 +275,7 @@ public class AuthorisationFacade extends AbstractSegueFacade {
 
             associationManager.revokeAssociation(ownerUser, user);
 
-            this.getLogManager().logEvent(user, request, SegueLogType.RELEASE_USER_ASSOCIATION,
+            this.getLogManager().logEvent(user, request, SegueServerLogType.RELEASE_USER_ASSOCIATION,
                     ImmutableMap.of(USER_ID_LIST_FKEY_FIELDNAME, Collections.singletonList(associationOwner)));
 
             return Response.status(Status.NO_CONTENT).build();
@@ -313,7 +313,7 @@ public class AuthorisationFacade extends AbstractSegueFacade {
 
             associationManager.revokeAllAssociationsByRecipientUser(user);
 
-            this.getLogManager().logEvent(user, request, SegueLogType.RELEASE_USER_ASSOCIATION,
+            this.getLogManager().logEvent(user, request, SegueServerLogType.RELEASE_USER_ASSOCIATION,
                     ImmutableMap.of(USER_ID_LIST_FKEY_FIELDNAME, userIdsWithAccess));
 
             return Response.status(Status.NO_CONTENT).build();
@@ -534,7 +534,7 @@ public class AuthorisationFacade extends AbstractSegueFacade {
             usersApproved.add(group.getOwnerId());
             usersApproved.addAll(group.getAdditionalManagersUserIds());
 
-            this.getLogManager().logEvent(user, request, SegueLogType.CREATE_USER_ASSOCIATION,
+            this.getLogManager().logEvent(user, request, SegueServerLogType.CREATE_USER_ASSOCIATION,
                     ImmutableMap.of(ASSOCIATION_TOKEN_FIELDNAME, associationToken.getToken(),
                                     GROUP_FK, associationToken.getGroupId(),
                                     USER_ID_LIST_FKEY_FIELDNAME, usersApproved));

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -322,7 +322,7 @@ public final class Constants {
     /**
      *  Class to represent Segue Log Types.
      */
-    public enum SegueLogType implements LogType {
+    public enum SegueServerLogType implements LogType {
         ADD_ADDITIONAL_GROUP_MANAGER,
         ADMIN_CHANGE_USER_SCHOOL,
         ADMIN_EVENT_ATTENDANCE_RECORDED,
@@ -362,7 +362,7 @@ public final class Constants {
         USER_SCHOOL_CHANGE
     }
 
-    public static final Set<String> SEGUE_LOG_TYPES = Arrays.stream(SegueLogType.values()).map(SegueLogType::name).collect(Collectors.toSet());
+    public static final Set<String> SEGUE_SERVER_LOG_TYPES = Arrays.stream(SegueServerLogType.values()).map(SegueServerLogType::name).collect(Collectors.toSet());
 
     // Websocket Component
     public static final String MAX_CONCURRENT_WEB_SOCKETS_PER_USER = "MAX_CONCURRENT_WEB_SOCKETS_PER_USER";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/ContactFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/ContactFacade.java
@@ -124,7 +124,7 @@ public class ContactFacade extends AbstractSegueFacade {
                             .put("replyToName", String.format("%s %s", form.get("firstName"), form.get("lastName")))
                             .build());
 
-            getLogManager().logEvent(userManager.getCurrentUser(request), request, SegueLogType.CONTACT_US_FORM_USED,
+            getLogManager().logEvent(userManager.getCurrentUser(request), request, SegueServerLogType.CONTACT_US_FORM_USED,
                     ImmutableMap.of("message", String.format("%s %s (%s) - %s", form.get("firstName"), form.get("lastName"),
                             form.get("emailAddress"), form.get("message"))));
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -345,7 +345,7 @@ public class EmailFacade extends AbstractSegueFacade {
             userManager.emailVerificationRequest(request, email);
 
             this.getLogManager().logEvent(userManager.getCurrentUser(request), request,
-                    SegueLogType.EMAIL_VERIFICATION_REQUEST_RECEIVED,
+                    SegueServerLogType.EMAIL_VERIFICATION_REQUEST_RECEIVED,
                     ImmutableMap.of(Constants.LOCAL_AUTH_EMAIL_VERIFICATION_TOKEN_FIELDNAME, email));
 
             return Response.ok().build();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
@@ -243,7 +243,7 @@ public class GroupsFacade extends AbstractSegueFacade {
 
             this.groupManager.setMembershipStatus(groupBasedOnId, currentRegisteredUser, newStatusEnum);
 
-            this.getLogManager().logEvent(currentRegisteredUser, request, SegueLogType.CHANGE_GROUP_MEMBERSHIP_STATUS,
+            this.getLogManager().logEvent(currentRegisteredUser, request, SegueServerLogType.CHANGE_GROUP_MEMBERSHIP_STATUS,
                     ImmutableMap.of(Constants.GROUP_FK, groupBasedOnId.getId(),
                             USER_ID_FKEY_FIELDNAME, currentRegisteredUser.getId(),
                             "newStatus", newStatusEnum.name()));
@@ -326,7 +326,7 @@ public class GroupsFacade extends AbstractSegueFacade {
             RegisteredUserDTO user = userManager.getCurrentRegisteredUser(request);
             UserGroupDTO group = groupManager.createUserGroup(groupDTO.getGroupName(), user);
 
-            this.getLogManager().logEvent(user, request, SegueLogType.CREATE_USER_GROUP,
+            this.getLogManager().logEvent(user, request, SegueServerLogType.CREATE_USER_GROUP,
                     ImmutableMap.of(Constants.GROUP_FK, group.getId()));
 
             this.userBadgeManager.updateBadge(user, UserBadgeManager.Badge.TEACHER_GROUPS_CREATED,
@@ -525,7 +525,7 @@ public class GroupsFacade extends AbstractSegueFacade {
 
             groupManager.removeUserFromGroup(groupBasedOnId, userToRemove);
 
-            this.getLogManager().logEvent(currentRegisteredUser, request, SegueLogType.REMOVE_USER_FROM_GROUP,
+            this.getLogManager().logEvent(currentRegisteredUser, request, SegueServerLogType.REMOVE_USER_FROM_GROUP,
                     ImmutableMap.of(Constants.GROUP_FK, groupBasedOnId.getId(),
                             USER_ID_FKEY_FIELDNAME, userToRemove.getId()));
 
@@ -572,7 +572,7 @@ public class GroupsFacade extends AbstractSegueFacade {
 
             groupManager.deleteGroup(groupBasedOnId);
 
-            this.getLogManager().logEvent(currentUser, request, SegueLogType.DELETE_USER_GROUP,
+            this.getLogManager().logEvent(currentUser, request, SegueServerLogType.DELETE_USER_GROUP,
                     ImmutableMap.of(Constants.GROUP_FK, groupBasedOnId.getId()));
 
         } catch (SegueDatabaseException e) {
@@ -636,7 +636,7 @@ public class GroupsFacade extends AbstractSegueFacade {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "This user is already an additional manager").toResponse();
             }
 
-            this.getLogManager().logEvent(user, request, SegueLogType.ADD_ADDITIONAL_GROUP_MANAGER,
+            this.getLogManager().logEvent(user, request, SegueServerLogType.ADD_ADDITIONAL_GROUP_MANAGER,
                     ImmutableMap.of(GROUP_FK, group.getId(), USER_ID_FKEY_FIELDNAME, userToAdd.getId()));
 
             return Response.ok(this.groupManager.addUserToManagerList(group, userToAdd)).build();
@@ -690,7 +690,7 @@ public class GroupsFacade extends AbstractSegueFacade {
 
             RegisteredUserDTO userToRemove = this.userManager.getUserDTOById(userId);
 
-            this.getLogManager().logEvent(user, request, SegueLogType.DELETE_ADDITIONAL_GROUP_MANAGER,
+            this.getLogManager().logEvent(user, request, SegueServerLogType.DELETE_ADDITIONAL_GROUP_MANAGER,
                     ImmutableMap.of(GROUP_FK, group.getId(), USER_ID_FKEY_FIELDNAME, userId));
 
             return Response.ok(this.groupManager.removeUserFromManagerList(group, userToRemove)).build();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/LogEventFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/LogEventFacade.java
@@ -108,7 +108,7 @@ public class LogEventFacade extends AbstractSegueFacade {
 
         String eventType = (String) eventJSON.get(TYPE_FIELDNAME);
 
-        if (SEGUE_LOG_TYPES.contains(eventType) || ISAAC_LOG_TYPES.contains(eventType)) {
+        if (SEGUE_SERVER_LOG_TYPES.contains(eventType) || ISAAC_SERVER_LOG_TYPES.contains(eventType)) {
             return new SegueErrorResponse(Status.FORBIDDEN, "Unable to record log message, restricted '"
                     + TYPE_FIELDNAME + "' value.").toResponse();
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
@@ -75,7 +75,7 @@ import java.util.List;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.HOST_NAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueLogType;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueServerLogType;
 
 /**
  * Question Facade
@@ -307,7 +307,7 @@ public class QuestionFacade extends AbstractSegueFacade {
                     misuseMonitor.notifyEvent(((RegisteredUserDTO) currentUser).getId().toString() + "|" + questionId,
                             QuestionAttemptMisuseHandler.class.getSimpleName());
                 } catch (SegueResourceMisuseException e) {
-                    this.getLogManager().logEvent(currentUser, request, SegueLogType.QUESTION_ATTEMPT_RATE_LIMITED, response.getEntity());
+                    this.getLogManager().logEvent(currentUser, request, SegueServerLogType.QUESTION_ATTEMPT_RATE_LIMITED, response.getEntity());
                     String message = "You have made too many attempts at this question part. Please try again later.";
                     return SegueErrorResponse.getRateThrottledResponse(message);
                 }
@@ -317,7 +317,7 @@ public class QuestionFacade extends AbstractSegueFacade {
                     misuseMonitor.notifyEvent(((AnonymousUserDTO) currentUser).getSessionId() + "|" + questionId,
                             AnonQuestionAttemptMisuseHandler.class.getSimpleName());
                 } catch (SegueResourceMisuseException e) {
-                    this.getLogManager().logEvent(currentUser, request, SegueLogType.QUESTION_ATTEMPT_RATE_LIMITED, response.getEntity());
+                    this.getLogManager().logEvent(currentUser, request, SegueServerLogType.QUESTION_ATTEMPT_RATE_LIMITED, response.getEntity());
                     String message = "You have made too many attempts at this question part. Please log in or try again later.";
                     return SegueErrorResponse.getRateThrottledResponse(message);
                 }
@@ -329,7 +329,7 @@ public class QuestionFacade extends AbstractSegueFacade {
                     misuseMonitor.notifyEvent(RequestIPExtractor.getClientIpAddr(request),
                             IPQuestionAttemptMisuseHandler.class.getSimpleName());
                 } catch (SegueResourceMisuseException e) {
-                    this.getLogManager().logEvent(currentUser, request, SegueLogType.QUESTION_ATTEMPT_RATE_LIMITED, response.getEntity());
+                    this.getLogManager().logEvent(currentUser, request, SegueServerLogType.QUESTION_ATTEMPT_RATE_LIMITED, response.getEntity());
                     String message = "Too many question attempts! Please log in or try again later.";
                     return SegueErrorResponse.getRateThrottledResponse(message);
                 }
@@ -341,7 +341,7 @@ public class QuestionFacade extends AbstractSegueFacade {
                         (QuestionValidationResponseDTO) response.getEntity());
             }
 
-            this.getLogManager().logEvent(currentUser, request, SegueLogType.ANSWER_QUESTION, response.getEntity());
+            this.getLogManager().logEvent(currentUser, request, SegueServerLogType.ANSWER_QUESTION, response.getEntity());
 
             // Update the user in case their streak has changed:
             if (currentUser instanceof RegisteredUserDTO) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -364,7 +364,7 @@ public class UsersFacade extends AbstractSegueFacade {
             userManager.resetPasswordRequest(userOfInterest);
 
             this.getLogManager()
-                    .logEvent(currentUser, httpServletRequest, SegueLogType.PASSWORD_RESET_REQUEST_RECEIVED,
+                    .logEvent(currentUser, httpServletRequest, SegueServerLogType.PASSWORD_RESET_REQUEST_RECEIVED,
                             ImmutableMap.of(
                                     LOCAL_AUTH_EMAIL_FIELDNAME, userOfInterest.getEmail(),
                                     LOCAL_AUTH_GROUP_MANAGER_EMAIL_FIELDNAME, currentUser.getEmail(),
@@ -425,7 +425,7 @@ public class UsersFacade extends AbstractSegueFacade {
             userManager.resetPasswordRequest(userObject);
 
             this.getLogManager()
-                    .logEvent(userManager.getCurrentUser(request), request, SegueLogType.PASSWORD_RESET_REQUEST_RECEIVED,
+                    .logEvent(userManager.getCurrentUser(request), request, SegueServerLogType.PASSWORD_RESET_REQUEST_RECEIVED,
                             ImmutableMap.of(LOCAL_AUTH_EMAIL_FIELDNAME, userObject.getEmail()));
 
             return Response.ok().build();
@@ -505,7 +505,7 @@ public class UsersFacade extends AbstractSegueFacade {
             String newPassword = clientResponse.get("password");
             RegisteredUserDTO userDTO = userManager.resetPassword(token, newPassword);
 
-            this.getLogManager().logEvent(userDTO, request, SegueLogType.PASSWORD_RESET_REQUEST_SUCCESSFUL,
+            this.getLogManager().logEvent(userDTO, request, SegueServerLogType.PASSWORD_RESET_REQUEST_SUCCESSFUL,
                     ImmutableMap.of(LOCAL_AUTH_EMAIL_FIELDNAME, userDTO.getEmail()));
 
             // we can reset the misuse monitor for incorrect logins now.
@@ -719,7 +719,7 @@ public class UsersFacade extends AbstractSegueFacade {
 
             UserSummaryDTO userOfInterestSummaryObject = userManager.convertToUserSummaryObject(userOfInterest);
 
-            if (!events.equals(SegueLogType.ANSWER_QUESTION.name()) && !isUserAnAdmin(userManager, currentUser)) {
+            if (!events.equals(SegueServerLogType.ANSWER_QUESTION.name()) && !isUserAnAdmin(userManager, currentUser)) {
                 // Non-admins should not be able to choose random log events.
                 return SegueErrorResponse.getIncorrectRoleResponse();
             }
@@ -946,7 +946,7 @@ public class UsersFacade extends AbstractSegueFacade {
                 log.info("ADMIN user " + currentlyLoggedInUser.getEmail() + " has modified the role of "
                         + updatedUser.getEmail() + "[" + updatedUser.getId() + "]" + " to "
                         + updatedUser.getRole());
-                this.getLogManager().logEvent(currentlyLoggedInUser, request, SegueLogType.CHANGE_USER_ROLE,
+                this.getLogManager().logEvent(currentlyLoggedInUser, request, SegueServerLogType.CHANGE_USER_ROLE,
                         ImmutableMap.of(USER_ID_FKEY_FIELDNAME, updatedUser.getId(),
                                         "oldRole", existingUserFromDb.getRole(),
                                         "newRole", updatedUser.getRole()));
@@ -964,10 +964,10 @@ public class UsersFacade extends AbstractSegueFacade {
                 if (!Objects.equals(currentlyLoggedInUser.getId(), updatedUser.getId())) {
                     // This is an ADMIN user changing another user's school:
                     eventDetails.put(USER_ID_FKEY_FIELDNAME, updatedUser.getId());
-                    this.getLogManager().logEvent(currentlyLoggedInUser, request, SegueLogType.ADMIN_CHANGE_USER_SCHOOL,
+                    this.getLogManager().logEvent(currentlyLoggedInUser, request, SegueServerLogType.ADMIN_CHANGE_USER_SCHOOL,
                             eventDetails);
                 } else {
-                    this.getLogManager().logEvent(currentlyLoggedInUser, request, SegueLogType.USER_SCHOOL_CHANGE,
+                    this.getLogManager().logEvent(currentlyLoggedInUser, request, SegueServerLogType.USER_SCHOOL_CHANGE,
                             eventDetails);
                 }
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -58,12 +58,12 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.Maps.immutableEntry;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.FAST_TRACK_QUESTION_TYPE;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.IsaacLogType;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.IsaacServerLogType;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.QUESTION_TYPE;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.BooleanOperator;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ID_FIELDNAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueLogType;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueServerLogType;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval.NINETY_DAYS;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval.SEVEN_DAYS;
@@ -156,8 +156,8 @@ public class StatisticsManager implements IStatisticsManager {
         result.put("userSchoolInfo", userManager.getSchoolInfoStats());
         result.put("groupCount", this.groupManager.getGroupCount());
 
-        result.put("viewQuestionEvents", logManager.getLogCountByType(IsaacLogType.VIEW_QUESTION.name()));
-        result.put("answeredQuestionEvents", logManager.getLogCountByType(SegueLogType.ANSWER_QUESTION.name()));
+        result.put("viewQuestionEvents", logManager.getLogCountByType(IsaacServerLogType.VIEW_QUESTION.name()));
+        result.put("answeredQuestionEvents", logManager.getLogCountByType(SegueServerLogType.ANSWER_QUESTION.name()));
 
         Map<String, Map<Role, Long>> rangedActiveUserStats = Maps.newHashMap();
         rangedActiveUserStats.put("sevenDays", userManager.getActiveRolesOverPrevious(SEVEN_DAYS));

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -795,7 +795,7 @@ public class UserAccountManager implements IUserAccountManager {
         //TODO: do we need this?
         userToReturn = this.database.createOrUpdateUser(userToReturn);
 
-        logManager.logEvent(this.convertUserDOToUserDTO(userToReturn), request, SegueLogType.USER_REGISTRATION,
+        logManager.logEvent(this.convertUserDOToUserDTO(userToReturn), request, SegueServerLogType.USER_REGISTRATION,
                 ImmutableMap.builder().put("provider", AuthenticationProvider.SEGUE.name()).build());
 
         // return it to the caller.
@@ -1456,7 +1456,7 @@ public class UserAccountManager implements IUserAccountManager {
                         logManager.transferLogEventsToRegisteredUser(anonymousUser.getSessionId(), user.getId()
                                 .toString());
 
-                        logManager.logInternalEvent(userDTO, SegueLogType.MERGE_USER,
+                        logManager.logInternalEvent(userDTO, SegueServerLogType.MERGE_USER,
                                 ImmutableMap.of("oldAnonymousUserId", anonymousUser.getSessionId()));
 
                         // delete the session attribute as merge has completed.
@@ -1561,7 +1561,7 @@ public class UserAccountManager implements IUserAccountManager {
                    EmailVerificationStatus.DELIVERY_FAILED);
         }
 
-        logManager.logInternalEvent(this.convertUserDOToUserDTO(localUserInformation), SegueLogType.USER_REGISTRATION,
+        logManager.logInternalEvent(this.convertUserDOToUserDTO(localUserInformation), SegueServerLogType.USER_REGISTRATION,
                 ImmutableMap.builder().put("provider", federatedAuthenticator.name())
                         .build());
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
@@ -60,6 +60,10 @@ public final class SegueMetrics {
     public static final Counter QUEUED_EMAIL = Counter.build()
             .name("segue_queued_email_total").help("All emails queued since process start").labelNames("type").register();
 
+    // Log Event Metrics
+    public static final Counter LOG_EVENT = Counter.build()
+            .name("isaac_log_event").help("Counter for Log Events by type").labelNames("type").register();
+
     /**
      *  Private constructor as it does not make sense to instantiate this class.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -263,7 +263,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
                 .put(CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA())
                 .put("numberFiltered", numberOfFilteredUsers).build();
 
-        this.logManager.logInternalEvent(sendingUser, SegueLogType.SEND_MASS_EMAIL, eventDetails);
+        this.logManager.logInternalEvent(sendingUser, SegueServerLogType.SEND_MASS_EMAIL, eventDetails);
         log.info(String.format("Admin user (%s) added %d emails to the queue. %d were filtered.", sendingUser.getEmail(),
                 allSelectedUsers.size() - numberOfFilteredUsers, numberOfFilteredUsers));
     }
@@ -305,7 +305,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
         // if this is an email type that cannot have a preference, send it and log as appropriate
         if (!email.getEmailType().isValidEmailPreference()) {
             log.info(String.format("Added %s email to the queue with subject: %s", email.getEmailType().toString().toLowerCase(), email.getSubject()));
-            logManager.logInternalEvent(userDTO, SegueLogType.SENT_EMAIL, eventDetails);
+            logManager.logInternalEvent(userDTO, SegueServerLogType.SENT_EMAIL, eventDetails);
             addToQueue(email);
             return true;
         }
@@ -314,7 +314,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
             UserPreference preference = userPreferenceManager.getUserPreference(SegueUserPreferences.EMAIL_PREFERENCE.name(), email.getEmailType().name(), userDTO.getId());
             // If no preference is present, send the email. This is consistent with sendCustomEmail(...) above.
             if (preference == null || preference.getPreferenceValue()) {
-                logManager.logInternalEvent(userDTO, SegueLogType.SENT_EMAIL, eventDetails);
+                logManager.logInternalEvent(userDTO, SegueServerLogType.SENT_EMAIL, eventDetails);
                 addToQueue(email);
                 return true;
             }


### PR DESCRIPTION
This will allow us to monitor and alert on behaviour changes, particularly client-side errors.

For the next few weeks, log event types which are not in out client side allow list, will just add an additional error to our process logs.
Once we are happy we have not accidentally missed out a client side log event type, we can act more severely to types not included in the allow list by failing the request.

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [x] Peer-Reviewed
