### PR TITLE
MailJet webhook callbacks

### DIFF
--- a/config-templates/linux-local-dev-segue-config.properties
+++ b/config-templates/linux-local-dev-segue-config.properties
@@ -98,6 +98,7 @@ TWITTER_CALLBACK_URI=http://localhost:8000/auth/twitter/callback
 IP_INFO_DB_API_KEY=[enter_key_here]
 
 # MailJet Secrets and Lists:
+MAILJET_WEBHOOK_TOKEN=[token_here]
 MAILJET_API_KEY=[key_here]
 MAILJET_API_SECRET=[key_here]
 MAILJET_NEWS_LIST_ID=[list_id_here]

--- a/config-templates/windows--local-dev-segue-config.properties
+++ b/config-templates/windows--local-dev-segue-config.properties
@@ -98,6 +98,7 @@ TWITTER_CALLBACK_URI=http://localhost:8000/auth/twitter/callback
 IP_INFO_DB_API_KEY=[enter_key_here]
 
 # MailJet Secrets and Lists:
+MAILJET_WEBHOOK_TOKEN=[token_here]
 MAILJET_API_KEY=[key_here]
 MAILJET_API_SECRET=[key_here]
 MAILJET_NEWS_LIST_ID=[list_id_here]

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -586,7 +586,7 @@ public class AdminFacade extends AbstractSegueFacade {
                                                 @PathParam("providerToken") final String providerToken,
                                                 final List<Map<String, Object>> eventDetailsList) {
         try {
-            final String expectedProviderToken = getProperties().getProperty(MAILJET_SECRET_KEY);
+            final String expectedProviderToken = getProperties().getProperty(MAILJET_WEBHOOK_TOKEN);
             if (!expectedProviderToken.equals(providerToken)) {
                 return SegueErrorResponse.getIncorrectRoleResponse();
             }
@@ -633,7 +633,7 @@ public class AdminFacade extends AbstractSegueFacade {
                                                 @PathParam("providerToken") final String providerToken,
                                                 final List<Map<String, Object>> eventDetailsList) {
         try {
-            final String expectedProviderToken = getProperties().getProperty(MAILJET_SECRET_KEY);
+            final String expectedProviderToken = getProperties().getProperty(MAILJET_WEBHOOK_TOKEN);
             if (!expectedProviderToken.equals(providerToken)) {
                 return SegueErrorResponse.getIncorrectRoleResponse();
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -587,6 +587,9 @@ public class AdminFacade extends AbstractSegueFacade {
                                                 final List<Map<String, Object>> eventDetailsList) {
         try {
             final String expectedProviderToken = getProperties().getProperty(MAILJET_WEBHOOK_TOKEN);
+            if (null == expectedProviderToken || expectedProviderToken.isEmpty()) {
+                return SegueErrorResponse.getNotImplementedResponse();
+            }
             if (!expectedProviderToken.equals(providerToken)) {
                 return SegueErrorResponse.getIncorrectRoleResponse();
             }
@@ -634,6 +637,9 @@ public class AdminFacade extends AbstractSegueFacade {
                                                 final List<Map<String, Object>> eventDetailsList) {
         try {
             final String expectedProviderToken = getProperties().getProperty(MAILJET_WEBHOOK_TOKEN);
+            if (null == expectedProviderToken || expectedProviderToken.isEmpty()) {
+                return SegueErrorResponse.getNotImplementedResponse();
+            }
             if (!expectedProviderToken.equals(providerToken)) {
                 return SegueErrorResponse.getIncorrectRoleResponse();
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -48,6 +48,7 @@ import uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics;
 import uk.ac.cam.cl.dtg.segue.api.monitors.UserSearchMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
+import uk.ac.cam.cl.dtg.segue.comm.EmailType;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.LocationManager;
 import uk.ac.cam.cl.dtg.segue.dao.ResourceNotFoundException;
@@ -565,7 +566,96 @@ public class AdminFacade extends AbstractSegueFacade {
         return Response.ok().build();
     }
 
+    /* This method will allow users' email verification status to be changed en-mass.
+     *
+     * @param request
+     *            - to help determine access rights.
+     * @param eventDetailsList
+     *            - a list of objects in the MailJet JSON format
+     * @return Success shown by returning an ok response
+     */
+    @POST
+    @Path("/users/delivery_failed_notification/{providerToken}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response notifyExternalDeliveryFailure(@Context final HttpServletRequest request,
+                                                @PathParam("providerToken") final String providerToken,
+                                                final List<Map<String, Object>> eventDetailsList) {
+        try {
+            final String expectedProviderToken = getProperties().getProperty(MAILJET_SECRET_KEY);
+            if (!expectedProviderToken.equals(providerToken)) {
+                return SegueErrorResponse.getIncorrectRoleResponse();
+            }
 
+            for (Map<String, Object> eventDetails: eventDetailsList) {
+                String recipientEmail = (String) eventDetails.get("email");
+                Object permanentFailureObject = eventDetails.get("hard_bounce");
+                String errorMessage = (String) eventDetails.get("error");
+
+                // Assume a hard failure unless told otherwise or message triggered by duplication issue:
+                boolean permanentFailure = !"duplicate in campaign".equals(errorMessage);
+                // The "hard_bounce" parameter might be null, a String, or a Boolean value:
+                if (permanentFailureObject instanceof Boolean) {
+                    permanentFailure = (boolean) permanentFailureObject;
+                } else if (permanentFailureObject instanceof String) {
+                    permanentFailure = Boolean.parseBoolean((String) permanentFailureObject);
+                }
+                // Update delivery failure status if necessary:
+                if (recipientEmail != null && !recipientEmail.isEmpty() && permanentFailure) {
+                    this.userManager.updateUserEmailVerificationStatus(recipientEmail, EmailVerificationStatus.DELIVERY_FAILED);
+                }
+            }
+            String remoteIpAddress = RequestIPExtractor.getClientIpAddr(request);
+            log.info(String.format("Request from (%s) updated the status of %s emails to DELIVERY_FAILED.", remoteIpAddress, eventDetailsList.size()));
+            return Response.ok().build();
+        } catch (SegueDatabaseException | ClassCastException e) {
+            return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Unable to process request.").toResponse();
+        }
+    }
+
+    /* This method will allow users' email preference status to be changed en-mass.
+     *
+     * @param request
+     *            - to help determine access rights.
+     * @param webhookPayload
+     *            - a list of user webhookPayload that need to be changed
+     * @return Success shown by returning an ok response
+     */
+    @POST
+    @Path("/users/unsubscription_notification/{providerToken}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response notifyExternalUnsubscriptionEvent(@Context final HttpServletRequest request,
+                                                @PathParam("providerToken") final String providerToken,
+                                                final List<Map<String, Object>> eventDetailsList) {
+        try {
+            final String expectedProviderToken = getProperties().getProperty(MAILJET_SECRET_KEY);
+            if (!expectedProviderToken.equals(providerToken)) {
+                return SegueErrorResponse.getIncorrectRoleResponse();
+            }
+
+            List<UserPreference> userPreferencesToUpdate = Lists.newArrayList();
+
+            for (Map<String, Object> eventDetails: eventDetailsList) {
+                String recipientEmail = (String) eventDetails.get("email");
+                if (recipientEmail != null && !recipientEmail.isEmpty()) {
+                    try {
+                        RegisteredUserDTO user = userManager.getUserDTOByEmail(recipientEmail);
+                        UserPreference preferenceToSave = new UserPreference(user.getId(), SegueUserPreferences.EMAIL_PREFERENCE.name(), EmailType.NEWS_AND_UPDATES.name(), false);
+                        userPreferencesToUpdate.add(preferenceToSave);
+                    } catch (NoUserException e) {
+                        log.warn(String.format("User with email (%s) attempted to unsubscribe, but no Isaac account found!", recipientEmail));
+                    }
+                }
+            }
+            userPreferenceManager.saveUserPreferences(userPreferencesToUpdate);
+            String remoteIpAddress = RequestIPExtractor.getClientIpAddr(request);
+            log.info(String.format("Request from (%s) unsubscribed %s emails from NEWS_AND_UPDATES emails.", remoteIpAddress, userPreferencesToUpdate.size()));
+            return Response.ok().build();
+        } catch (SegueDatabaseException | ClassCastException e) {
+            return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Unable to process request.").toResponse();
+        }
+    }
 
     /**
      * This method will delete all cached data from the CMS and any search indices.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -188,6 +188,7 @@ public final class Constants {
     public static final String EVENT_ICAL_UID_DOMAIN = "EVENT_ICAL_UID_DOMAIN";
 
     // MailJet Stuff:
+    public static final String MAILJET_WEBHOOK_TOKEN = "MAILJET_WEBHOOK_TOKEN";
     public static final String MAILJET_API_KEY = "MAILJET_API_KEY";
     public static final String MAILJET_API_SECRET = "MAILJET_API_SECRET";
     public static final String MAILJET_NEWS_LIST_ID = "MAILJET_NEWS_LIST_ID";
@@ -379,9 +380,6 @@ public final class Constants {
 
     // IP Geocoding stuff
     public static final String IP_INFO_DB_API_KEY = "IP_INFO_DB_API_KEY";
-
-    // MailJet WebHook Token
-    public static final String MAILJET_SECRET_KEY = "MAILJET_SECRET_KEY";
 
 
     /*

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -374,6 +374,10 @@ public final class Constants {
     // IP Geocoding stuff
     public static final String IP_INFO_DB_API_KEY = "IP_INFO_DB_API_KEY";
 
+    // MailJet WebHook Token
+    public static final String MAILJET_SECRET_KEY = "MAILJET_SECRET_KEY";
+
+
     /*
      * Default values.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -35,6 +35,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -575,9 +576,10 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
 
                 // Hash all linked account provider IDs to prevent clashes if the user creates a new account.
                 PreparedStatement markUserAsDeleted;
-                markUserAsDeleted = conn.prepareStatement("UPDATE users SET deleted = TRUE WHERE id = ?");
+                markUserAsDeleted = conn.prepareStatement("UPDATE users SET deleted=TRUE, last_updated=? WHERE id = ?");
 
-                markUserAsDeleted.setLong(1, userToDelete.getId());
+                markUserAsDeleted.setTimestamp(1, new Timestamp(new Date().getTime()));
+                markUserAsDeleted.setLong(2, userToDelete.getId());
                 markUserAsDeleted.execute();
 
                 conn.commit();


### PR DESCRIPTION
This uses a path parameter for validation, since MailJet doesn't sign its webhooks. It ought to be safe enough for an endpoint that returns only empty 200 OK responses, where abuse would be a nuisance but not severe. I don't like it, but single-endpoint HTTP Basic auth in Jetty looked awful and isn't fundamentally any more secure or less succeptable to brute forcing.

Also, and slightly unrelatedly, update the `last_updated` time on a user when they are deleted. This is also needed for MailJet sync to function.