### PR TITLE
Override question attempt misuse threshold 

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -502,6 +502,8 @@ public final class Constants {
     public static final String CHEMISTRY_CHECKER_HOST = "CHEMISTRY_CHECKER_HOST";
     public static final String CHEMISTRY_CHECKER_PORT = "CHEMISTRY_CHECKER_PORT";
 
+    public static final String QUESTION_MISUSE_THRESHOLD_OVERRIDE = "QUESTION_MISUSE_THRESHOLD_OVERRIDE";
+
     // User Preferences:
     public enum SegueUserPreferences {
         EMAIL_PREFERENCE

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/QuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/QuestionAttemptMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,21 +33,15 @@ public class QuestionAttemptMisuseHandler implements IMisuseHandler {
     private static final Integer HARD_THRESHOLD = 15;
     private static final Integer ACCOUNTING_INTERVAL = Constants.NUMBER_SECONDS_IN_FIFTEEN_MINUTES;
 
-    private PropertiesLoader properties;
-    private EmailManager emailManager;
     private Integer overrideHardThreshold;
 
 
     /**
-     * @param emailManager
-     *            - so we can send e-mails if the threshold limits have been reached.
      * @param properties
      *            - so that we can look up properties set.
      */
     @Inject
-    public QuestionAttemptMisuseHandler(final EmailManager emailManager, final PropertiesLoader properties) {
-        this.properties = properties;
-        this.emailManager = emailManager;
+    public QuestionAttemptMisuseHandler(final PropertiesLoader properties) {
         String overrideThresholdString = properties.getProperty(Constants.QUESTION_MISUSE_THRESHOLD_OVERRIDE);
         if (null != overrideThresholdString) {
             this.overrideHardThreshold = Integer.parseInt(overrideThresholdString);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/QuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/QuestionAttemptMisuseHandler.java
@@ -35,6 +35,7 @@ public class QuestionAttemptMisuseHandler implements IMisuseHandler {
 
     private PropertiesLoader properties;
     private EmailManager emailManager;
+    private Integer overrideHardThreshold;
 
 
     /**
@@ -47,6 +48,10 @@ public class QuestionAttemptMisuseHandler implements IMisuseHandler {
     public QuestionAttemptMisuseHandler(final EmailManager emailManager, final PropertiesLoader properties) {
         this.properties = properties;
         this.emailManager = emailManager;
+        String overrideThresholdString = properties.getProperty(Constants.QUESTION_MISUSE_THRESHOLD_OVERRIDE);
+        if (null != overrideThresholdString) {
+            this.overrideHardThreshold = Integer.parseInt(overrideThresholdString);
+        }
     }
 
     @Override
@@ -56,6 +61,9 @@ public class QuestionAttemptMisuseHandler implements IMisuseHandler {
 
     @Override
     public Integer getHardThreshold() {
+        if (null != overrideHardThreshold) {
+            return overrideHardThreshold;
+        }
         return HARD_THRESHOLD;
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -705,7 +705,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
                     new LogEventMisuseHandler(emailManager, properties));
 
             misuseMonitor.registerHandler(QuestionAttemptMisuseHandler.class.getSimpleName(),
-                    new QuestionAttemptMisuseHandler(emailManager, properties));
+                    new QuestionAttemptMisuseHandler(properties));
 
             misuseMonitor.registerHandler(AnonQuestionAttemptMisuseHandler.class.getSimpleName(),
                     new AnonQuestionAttemptMisuseHandler());


### PR DESCRIPTION
This property is only read at startup, and so can't be changed on the fly. It wouldn't be too difficult to change to reading it on the fly, but it felt more efficient to parse the string only once, not every single time a question is attempted on the platform.
It fails gracefully if the server property is not provided, to the normal default value, so it can safely be ignored on the live platform and just adjusted on staging. It only applies to logged in users, since anonymous users have several rate limits.