### PR TITLE
Upgrade JGit to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,14 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.5.1.201910021850-r</version>
+            <version>5.11.1.202105131744-r</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+            <version>5.11.1.202105131744-r</version>
+        </dependency>
+
 
         <dependency>
             <groupId>ma.glasnost.orika</groupId>


### PR DESCRIPTION
In version 5.8, the library moved the SSH requirements into a separate package, which we need to include. The code and imports remain unchanged, and although Jsch is no longer the recommended SSH implementation it is still supported.

My hope is this might help address the many `java.io.IOException: Unreadable pack index` exceptions we have been seeing, although the bugfixes mentioned are for slightly different issues with pack files.