### PR TITLE
Add question category option to gameboard filter

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -142,6 +142,8 @@ public class GameboardsFacade extends AbstractIsaacFacade {
      *            - a comma separated list of levels
      * @param concepts
      *            - a comma separated list of conceptIds
+     * @param questionCategories
+     *            - a comma separated list of question categories
      * @return a Response containing a gameboard object or containing a SegueErrorResponse.
      */
     @GET
@@ -152,12 +154,14 @@ public class GameboardsFacade extends AbstractIsaacFacade {
     public final Response generateTemporaryGameboard(@Context final HttpServletRequest request,
             @QueryParam("title") final String title, @QueryParam("subjects") final String subjects,
             @QueryParam("fields") final String fields, @QueryParam("topics") final String topics,
-            @QueryParam("levels") final String levels, @QueryParam("concepts") final String concepts) {
+            @QueryParam("levels") final String levels, @QueryParam("concepts") final String concepts,
+            @QueryParam("questionCategories") final String questionCategories) {
         List<String> subjectsList = null;
         List<String> fieldsList = null;
         List<String> topicsList = null;
         List<Integer> levelsList = null;
         List<String> conceptsList = null;
+        List<String> questionCategoriesList = null;
 
         if (null != subjects && !subjects.isEmpty()) {
             subjectsList = Arrays.asList(subjects.split(","));
@@ -189,12 +193,16 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             conceptsList = Arrays.asList(concepts.split(","));
         }
 
+        if (null != questionCategories && !questionCategories.isEmpty()) {
+            questionCategoriesList = Arrays.asList(questionCategories.split(","));
+        }
+
         try {
             AbstractSegueUserDTO boardOwner = this.userManager.getCurrentUser(request);
             GameboardDTO gameboard;
 
             gameboard = gameManager.generateRandomGameboard(title, subjectsList, fieldsList, topicsList, levelsList,
-                    conceptsList, boardOwner);
+                    conceptsList, questionCategoriesList, boardOwner);
 
             if (null == gameboard) {
                 return new SegueErrorResponse(Status.NO_CONTENT,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -117,16 +117,18 @@ public class GameManager {
      *
      * @param title
      *            title of the board
-     * @param subjectsList
+     * @param subjects
      *            list of subjects to include in filtered results
-     * @param fieldsList
+     * @param fields
      *            list of fields to include in filtered results
-     * @param topicsList
+     * @param topics
      *            list of topics to include in filtered results
-     * @param levelsList
+     * @param levels
      *            list of levels to include in filtered results
-     * @param conceptsList
+     * @param concepts
      *            list of concepts (relatedContent) to include in filtered results
+     * @param questionCategories
+     *            list of question categories (i.e. problem_solving, book) to include in filtered results
      * @param boardOwner
      *            The user that should be marked as the creator of the gameBoard.
      * @return a gameboard if possible that satisifies the conditions provided by the parameters. Will return null if no
@@ -138,10 +140,11 @@ public class GameManager {
      * @throws ContentManagerException
      *             - if there is an error retrieving the content requested.
      */
-    public GameboardDTO generateRandomGameboard(final String title, final List<String> subjectsList,
-            final List<String> fieldsList, final List<String> topicsList, final List<Integer> levelsList,
-            final List<String> conceptsList, final AbstractSegueUserDTO boardOwner) throws NoWildcardException,
-            SegueDatabaseException, ContentManagerException {
+    public GameboardDTO generateRandomGameboard(
+            final String title, final List<String> subjects, final List<String> fields, final List<String> topics,
+            final List<Integer> levels, final List<String> concepts, final List<String> questionCategories,
+            final AbstractSegueUserDTO boardOwner)
+    throws NoWildcardException, SegueDatabaseException, ContentManagerException {
 
         Long boardOwnerId;
         if (boardOwner instanceof RegisteredUserDTO) {
@@ -154,19 +157,19 @@ public class GameManager {
         Map<String, Map<String, List<QuestionValidationResponse>>> usersQuestionAttempts = questionManager
                 .getQuestionAttemptsByUser(boardOwner);
 
-        GameFilter gameFilter = new GameFilter(subjectsList, fieldsList, topicsList, levelsList, conceptsList);
+        GameFilter gameFilter = new GameFilter(subjects, fields, topics, levels, concepts, questionCategories);
 
-        List<GameboardItem> selectionOfGameboardQuestions = this.getSelectedGameboardQuestions(gameFilter,
-                usersQuestionAttempts);
+        List<GameboardItem> selectionOfGameboardQuestions =
+                this.getSelectedGameboardQuestions(gameFilter, usersQuestionAttempts);
 
         if (!selectionOfGameboardQuestions.isEmpty()) {
             String uuid = UUID.randomUUID().toString();
 
-            // filter game board ready questions to make up a decent game board.
+            // filter game board ready questions to make up a decent gameboard.
             log.debug("Created gameboard " + uuid);
 
             GameboardDTO gameboardDTO = new GameboardDTO(uuid, title, selectionOfGameboardQuestions,
-                    getRandomWildcard(mapper, subjectsList), generateRandomWildCardPosition(), new Date(), gameFilter,
+                    getRandomWildcard(mapper, subjects), generateRandomWildCardPosition(), new Date(), gameFilter,
                     boardOwnerId, GameboardCreationMethod.FILTER, Sets.newHashSet());
 
             this.gameboardPersistenceManager.temporarilyStoreGameboard(gameboardDTO);
@@ -1178,28 +1181,34 @@ public class GameManager {
 
         Map<Map.Entry<BooleanOperator, String>, List<String>> fieldsToMatchOutput = Maps.newHashMap();
 
-        // Deal with tags which represent subjects, fields and topics
-        List<String> ands = Lists.newArrayList();
-        List<String> ors = Lists.newArrayList();
+        // Filter on content tags
+        List<String> tagAnds = Lists.newArrayList();
+        List<String> tagOrs = Lists.newArrayList();
 
+        // handle question categories
+        if (null != gameFilter.getQuestionCategories()) {
+            tagAnds.addAll(gameFilter.getQuestionCategories());
+        }
+
+        // deal with tags which represent subjects, fields and topics
         if (null != gameFilter.getSubjects()) {
             if (gameFilter.getSubjects().size() > 1) {
-                ors.addAll(gameFilter.getSubjects());
+                tagOrs.addAll(gameFilter.getSubjects());
             } else { // should be exactly 1
-                ands.addAll(gameFilter.getSubjects());
+                tagAnds.addAll(gameFilter.getSubjects());
 
                 // ok now we are allowed to look at the fields
                 if (null != gameFilter.getFields()) {
                     if (gameFilter.getFields().size() > 1) {
-                        ors.addAll(gameFilter.getFields());
+                        tagOrs.addAll(gameFilter.getFields());
                     } else { // should be exactly 1
-                        ands.addAll(gameFilter.getFields());
+                        tagAnds.addAll(gameFilter.getFields());
 
                         if (null != gameFilter.getTopics()) {
                             if (gameFilter.getTopics().size() > 1) {
-                                ors.addAll(gameFilter.getTopics());
+                                tagOrs.addAll(gameFilter.getTopics());
                             } else {
-                                ands.addAll(gameFilter.getTopics());
+                                tagAnds.addAll(gameFilter.getTopics());
                             }
                         }
                     }
@@ -1207,15 +1216,14 @@ public class GameManager {
             }
         }
 
-        // deal with adding overloaded tags field for subjects, fields and
-        // topics
-        if (ands.size() > 0) {
+        // deal with adding overloaded tags field for subjects, fields and topics
+        if (tagAnds.size() > 0) {
             Map.Entry<BooleanOperator, String> newEntry = immutableEntry(BooleanOperator.AND, TAGS_FIELDNAME);
-            fieldsToMatchOutput.put(newEntry, ands);
+            fieldsToMatchOutput.put(newEntry, tagAnds);
         }
-        if (ors.size() > 0) {
+        if (tagOrs.size() > 0) {
             Map.Entry<BooleanOperator, String> newEntry = immutableEntry(BooleanOperator.OR, TAGS_FIELDNAME);
-            fieldsToMatchOutput.put(newEntry, ors);
+            fieldsToMatchOutput.put(newEntry, tagOrs);
         }
 
         // now deal with levels
@@ -1235,14 +1243,9 @@ public class GameManager {
             fieldsToMatchOutput.put(newEntry, gameFilter.getConcepts());
         }
 
+        // handle exclusions
         List<String> tagsToExclude = Lists.newArrayList();
-        // add no filter constraint
-        tagsToExclude.add(HIDE_FROM_FILTER_TAG);
-
-        // Temporarily ignore book and quick_quiz question types.
-        // Strings hardcoded until question types are passed in as part of the query.
-        tagsToExclude.addAll(ImmutableList.of("quick_quiz", "book"));
-
+        tagsToExclude.add(HIDE_FROM_FILTER_TAG); // add no filter constraint
         fieldsToMatchOutput.put(immutableEntry(BooleanOperator.NOT, TAGS_FIELDNAME), tagsToExclude);
 
         return fieldsToMatchOutput;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameFilter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameFilter.java
@@ -29,6 +29,7 @@ public class GameFilter {
     private List<String> topics;
     private List<Integer> levels;
     private List<String> concepts;
+    private List<String> questionCategories;
 
     /**
      * Create a default game filter object.
@@ -40,30 +41,33 @@ public class GameFilter {
         this.topics = Lists.newArrayList();
         this.levels = Lists.newArrayList();
         this.concepts = Lists.newArrayList();
+        this.questionCategories = Lists.newArrayList();
     }
 
     /**
      * Constructor to fully populate the game filter object.
      * 
-     * @param subjectsList
+     * @param subjects
      *            - List of subjects used to get the gameboard
-     * @param fieldsList
+     * @param fields
      *            - List of fields used to get the gameboard
-     * @param topicsList
+     * @param topics
      *            - List of topics used to get the gameboard
-     * @param levelsList
+     * @param levels
      *            - List of levels used to get the gameboard
-     * @param conceptsList
+     * @param concepts
      *            - List of concepts used to get the gameboard
+     * @param questionCategories
+     *            - List of questionCategories to get the gameboard ('problem_solving', 'book', etc.)
      */
-    public GameFilter(final List<String> subjectsList, final List<String> fieldsList, final List<String> topicsList,
-            final List<Integer> levelsList, final List<String> conceptsList) {
-
-        this.subjects = subjectsList;
-        this.fields = fieldsList;
-        this.topics = topicsList;
-        this.levels = levelsList;
-        this.concepts = conceptsList;
+    public GameFilter(final List<String> subjects, final List<String> fields, final List<String> topics,
+            final List<Integer> levels, final List<String> concepts, final List<String> questionCategories) {
+        this.subjects = subjects;
+        this.fields = fields;
+        this.topics = topics;
+        this.levels = levels;
+        this.concepts = concepts;
+        this.questionCategories = questionCategories;
     }
 
     /**
@@ -111,6 +115,16 @@ public class GameFilter {
         return concepts;
     }
 
+
+    /**
+     * Gets the questionCategories.
+     *
+     * @return the questionCategories
+     */
+    public final List<String> getQuestionCategories() {
+        return questionCategories;
+    }
+
     /**
      * Sets the subjects.
      * 
@@ -153,7 +167,7 @@ public class GameFilter {
 
     /**
      * Sets the concepts.
-     * 
+     *
      * @param concepts
      *            the concepts to set
      */
@@ -161,14 +175,25 @@ public class GameFilter {
         this.concepts = concepts;
     }
 
+    /**
+     * Sets the questionCategories.
+     *
+     * @param questionCategories
+     *            the question categories to set
+     */
+    public final void setQuestionCategories(final List<String> questionCategories) {
+        this.questionCategories = questionCategories;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("subjects: " + subjects);
-        sb.append("fields: " + fields);
-        sb.append("topics: " + topics);
-        sb.append("levels: " + levels);
-        sb.append("concepts: " + concepts);
+        sb.append("subjects: " + subjects + " ");
+        sb.append("fields: " + fields + " ");
+        sb.append("topics: " + topics + " ");
+        sb.append("levels: " + levels + " ");
+        sb.append("concepts: " + concepts + " ");
+        sb.append("questionCategories: " + questionCategories);
         return sb.toString();
     }
 
@@ -181,6 +206,7 @@ public class GameFilter {
         result = prime * result + ((levels == null) ? 0 : levels.hashCode());
         result = prime * result + ((subjects == null) ? 0 : subjects.hashCode());
         result = prime * result + ((topics == null) ? 0 : topics.hashCode());
+        result = prime * result + ((questionCategories == null) ? 0 : questionCategories.hashCode());
         return result;
     }
 
@@ -231,7 +257,11 @@ public class GameFilter {
         } else if (!topics.equals(other.topics)) {
             return false;
         }
-        return true;
+        if (questionCategories == null) {
+            return other.questionCategories == null;
+        } else {
+            return questionCategories.equals(other.questionCategories);
+        }
     }
 
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
@@ -107,11 +107,13 @@ public class GameboardsFacadeTest {
 		String levels = "2,3,4";
 		String concepts = "newtoni";
 		String title = "Newton";
+		String questionCategory = "problem_solving";
 
 		expect(
-				dummyGameManager.generateRandomGameboard(EasyMock.<String> anyObject(),
+				dummyGameManager.generateRandomGameboard(
+						EasyMock.<String> anyObject(), EasyMock.<List<String>> anyObject(),
 						EasyMock.<List<String>> anyObject(), EasyMock.<List<String>> anyObject(),
-						EasyMock.<List<String>> anyObject(), EasyMock.<List<Integer>> anyObject(),
+						EasyMock.<List<Integer>> anyObject(), EasyMock.<List<String>> anyObject(),
 						EasyMock.<List<String>> anyObject(), EasyMock.<AbstractSegueUserDTO> anyObject()))
 					.andReturn(null).atLeastOnce();
 
@@ -121,7 +123,7 @@ public class GameboardsFacadeTest {
 		replay(dummyGameManager);
 
 		Response r = gameboardFacade.generateTemporaryGameboard(dummyRequest, title, subjects, fields, topics,
-				levels, concepts);
+				levels, concepts, questionCategory);
 
 		assertTrue(r.getStatus() == Status.NO_CONTENT.getStatusCode());
 		verify(dummyGameManager);


### PR DESCRIPTION
This PR depends on https://github.com/isaacphysics/isaac-react-app/pull/360

This will allow users to conditionally provide a "question category" parameter to the question filter. If present it will only return questions tagged with that question category. Not providing a question category is valid and is likely to be what CS want to use in the future.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
