### PR TITLE
Add recent questions and oldest incomplete questions to progress stats

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -421,8 +421,7 @@ public class IsaacController extends AbstractIsaacFacade {
             userOfInterestSummary = userManager.convertToUserSummaryObject(userOfInterestFull);
 
             if (associationManager.hasPermission(user, userOfInterestSummary)) {
-                Map<String, Object> userProgressInformation = statsManager
-                        .getUserQuestionInformation(userOfInterestFull);
+                Map<String, Object> userProgressInformation = statsManager.getUserQuestionInformation(userOfInterestFull);
 
                 // augment details with user snapshot data (perhaps one day we will replace the entire endpoint with this call)
                 Map<String, Object> dailyStreakRecord = userStreaksManager.getCurrentStreakRecord(userOfInterestFull);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -23,6 +23,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,7 @@ import uk.ac.cam.cl.dtg.segue.dos.users.Role;
 import uk.ac.cam.cl.dtg.segue.dos.users.School;
 import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.segue.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.segue.dto.content.QuestionDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.search.SegueSearchException;
@@ -62,23 +64,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.Maps.immutableEntry;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.FAST_TRACK_QUESTION_TYPE;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.IsaacServerLogType;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.QUESTION_TYPE;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.BooleanOperator;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.ID_FIELDNAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueServerLogType;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval.NINETY_DAYS;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval.SEVEN_DAYS;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval.SIX_MONTHS;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval.THIRTY_DAYS;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval.*;
 
 /**
  * StatisticsManager.
@@ -92,7 +86,6 @@ public class StatisticsManager implements IStatisticsManager {
     private final String contentIndex;
     private GroupManager groupManager;
     private QuestionManager questionManager;
-    private GameManager gameManager;
     private IUserStreaksManager userStreaksManager;
     
     private Cache<String, Object> longStatsCache;
@@ -104,6 +97,7 @@ public class StatisticsManager implements IStatisticsManager {
     private static final String LOCATION_STATS = "LOCATION_STATS";
     private static final int LONG_STATS_EVICTION_INTERVAL_MINUTES = 720; // 12 hours
     private static final long LONG_STATS_MAX_ITEMS = 20;
+    private static final int PROGRESS_MAX_RECENT_QUESTIONS = 5;
 
     
     /**
@@ -129,8 +123,7 @@ public class StatisticsManager implements IStatisticsManager {
                              final SchoolListReader schoolManager, final IContentManager contentManager,
                              @Named(CONTENT_INDEX) final String contentIndex,
                              final LocationManager locationHistoryManager, final GroupManager groupManager,
-                             final QuestionManager questionManager, final GameManager gameManager,
-                             final IUserStreaksManager userStreaksManager) {
+                             final QuestionManager questionManager, final IUserStreaksManager userStreaksManager) {
         this.userManager = userManager;
         this.logManager = logManager;
         this.schoolManager = schoolManager;
@@ -141,7 +134,6 @@ public class StatisticsManager implements IStatisticsManager {
         this.locationHistoryManager = locationHistoryManager;
         this.groupManager = groupManager;
         this.questionManager = questionManager;
-        this.gameManager = gameManager;
         this.userStreaksManager = userStreaksManager;
 
         this.longStatsCache = CacheBuilder.newBuilder()
@@ -417,6 +409,8 @@ public class StatisticsManager implements IStatisticsManager {
         Map<String, Integer> questionsCorrectByLevelStats = Maps.newHashMap();
         Map<String, Integer> questionAttemptsByTypeStats = Maps.newHashMap();
         Map<String, Integer> questionsCorrectByTypeStats = Maps.newHashMap();
+        List<ContentDTO> questionPagesNotComplete = Lists.newArrayList();
+        Queue<ContentDTO> mostRecentlyAttemptedQuestionPages = new CircularFifoQueue<>(PROGRESS_MAX_RECENT_QUESTIONS);
 
         LocalDate now = LocalDate.now();
         LocalDate endOfAugustThisYear = LocalDate.of(now.getYear(), Month.AUGUST, 31);
@@ -429,15 +423,21 @@ public class StatisticsManager implements IStatisticsManager {
 
         // Loop through each Question attempted:
         for (Entry<String, Map<String, List<QuestionValidationResponse>>> question : questionAttemptsByUser.entrySet()) {
-            attemptedQuestions++;
+            ContentDTO questionContentDTO = questionMap.get(question.getKey());
+            if (null == questionContentDTO) {
+                log.warn(String.format("Excluding missing question (%s) from user progress statistics for user (%s)!",
+                        question.getKey(), userOfInterest.getId()));
+                // We no longer have any information on this question, so we won't count it towards statistics!
+                continue;
+            }
 
+            mostRecentlyAttemptedQuestionPages.add(questionContentDTO);  // Assumes questionAttemptsByUser is sorted!
+            attemptedQuestions++;
             boolean questionIsCorrect = true;  // Are all Parts of the Question correct?
             LocalDate mostRecentCorrectQuestionPart = null;
             LocalDate mostRecentAttemptAtQuestion = null;
             // Loop through each Part of the Question:
-            // TODO - We might be able to avoid using a GameManager here!
-            // The question page content object is questionMap.get(question.getKey()) and we could search this instead!
-            for (QuestionDTO questionPart : gameManager.getAllMarkableQuestionPartsDFSOrder(question.getKey())) {
+            for (QuestionDTO questionPart : GameManager.getAllMarkableQuestionPartsDFSOrder(questionContentDTO)) {
 
                 boolean questionPartIsCorrect = false;  // Is this Part of the Question correct?
                 // Has the user attempted this part of the question at all?
@@ -498,12 +498,6 @@ public class StatisticsManager implements IStatisticsManager {
                 questionIsCorrect = questionIsCorrect && questionPartIsCorrect;
             }
 
-            ContentDTO questionContentDTO = questionMap.get(question.getKey());
-            if (null == questionContentDTO) {
-                // We no longer have any information on this question!
-                continue;
-            }
-
             // Tag Stats - Loop through the Question's tags:
             for (String tag : questionContentDTO.getTags()) {
                 // Count the attempt at the Question:
@@ -552,10 +546,18 @@ public class StatisticsManager implements IStatisticsManager {
                 } else {
                     questionsCorrectByLevelStats.put(questionLevel, 1);
                 }
+            } else if (questionPagesNotComplete.size() < PROGRESS_MAX_RECENT_QUESTIONS) {
+                questionPagesNotComplete.add(questionContentDTO);
             }
         }
 
+        // Collate all the information into the JSON response as a Map:
         Map<String, Object> questionInfo = Maps.newHashMap();
+        List<ContentSummaryDTO> mostRecentlyAttemptedQuestionsList = mostRecentlyAttemptedQuestionPages
+                .stream().map(contentManager::extractContentSummary).collect(Collectors.toList());
+        Collections.reverse(mostRecentlyAttemptedQuestionsList);  // We want most-recent first order and streams cannot reverse.
+        List<ContentSummaryDTO> questionsNotCompleteList = questionPagesNotComplete
+                .stream().map(contentManager::extractContentSummary).collect(Collectors.toList());
 
         questionInfo.put("totalQuestionsAttempted", attemptedQuestions);
         questionInfo.put("totalQuestionsCorrect", correctQuestions);
@@ -571,6 +573,8 @@ public class StatisticsManager implements IStatisticsManager {
         questionInfo.put("correctByLevel", questionsCorrectByLevelStats);
         questionInfo.put("attemptsByType", questionAttemptsByTypeStats);
         questionInfo.put("correctByType", questionsCorrectByTypeStats);
+        questionInfo.put("oldestIncompleteQuestions", questionsNotCompleteList);
+        questionInfo.put("mostRecentQuestions", mostRecentlyAttemptedQuestionsList);
         questionInfo.put("userDetails", this.userManager.convertToUserSummaryObject(userOfInterest));
 
         return questionInfo;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -868,8 +868,6 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
      *            - dependency
      * @param questionManager
      *            - dependency
-     * @param gameManager
-     *            - dependency
      * @return stats manager
      */
     @Provides
@@ -878,12 +876,12 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     private static StatisticsManager getStatsManager(final UserAccountManager userManager,
                                                      final ILogManager logManager, final SchoolListReader schoolManager,
                                                      final IContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex, final LocationManager locationHistoryManager,
-                                                     final GroupManager groupManager, final QuestionManager questionManager, final GameManager gameManager,
+                                                     final GroupManager groupManager, final QuestionManager questionManager,
                                                      final IUserStreaksManager userStreaksManager) {
 
         if (null == statsManager) {
             statsManager = new StatisticsManager(userManager, logManager, schoolManager, contentManager, contentIndex,
-                    locationHistoryManager, groupManager, questionManager, gameManager, userStreaksManager);
+                    locationHistoryManager, groupManager, questionManager, userStreaksManager);
             log.info("Created Singleton of Statistics Manager");
         }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/PgQuestionAttempts.java
@@ -203,7 +203,8 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
 
             ResultSet results = pst.executeQuery();
 
-            Map<String, Map<String, List<QuestionValidationResponse>>> mapOfQuestionAttemptsByPage = Maps.newHashMap();
+            // Since we go to the effort of sorting the attempts in Postgres, use LinkedHashMap which is ordered:
+            Map<String, Map<String, List<QuestionValidationResponse>>> mapOfQuestionAttemptsByPage = Maps.newLinkedHashMap();
 
             while (results.next()) {
                 QuestionValidationResponse questionAttempt = objectMapper.readValue(
@@ -216,7 +217,7 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
                         .get(questionPageId);
                 
                 if (null == attemptsForThisQuestionPage) {
-                    attemptsForThisQuestionPage = Maps.newHashMap();
+                    attemptsForThisQuestionPage = Maps.newLinkedHashMap();
                     mapOfQuestionAttemptsByPage.put(questionPageId, attemptsForThisQuestionPage);
                 }
                 


### PR DESCRIPTION
To keep the response size manageable, only include the most recent 5 questions and oldest 5 incomplete questions. Use a FIFO queue to keep the most recent 5 questions, since this is more efficient than a list.
Doing this assumes the input Map is sorted, which it was not despite the results being returned from Postgres in order. LinkedHashMaps offer this order without much of an overhead and required minimal code change!

I also implemented my 4 year old TODO and removed the need for a local GameManager by using the static method and the existing DTOs, which should also be a performance boost by not loading everything from ElasticSearch twice.
