### PR TITLE
Create a list of tags to exclude so as to fix a bug

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -1235,14 +1235,15 @@ public class GameManager {
             fieldsToMatchOutput.put(newEntry, gameFilter.getConcepts());
         }
 
+        List<String> tagsToExclude = Lists.newArrayList();
         // add no filter constraint
-        fieldsToMatchOutput.put(
-                immutableEntry(BooleanOperator.NOT, TAGS_FIELDNAME), Collections.singletonList(HIDE_FROM_FILTER_TAG));
+        tagsToExclude.add(HIDE_FROM_FILTER_TAG);
 
         // Temporarily ignore book and quick_quiz question types.
         // Strings hardcoded until question types are passed in as part of the query.
-        fieldsToMatchOutput.put(
-                immutableEntry(BooleanOperator.NOT, TAGS_FIELDNAME), ImmutableList.of("quick_quiz", "book"));
+        tagsToExclude.addAll(ImmutableList.of("quick_quiz", "book"));
+
+        fieldsToMatchOutput.put(immutableEntry(BooleanOperator.NOT, TAGS_FIELDNAME), tagsToExclude);
 
         return fieldsToMatchOutput;
     }


### PR DESCRIPTION
Previous code was overwriting the value in the hash map for the (not, tag) tuple rather than adding to it.

I made a list with two additions to it rather than having one list with all three tags to avoid the accidental removal of all three when we remove the book and quick_quiz tags.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
