### PR TITLE
Skip over deleted users for events booking CSV.

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -615,7 +615,13 @@ public class EventsFacade extends AbstractIsaacFacade {
             for (EventBookingDTO booking : eventBookings) {
                 ArrayList<String> resultRow = Lists.newArrayList();
                 UserSummaryDTO resultUser = booking.getUserBooked();
-                RegisteredUserDTO resultRegisteredUser = this.userAccountManager.getUserDTOById(resultUser.getId());
+                RegisteredUserDTO resultRegisteredUser;
+                try {
+                    resultRegisteredUser = this.userAccountManager.getUserDTOById(resultUser.getId());
+                } catch (NoUserException e) {
+                    log.error(String.format("User with ID \"%d\" could not be retrieved. Continuing...", resultUser.getId()));
+                    continue;
+                }
                 String schoolId = resultRegisteredUser.getSchoolId();
                 Map<String, String> resultAdditionalInformation = booking.getAdditionalInformation();
                 BookingStatus resultBookingStatus = booking.getBookingStatus();
@@ -659,8 +665,6 @@ public class EventsFacade extends AbstractIsaacFacade {
 
         } catch (IOException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error while building the CSV file.").toResponse();
-        } catch (NoUserException e) {
-            return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "No user found with this ID!").toResponse();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (SegueDatabaseException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -619,7 +619,7 @@ public class EventsFacade extends AbstractIsaacFacade {
                 try {
                     resultRegisteredUser = this.userAccountManager.getUserDTOById(resultUser.getId());
                 } catch (NoUserException e) {
-                    log.error(String.format("User with ID \"%d\" could not be retrieved. Continuing...", resultUser.getId()));
+                    // Possibly a deleted user, silently skipping.
                     continue;
                 }
                 String schoolId = resultRegisteredUser.getSchoolId();


### PR DESCRIPTION
Deleted users cannot be retrieved by the UserAccountManager if they have been deleted, yet we were doing just that and re-throwing the exception while building the CSV. This commit catches the exception and advances the loop to skip over the student that was deleted.

We could possibly want to add a line that says DELETED or something like that.

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Peer-Reviewed
