### PR TITLE
Fix: ContentService: was lacking a @Named(CONTENT_INDEX) constructor annotation

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
@@ -17,6 +17,7 @@ package uk.ac.cam.cl.dtg.segue.api.services;
 
 import com.google.api.client.util.Maps;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.immutableEntry;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ID_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
 
@@ -36,7 +38,7 @@ public class ContentService {
     private final String contentIndex;
 
     @Inject
-    public ContentService(final IContentManager contentManager, final String contentIndex) {
+    public ContentService(final IContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex) {
         this.contentManager = contentManager;
         this.contentIndex = contentIndex;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -98,6 +98,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.EnvironmentType.*;
 
 /**
  * This class is responsible for injecting configuration values for persistence related classes.
@@ -205,6 +206,21 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
         this.bindConstantToProperty(CONTENT_INDEX, globalProperties);
 
         this.bindConstantToProperty(Constants.API_METRICS_EXPORT_PORT, globalProperties);
+
+        this.bind(String.class).toProvider(() -> {
+            // Any binding to String without a matching @Named annotation will always get the empty string
+            // which seems incredibly likely to cause errors and rarely to be intended behaviour,
+            // so throw an error early in DEV and log an error in PROD.
+            try {
+                throw new IllegalArgumentException("Binding a String without a matching @Named annotation");
+            } catch (IllegalArgumentException e) {
+                if (globalProperties.getProperty(SEGUE_APP_ENVIRONMENT).equals(DEV.name())) {
+                    throw e;
+                }
+                log.error("Binding a String without a matching @Named annotation", e);
+            }
+            return "";
+        });
     }
 
     /**


### PR DESCRIPTION
I've also added a check in the Guice configuration to throw an error in DEV and log an error in PROD to avoid this happening again.

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Security - Access Control - Check authorisation on every new endpoint
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
