### PR TITLE
Feature/fine grained endpoint metrics

### DIFF
--- a/override-api-web.xml
+++ b/override-api-web.xml
@@ -1,27 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- API CONFIG -->
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:web="http://java.sun.com/xml/ns/javaee" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd" version="3.0">
- 
-    <filter>
-      <filter-name>prometheusFilter</filter-name>
-      <filter-class>io.prometheus.client.filter.MetricsFilter</filter-class>
-      <init-param>
-        <param-name>metric-name</param-name>
-        <param-value>isaac_api_servlet_filter</param-value>
-      </init-param>
-      <init-param>
-        <param-name>help</param-name>
-        <param-value>Servlet metrics filter for request response time</param-value>
-      </init-param>
-      <init-param>
-        <param-name>path-components</param-name>
-        <param-value>3</param-value><!-- depth of path granularity to facade level -->
-      </init-param>
-    </filter>
-    <filter-mapping>
-      <filter-name>prometheusFilter</filter-name>
-      <url-pattern>/*</url-pattern>
-    </filter-mapping>
 
     <filter>
         <filter-name>cross-origin</filter-name>

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PerformanceMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PerformanceMonitor.java
@@ -101,7 +101,7 @@ public class PerformanceMonitor implements ContainerRequestFilter, ContainerResp
             return NO_MATCHING_ENDPOINT;
         }
 
-        String mostSpecificMatchingUri = matchingUris.get(0);
+        String mostSpecificMatchingUri = "/" + matchingUris.get(0);
         // Replace any path param values with its curly-braced, path param identifier
         for (Map.Entry<String, List<String>> pathParams : uri.getPathParameters().entrySet()) {
             for (String paramValue : pathParams.getValue()) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PerformanceMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PerformanceMonitor.java
@@ -96,19 +96,19 @@ public class PerformanceMonitor implements ContainerRequestFilter, ContainerResp
 
     private String pathWithoutPathParamValues(UriInfo uri) {
         List<String> matchingUris = uri.getMatchedURIs(); // Ordered so that current resource URI is first
-        if (!matchingUris.isEmpty()) {
-            String mostSpecificMatchingUri = matchingUris.get(0);
-            // Replace any path param values with its curly-braced, path param identifier
-            for (Map.Entry<String, List<String>> pathParams : uri.getPathParameters().entrySet()) {
-                for (String paramValue : pathParams.getValue()) {
-                    mostSpecificMatchingUri =
-                            mostSpecificMatchingUri.replace(paramValue, "{" + pathParams.getKey() + "}");
-                }
-            }
-            return mostSpecificMatchingUri;
-        } else {
+
+        if (matchingUris.isEmpty()) {
             return NO_MATCHING_ENDPOINT;
         }
 
+        String mostSpecificMatchingUri = matchingUris.get(0);
+        // Replace any path param values with its curly-braced, path param identifier
+        for (Map.Entry<String, List<String>> pathParams : uri.getPathParameters().entrySet()) {
+            for (String paramValue : pathParams.getValue()) {
+                mostSpecificMatchingUri =
+                        mostSpecificMatchingUri.replace(paramValue, "{" + pathParams.getKey() + "}");
+            }
+        }
+        return mostSpecificMatchingUri;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
@@ -17,6 +17,7 @@ package uk.ac.cam.cl.dtg.segue.api.monitors;
 
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
 import io.prometheus.client.guava.cache.CacheMetricsCollector;
 
 /**
@@ -25,6 +26,14 @@ import io.prometheus.client.guava.cache.CacheMetricsCollector;
  * Metric and label naming conventions can be found here: https://prometheus.io/docs/practices/naming/
  */
 public final class SegueMetrics {
+
+    // Request Response Time Metrics
+    public static final Histogram REQUEST_LATENCY_HISTOGRAM = Histogram.build()
+            .name("isaac_api_requests")
+            .labelNames("method", "path")
+            .help("Request latency in seconds.").register();
+
+    // Cache Metrics
     public static final CacheMetricsCollector CACHE_METRICS_COLLECTOR = new CacheMetricsCollector().register();
 
     // Websocket Metrics


### PR DESCRIPTION
We used to use the preconfigured Prometheus java client filter which would use the whole URL path.
As we use URL path parameters for question ID, page ID etc, we ended up with a new label for each question visited on the site, this created a lot of objects, enough so to bring the site down temporarily when we first did this (a few years ago).
Since then we've been limiting the depth of the path label to 3, i.e. isaac-api/api/pages, because no path params appear in the first 3 parts, which was OK in indicating where a problem might be but was not very specific.

This pull request records the path at full granularity but replacing any URL path params with their identifiers so that we get one label per endpoint. This will allow us to see which specific endpoints are most in need of optimising, and seeing it clearly will hopefully motivate us to actually spend time on doing the optimisation!

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Peer-Reviewed
