### PR TITLE
Search school URN by exact match

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/SchoolListReader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/SchoolListReader.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.util.Lists;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +27,6 @@ import uk.ac.cam.cl.dtg.segue.search.ISearchProvider;
 import uk.ac.cam.cl.dtg.segue.search.SegueSearchException;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_RESULTS_LIMIT;
@@ -136,7 +133,7 @@ public class SchoolListReader {
 
         List<String> matchingSchoolList;
         
-        matchingSchoolList = searchProvider.findByPrefix(SCHOOLS_INDEX_BASE, SCHOOLS_INDEX_TYPE.SCHOOL_SEARCH.toString(),
+        matchingSchoolList = searchProvider.findByExactMatch(SCHOOLS_INDEX_BASE, SCHOOLS_INDEX_TYPE.SCHOOL_SEARCH.toString(),
                 SCHOOL_URN_FIELDNAME.toLowerCase() + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX,
                 schoolURN, 0, DEFAULT_RESULTS_LIMIT, null).getResults();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
@@ -287,6 +287,25 @@ public class ElasticSearchProvider implements ISearchProvider {
     }
 
     @Override
+    public ResultsWrapper<String> findByExactMatch(final String indexBase, final String indexType,
+                                                   final String fieldname, final String needle, final int startIndex,
+                                                   final int limit,
+                                                   final Map<String, AbstractFilterInstruction> filterInstructions)
+            throws SegueSearchException {
+        ResultsWrapper<String> resultList;
+
+        QueryBuilder query = QueryBuilders.matchQuery(fieldname, needle);
+
+        if (filterInstructions != null) {
+            query = QueryBuilders.boolQuery().must(query).filter(generateFilterQuery(filterInstructions));
+        }
+
+        resultList = this.executeBasicQuery(indexBase, indexType, query, startIndex, limit);
+
+        return resultList;
+    }
+
+    @Override
     public ResultsWrapper<String> findByPrefix(final String indexBase, final String indexType, final String fieldname,
                                                final String prefix, final int startIndex, final int limit, final Map<String, AbstractFilterInstruction> filterInstructions)
             throws SegueSearchException {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
@@ -159,6 +159,28 @@ public interface ISearchProvider {
             int startIndex, int limit, Long randomSeed, Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
 
     /**
+     * Query for a list of Results that exactly match a given id.
+     *
+     * @param indexBase
+     *            base string for the index that the content is stored in
+     * @param indexType
+     *            - type of index as registered with search provider.
+     * @param fieldname
+     *            - fieldName to search within.
+     * @param needle
+     *            - needle to search for.
+     * @param startIndex
+     *            - start index for results
+     * @param limit
+     *            - the maximum number of results to return -1 will attempt to return all results.
+     * @param filterInstructions
+     *            - post search filter instructions e.g. remove content of a certain type.
+     * @return A list of results that match the id prefix.
+     */
+    ResultsWrapper<String> findByExactMatch(String indexBase, String indexType, String fieldname, String needle,
+                                            int startIndex, int limit, @Nullable Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+
+    /**
      * Query for a list of Results that match a given id prefix.
      * 
      * This is useful if you use un-analysed fields for ids and use the dot separator as a way of nesting fields.


### PR DESCRIPTION
This adds an exact match method to ISearchProvider so that we search for an exact match for a given needle in a given field. This helps with duplicate schools when searching by URN prefix.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Peer-Reviewed
