### PR TITLE
Feature/get reserved events

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -353,9 +353,9 @@ public class EventsFacade extends AbstractIsaacFacade {
             throws SegueDatabaseException, ContentManagerException {
         List<ContentDTO> filteredResults = Lists.newArrayList();
 
-        List<DetailedEventBookingDTO> userReservationList = this.bookingManager.getAllEventReservationsForUser(currentUser.getId());
+        List<EventBookingDTO> userReservationList = this.mapper.mapAsList(bookingManager.getAllEventReservationsForUser(currentUser.getId()), EventBookingDTO.class);
 
-        for (DetailedEventBookingDTO booking : userReservationList) {
+        for (EventBookingDTO booking : userReservationList) {
 
             final IsaacEventPageDTO eventDTOById = this.getAugmentedEventDTOById(request, booking.getEventId());
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -359,9 +359,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             final IsaacEventPageDTO eventDTOById = this.getAugmentedEventDTOById(request, booking.getEventId());
 
-            if (!filteredResults.contains(eventDTOById)) {
-                filteredResults.add(eventDTOById);
-            }
+            filteredResults.add(eventDTOById);
         }
         return new ResultsWrapper<>(filteredResults, (long) filteredResults.size());
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -204,7 +204,8 @@ public class EventsFacade extends AbstractIsaacFacade {
             @QueryParam("sort_by") final String sortOrder,
             @QueryParam("show_active_only") final Boolean showActiveOnly,
             @QueryParam("show_inactive_only") final Boolean showInactiveOnly,
-            @QueryParam("show_booked_only") final Boolean showMyBookingsOnly) {
+            @QueryParam("show_booked_only") final Boolean showMyBookingsOnly,
+            @QueryParam("show_reservations_only") final Boolean showReservationsOnly) {
         Map<String, List<String>> fieldsToMatch = Maps.newHashMap();
 
         Integer newLimit = null;
@@ -266,6 +267,18 @@ public class EventsFacade extends AbstractIsaacFacade {
                 } else {
                     SegueErrorResponse.getNotLoggedInResponse();
                 }
+            } else if (null != showReservationsOnly && showReservationsOnly) {
+                RegisteredUserDTO currentUser = null;
+                try {
+                    currentUser = this.userManager.getCurrentRegisteredUser(request);
+                } catch (NoUserLoggedInException e) {
+                    /* Safe to ignore; will just leave currentUser null. */
+                }
+                if (null != currentUser) {
+                    findByFieldNames = getEventsReservedByUser(request, currentUser);
+                } else {
+                    SegueErrorResponse.getNotLoggedInResponse();
+                }
             } else {
                 findByFieldNames = this.contentManager.findByFieldNames(
                     this.contentIndex, ContentService.generateDefaultFieldToMatch(fieldsToMatch),
@@ -323,6 +336,33 @@ public class EventsFacade extends AbstractIsaacFacade {
 
 			filteredResults.add(eventDTOById);
 		}
+        return new ResultsWrapper<>(filteredResults, (long) filteredResults.size());
+    }
+
+    /**
+     * Get Events Reserved by user.
+     *
+     * @param request - the http request so we can resolve booking information
+     * @param currentUser - the currently logged on user.
+     * @return a list of event pages that the user has been booked
+     * @throws SegueDatabaseException
+     * @throws ContentManagerException
+     */
+    private ResultsWrapper<ContentDTO> getEventsReservedByUser(final HttpServletRequest request,
+                                                               final RegisteredUserDTO currentUser)
+            throws SegueDatabaseException, ContentManagerException {
+        List<ContentDTO> filteredResults = Lists.newArrayList();
+
+        List<DetailedEventBookingDTO> userReservationList = this.bookingManager.getAllEventReservationsForUser(currentUser.getId());
+
+        for (DetailedEventBookingDTO booking : userReservationList) {
+
+            final IsaacEventPageDTO eventDTOById = this.getAugmentedEventDTOById(request, booking.getEventId());
+
+            if (!filteredResults.contains(eventDTOById)) {
+                filteredResults.add(eventDTOById);
+            }
+        }
         return new ResultsWrapper<>(filteredResults, (long) filteredResults.size());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -136,6 +136,17 @@ public class EventBookingManager {
     }
 
     /**
+     * This will get all reservations made by a given user.
+     *
+     * @param userId - user of interest.
+     * @return events
+     * @throws SegueDatabaseException - if an error occurs.
+     */
+    public List<DetailedEventBookingDTO> getAllEventReservationsForUser(final Long userId) throws SegueDatabaseException {
+        return this.bookingPersistenceManager.getEventReservationsByUserId(userId);
+    }
+
+    /**
      * @param bookingId - of interest
      * @return event booking
      * @throws SegueDatabaseException - if an error occurs.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -80,6 +80,17 @@ public class EventBookingPersistenceManager {
     }
 
     /**
+     * @param userId
+     *            - user of interest.
+     * @return events
+     * @throws SegueDatabaseException
+     *             - if an error occurs.
+     */
+    public List<DetailedEventBookingDTO> getEventReservationsByUserId(final Long userId) throws SegueDatabaseException {
+        return convertToDTO(Lists.newArrayList(dao.findAllReservationsByUserId(userId)));
+    }
+
+    /**
      * @param bookingId
      *            - of interest
      * @return event booking

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -160,6 +160,18 @@ public interface EventBookings {
      */
     Iterable<EventBooking> findAllByUserId(final Long userId) throws SegueDatabaseException;
 
+
+    /**
+     * Find all event reservations by a given user.
+     *
+     * @param userId
+     *            - the user of interest.
+     * @return an iterable with all the events matching the criteria.
+     * @throws SegueDatabaseException
+     *             - if an error occurs.
+     */
+    Iterable<EventBooking> findAllReservationsByUserId(final Long userId) throws SegueDatabaseException;
+
     /**
      * Find an event booking by event and user id.
      * 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -434,6 +434,26 @@ public class PgEventBookings implements EventBookings {
         }
     }
 
+    public Iterable<EventBooking> findAllReservationsByUserId(final Long userId) throws SegueDatabaseException {
+        Validate.notNull(userId);
+
+        try (Connection conn = ds.getDatabaseConnection()) {
+            PreparedStatement pst;
+            pst = conn.prepareStatement("SELECT * FROM event_bookings WHERE reserved_by = ?");
+            pst.setLong(1, userId);
+            ResultSet results = pst.executeQuery();
+
+            List<EventBooking> returnResult = Lists.newArrayList();
+            while (results.next()) {
+                returnResult.add(buildPgEventBooking(results));
+
+            }
+            return returnResult;
+        } catch (SQLException e) {
+            throw new SegueDatabaseException("Postgres exception", e);
+        }
+    }
+
     /**
      * Create a pgEventBooking from a results set.
      * 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -434,6 +434,7 @@ public class PgEventBookings implements EventBookings {
         }
     }
 
+    @Override
     public Iterable<EventBooking> findAllReservationsByUserId(final Long userId) throws SegueDatabaseException {
         Validate.notNull(userId);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -439,7 +439,7 @@ public class PgEventBookings implements EventBookings {
 
         try (Connection conn = ds.getDatabaseConnection()) {
             PreparedStatement pst;
-            pst = conn.prepareStatement("SELECT * FROM event_bookings WHERE reserved_by = ?");
+            pst = conn.prepareStatement("SELECT distinct on (event_id) * FROM event_bookings WHERE reserved_by = ?");
             pst.setLong(1, userId);
             ResultSet results = pst.executeQuery();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -439,7 +439,7 @@ public class PgEventBookings implements EventBookings {
 
         try (Connection conn = ds.getDatabaseConnection()) {
             PreparedStatement pst;
-            pst = conn.prepareStatement("SELECT distinct on (event_id) * FROM event_bookings WHERE reserved_by = ?");
+            pst = conn.prepareStatement("SELECT distinct on (event_id) * FROM event_bookings WHERE reserved_by = ? AND status != 'CANCELLED'");
             pst.setLong(1, userId);
             ResultSet results = pst.executeQuery();
 


### PR DESCRIPTION
Allows specification of 'events you have made group reservations on' in https://github.com/isaacphysics/isaac-react-app/pull/361

Mirrors getEventsBookedByUser in the facade, with a separate database call for events you have reserved on of which the reservations aren't cancelled

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
