### PR TITLE
Improvements to group reservations for events

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -96,7 +96,22 @@ import java.util.stream.Collectors;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.DATE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.ENDDATE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.EVENT_TYPE;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.ADMIN_BOOKING_REASON_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.ATTENDED_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.BOOKING_STATUS_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_RESULTS_LIMIT_AS_STRING;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_START_INDEX_AS_STRING;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.EVENT_DATE_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.EVENT_ID_FKEY_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.EVENT_TAGS_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.EventFilterOption;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.NEVER_CACHE_WITHOUT_ETAG_CHECK;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueServerLogType;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.SortOrder;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TAGS_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.USER_ID_FKEY_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.USER_ID_LIST_FKEY_FIELDNAME;
 
 /**
  * Events Facade.
@@ -843,10 +858,6 @@ public class EventsFacade extends AbstractIsaacFacade {
                     .toResponse();
         } catch (NoUserException e) {
             return SegueErrorResponse.getResourceNotFoundResponse("Unable to locate one of the users specified.");
-        } catch (EmailMustBeVerifiedException e) {
-            return new SegueErrorResponse(Status.BAD_REQUEST,
-                    "All users must have a verified email address before they can be reserved on this event.")
-                    .toResponse();
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -808,14 +808,6 @@ public class EventsFacade extends AbstractIsaacFacade {
                 if (userAssociationManager.hasPermission(reservingUser, userToReserve)) {
                     usersToReserve.add(userToReserve);
                 } else {
-                    // TODO: Turn this into a "failed to booked these students" email maybe? Must include:
-                    // - group name (may need to pass this along with the request as students can belong to multiple groups)
-                    // - event name with link to event page
-                    // Trello card: Group Booking (1)
-                    //
-                    // Group Booking (2) Could this also include unverified users? Or is it something that we handle at
-                    // the front-end? Probably better to handle this both ways. If we still have unverified accounts in
-                    // the request even though we made them not selectable in the front-end, we can silently ignore them.
                     return new SegueErrorResponse(Status.FORBIDDEN,
                             "You do not have permission to book or reserve some of these users onto this event.")
                             .toResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -793,6 +793,14 @@ public class EventsFacade extends AbstractIsaacFacade {
                 if (userAssociationManager.hasPermission(reservingUser, userToReserve)) {
                     usersToReserve.add(userToReserve);
                 } else {
+                    // TODO: Turn this into a "failed to booked these students" email maybe? Must include:
+                    // - group name (may need to pass this along with the request as students can belong to multiple groups)
+                    // - event name with link to event page
+                    // Trello card: Group Booking (1)
+                    //
+                    // Group Booking (2) Could this also include unverified users? Or is it something that we handle at
+                    // the front-end? Probably better to handle this both ways. If we still have unverified accounts in
+                    // the request even though we made them not selectable in the front-end, we can silently ignore them.
                     return new SegueErrorResponse(Status.FORBIDDEN,
                             "You do not have permission to book or reserve some of these users onto this event.")
                             .toResponse();
@@ -1609,7 +1617,6 @@ public class EventsFacade extends AbstractIsaacFacade {
                 RegisteredUserDTO user = userManager.getCurrentRegisteredUser(request);
                 page.setUserBooked(this.bookingManager.isUserBooked(page.getId(), user.getId()));
                 page.setUserOnWaitList(this.bookingManager.hasBookingWithStatus(page.getId(), user.getId(), BookingStatus.WAITING_LIST));
-                // TODO: Are either of the above attributes necessary with this new booking status attribute?
                 page.setUserBookingStatus(this.bookingManager.getBookingStatus(page.getId(), user.getId()));
             } catch (NoUserLoggedInException e) {
                 // no action as we don't require the user to be logged in.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -407,7 +407,11 @@ public class EventBookingManager {
                         BookingStatus.CONFIRMED, additionalEventInformation);
             }
 
+            addUserToEventGroup(event, user);
+
             try {
+                // TODO: Find out why Trello card Group Booking (3) says there is no email when a student confirms a reservation.
+                // This should send a confirmation email in any case.
                 emailManager.sendTemplatedEmailToUser(user,
                         emailManager.getEmailTemplateDTO("email-event-booking-confirmed"),
                         new ImmutableMap.Builder<String, Object>()
@@ -424,8 +428,6 @@ public class EventBookingManager {
                 log.error(String.format("Unable to send event email (%s) to user (%s)", event.getId(), user
                         .getEmail()), e);
             }
-
-            addUserToEventGroup(event, user);
 
             return booking;
         } finally {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -581,7 +581,7 @@ public class EventBookingManager {
                             "event", event,
                             "studentsList", plainTextSB.toString(),
                             "studentsList_HTML", htmlSB.toString()
-                    ), EmailType.EVENTS);
+                    ), EmailType.SYSTEM);
         } catch (NoUserException e) {
             // This should never really happen, though...
             log.error(String.format("Unable to find reserved user while sending recap email for event (%s) to reserving user (%s)",

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -421,7 +421,6 @@ public class EventBookingManager {
             addUserToEventGroup(event, user);
 
             try {
-                // TODO: Find out why Trello card Group Booking (3) says there is no email when a student confirms a reservation.
                 // This should send a confirmation email in any case.
                 emailManager.sendTemplatedEmailToUser(user,
                         emailManager.getEmailTemplateDTO("email-event-booking-confirmed"),

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -584,7 +584,7 @@ public class EventBookingManager {
         } catch (NoUserException e) {
             // This should never really happen, though...
             log.error(String.format("Unable to find reserved user while sending recap email for event (%s) to reserving user (%s)",
-                    event.getId()), reservingUser.getId(), e);
+                    event.getId(), reservingUser.getId()), e);
         } catch (SegueDatabaseException | ContentManagerException e) {
             log.error(String.format("Unable to send event reservation recap email (%s) to user (%s)",
                     event.getId(), reservingUser.getId()), e);
@@ -593,7 +593,7 @@ public class EventBookingManager {
         // If the frontend prevents selection of unreservable users, then this email should never go out.
         if (unreservableUsers.size() > 0) {
             // Log that the reserving user tried to reserve invalid users.
-            log.error(String.format("User (%s) tried to request a reservation for invalid users on an event (%s). Users requested: %s", reservingUser.getId()), event.getId(), unreservableUsers);
+            log.error(String.format("User (%s) tried to request a reservation for invalid users on an event (%s). Users requested: %s", reservingUser.getId(), event.getId(), unreservableUsers));
         }
 
         return reservations;

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
@@ -880,13 +880,17 @@ public class EventBookingManagerTest {
 
         // Send Emails
         expect(dummyEmailManager.getEmailTemplateDTO(("email-event-reservation-requested"))).andReturn(testCase.reservationEmail).atLeastOnce();
+        expect(dummyEmailManager.getEmailTemplateDTO(("email-event-reservation-recap"))).andReturn(testCase.reservationEmail).atLeastOnce();
 
-        expect(dummyUserAccountManager.getUserDTOById(testCase.student1.getId())).andReturn(testCase.student1).once();
+        expect(dummyUserAccountManager.getUserDTOById(testCase.student1.getId())).andReturn(testCase.student1).times(2);
         dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.student1), eq(testCase.reservationEmail), anyObject(), eq(EmailType.SYSTEM));
         expectLastCall().once();
 
-        expect(dummyUserAccountManager.getUserDTOById(testCase.student2.getId())).andReturn(testCase.student2).once();
+        expect(dummyUserAccountManager.getUserDTOById(testCase.student2.getId())).andReturn(testCase.student2).times(2);
         dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.student2), eq(testCase.reservationEmail), anyObject(), eq(EmailType.SYSTEM));
+        expectLastCall().once();
+
+        dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.teacher), eq(testCase.reservationEmail), anyObject(), eq(EmailType.EVENTS));
         expectLastCall().once();
 
         // Run the test for a student event
@@ -1019,10 +1023,13 @@ public class EventBookingManagerTest {
 
         // Send Emails
         expect(dummyEmailManager.getEmailTemplateDTO(("email-event-reservation-requested"))).andReturn(testCase.reservationEmail).atLeastOnce();
+        expect(dummyEmailManager.getEmailTemplateDTO(("email-event-reservation-recap"))).andReturn(testCase.reservationEmail).atLeastOnce();
 
-        expect(dummyUserAccountManager.getUserDTOById(testCase.student1.getId())).andReturn(testCase.student1).once();
+        expect(dummyUserAccountManager.getUserDTOById(testCase.student1.getId())).andReturn(testCase.student1).atLeastOnce();
         dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.student1), eq(testCase.reservationEmail), anyObject(), eq(EmailType.SYSTEM));
         expectLastCall().once();
+        dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.teacher), eq(testCase.reservationEmail), anyObject(), eq(EmailType.EVENTS));
+        expectLastCall().atLeastOnce();
 
         // Run the test for a student event
         Object[] mockedObjects = {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
@@ -890,7 +890,7 @@ public class EventBookingManagerTest {
         dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.student2), eq(testCase.reservationEmail), anyObject(), eq(EmailType.SYSTEM));
         expectLastCall().once();
 
-        dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.teacher), eq(testCase.reservationEmail), anyObject(), eq(EmailType.EVENTS));
+        dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.teacher), eq(testCase.reservationEmail), anyObject(), eq(EmailType.SYSTEM));
         expectLastCall().once();
 
         // Run the test for a student event
@@ -1028,7 +1028,7 @@ public class EventBookingManagerTest {
         expect(dummyUserAccountManager.getUserDTOById(testCase.student1.getId())).andReturn(testCase.student1).atLeastOnce();
         dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.student1), eq(testCase.reservationEmail), anyObject(), eq(EmailType.SYSTEM));
         expectLastCall().once();
-        dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.teacher), eq(testCase.reservationEmail), anyObject(), eq(EmailType.EVENTS));
+        dummyEmailManager.sendTemplatedEmailToUser(eq(testCase.teacher), eq(testCase.reservationEmail), anyObject(), eq(EmailType.SYSTEM));
         expectLastCall().atLeastOnce();
 
         // Run the test for a student event


### PR DESCRIPTION
Goes hand in hand with [this one](https://github.com/isaacphysics/isaac-react-app/pull/334).

* 900ce3c5 Log an error if user tries to reserve places for invalid users
* e0ebeca7 Send event reservation recap email to reserving users (needs template: `email-event-reservation-recap`)
* 14fa5e20 Verified that emails are sent without delay

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [ ] Peer-Reviewed
