### PR TITLE
Add a new password algorithm using PBKDF2-HMAC-SHA512

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v3.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Stephen Cummins
+ * Copyright 2021 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,19 @@ package uk.ac.cam.cl.dtg.segue.auth;
  * Represents an instance of a hashing scheme used in Segue.
  *
  */
-@Deprecated
-public class SeguePBKDF2v2 extends SeguePBKDF2 implements ISegueHashingAlgorithm {
-    private static final String CRYPTO_ALGORITHM = "PBKDF2WithHmacSHA1";
+public class SeguePBKDF2v3 extends SeguePBKDF2 implements ISegueHashingAlgorithm {
+    private static final String CRYPTO_ALGORITHM = "PBKDF2WithHmacSHA512";
     private static final String SALTING_ALGORITHM = "SHA1PRNG";
-    private static final Integer ITERATIONS = 100000;
+    private static final Integer ITERATIONS = 150000;
     private static final Integer KEY_LENGTH = 512;
     private static final int SALT_SIZE = 16;
 
-    public SeguePBKDF2v2() {
+    public SeguePBKDF2v3() {
         super(CRYPTO_ALGORITHM, KEY_LENGTH, ITERATIONS, SALTING_ALGORITHM, SALT_SIZE);
     }
 
     @Override
     public String hashingAlgorithmName() {
-        return "SeguePBKDF2v2";
+        return "SeguePBKDF2v3";
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -469,12 +469,15 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Provides
     private static SegueLocalAuthenticator getSegueLocalAuthenticator(final IUserDataManager database, final IPasswordDataManager passwordDataManager,
                                                                       final PropertiesLoader properties) {
-        ISegueHashingAlgorithm preferredAlgorithm = new SeguePBKDF2v2();
-        ISegueHashingAlgorithm oldAlgorithm = new SeguePBKDF2v1();
+        ISegueHashingAlgorithm preferredAlgorithm = new SeguePBKDF2v3();
+        ISegueHashingAlgorithm oldAlgorithm1 = new SeguePBKDF2v1();
+        ISegueHashingAlgorithm oldAlgorithm2 = new SeguePBKDF2v2();
 
-        Map<String, ISegueHashingAlgorithm> possibleAlgorithms
-                = ImmutableMap.of(preferredAlgorithm.hashingAlgorithmName(), preferredAlgorithm,
-                oldAlgorithm.hashingAlgorithmName(), oldAlgorithm);
+        Map<String, ISegueHashingAlgorithm> possibleAlgorithms = ImmutableMap.of(
+                        preferredAlgorithm.hashingAlgorithmName(), preferredAlgorithm,
+                        oldAlgorithm1.hashingAlgorithmName(), oldAlgorithm1,
+                        oldAlgorithm2.hashingAlgorithmName(), oldAlgorithm2
+        );
 
         return new SegueLocalAuthenticator(database, passwordDataManager, properties, possibleAlgorithms, preferredAlgorithm);
     }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -15,15 +15,9 @@
  */
 package uk.ac.cam.cl.dtg.segue.auth;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
 import org.junit.Test;
-
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.IncorrectCredentialsProvidedException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidPasswordException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoCredentialsAvailableException;
@@ -37,6 +31,13 @@ import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import java.util.Map;
 
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.fail;
+
 /**
  * Test class for the SegueLocalAuthenticator class.
  * 
@@ -47,12 +48,15 @@ public class SegueLocalAuthenticatorTest {
 	private IPasswordDataManager passwordDataManager;
 	private PropertiesLoader propertiesLoader;
 
-	private ISegueHashingAlgorithm preferredAlgorithm = new SeguePBKDF2v2();
-	private ISegueHashingAlgorithm oldAlgorithm = new SeguePBKDF2v1();
+	private ISegueHashingAlgorithm preferredAlgorithm = new SeguePBKDF2v3();
+	private ISegueHashingAlgorithm oldAlgorithm1 = new SeguePBKDF2v1();
+    private ISegueHashingAlgorithm oldAlgorithm2 = new SeguePBKDF2v2();
 
-	private Map<String, ISegueHashingAlgorithm> possibleAlgorithms
-			= ImmutableMap.of(preferredAlgorithm.hashingAlgorithmName(), preferredAlgorithm,
-                              oldAlgorithm.hashingAlgorithmName(), oldAlgorithm);
+    Map<String, ISegueHashingAlgorithm> possibleAlgorithms = ImmutableMap.of(
+            preferredAlgorithm.hashingAlgorithmName(), preferredAlgorithm,
+            oldAlgorithm1.hashingAlgorithmName(), oldAlgorithm1,
+            oldAlgorithm2.hashingAlgorithmName(), oldAlgorithm2
+    );
 
 	/**
 	 * Initial configuration of tests.
@@ -258,5 +262,5 @@ public class SegueLocalAuthenticatorTest {
 		} catch (NoUserException e) {
 			fail("We expect a user to be returned");
 		} 
-	}	
+	}
 }


### PR DESCRIPTION
This has several advantages over the existing SHA-1 based algorithm:
 - PBKDF2 using SHA-512 is slower for GPU brute force attacks than SHA-1;
 - for our 512-bit output key length, using SHA-512 is faster on a CPU than SHA-1;
 - the iteration count can rise by 50% to 150k with a _reduction_ in the
    compute time for our API use case due to the speed boost.
 - SHA-1 was never the best choice, but Java 7 did not offer other options. 
   Now we use Java 8, we have the flexibility to be more secure.

Overall my testing found that SeguePBKDF2v3 was 20% faster for us, and at least 10x
slower for an attack using modern GPU-based brute forcing, than SeguePBKDF2v2.

The code already has the architecture to magically upgrade all users who
log in using older algorithms, so this upgrade will happen seamlessly.