### PR TITLE
Require admin users authenticating with a password to have 2FA enabled

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
@@ -39,6 +39,7 @@ import uk.ac.cam.cl.dtg.segue.auth.exceptions.DuplicateAccountException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.IncorrectCredentialsProvidedException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.MissingRequiredFieldException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoCredentialsAvailableException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.MFARequiredButNotConfiguredException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
@@ -404,6 +405,9 @@ public class AuthenticationFacade extends AbstractSegueFacade {
                 log.error(String.format("Segue Login Blocked for (%s). Rate limited - too many logins.", email));
                 return SegueErrorResponse.getRateThrottledResponse(rateThrottleMessage);
             }
+        } catch (MFARequiredButNotConfiguredException e) {
+            log.warn(String.format("Login blocked for ADMIN account (%s) which does not have 2FA configured.", email));
+            return new SegueErrorResponse(Status.UNAUTHORIZED, e.getMessage()).toResponse();
         } catch (SegueDatabaseException e) {
             String errorMsg = "Internal Database error has occurred during authentication.";
             log.error(errorMsg, e);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/MFARequiredButNotConfiguredException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/MFARequiredButNotConfiguredException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.auth.exceptions;
+
+/**
+ * An exception which indicates that multi-factor authentication is required but
+ * not configured for an account.
+ * 
+ */
+public class MFARequiredButNotConfiguredException extends Exception {
+    private static final long serialVersionUID = 2703137658697650020L;
+
+    /**
+     * Creates a NoMFAAvailableException.
+     *
+     * @param message
+     *            - to accompany the exception.
+     */
+    public MFARequiredButNotConfiguredException(final String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
This will block login via email and password for admin accounts that do not have 2FA configured on their accounts. It does not automatically demote the account, just prevents login with a warning message.