### PR TITLE
Trim leading whitespace in string match answers with option to preserve it

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
@@ -31,6 +31,7 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 public class IsaacStringMatchQuestion extends IsaacQuestionBase {
     private Boolean multiLineEntry;
     private Boolean preserveTrailingWhitespace;
+    private Boolean preserveLeadingWhitespace;
 
     public Boolean getMultiLineEntry() {
         return multiLineEntry;
@@ -46,5 +47,13 @@ public class IsaacStringMatchQuestion extends IsaacQuestionBase {
 
     public void setPreserveTrailingWhitespace(final Boolean preserveTrailingWhitespace) {
         this.preserveTrailingWhitespace = preserveTrailingWhitespace;
+    }
+
+    public Boolean getPreserveLeadingWhitespace() {
+        return preserveLeadingWhitespace;
+    }
+
+    public void setPreserveLeadingWhitespace(final Boolean preserveLeadingWhitespace) {
+        this.preserveLeadingWhitespace = preserveLeadingWhitespace;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
@@ -30,8 +30,8 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 @ValidatesWith(IsaacStringMatchValidator.class)
 public class IsaacStringMatchQuestion extends IsaacQuestionBase {
     private Boolean multiLineEntry;
-    private Boolean preserveTrailingWhitespace;
     private Boolean preserveLeadingWhitespace;
+    private Boolean preserveTrailingWhitespace;
 
     public Boolean getMultiLineEntry() {
         return multiLineEntry;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
@@ -27,8 +27,8 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 @ValidatesWith(IsaacStringMatchValidator.class)
 public class IsaacStringMatchQuestionDTO extends IsaacQuestionBaseDTO {
     private Boolean multiLineEntry;
-    private Boolean preserveTrailingWhitespace;
     private Boolean preserveLeadingWhitespace;
+    private Boolean preserveTrailingWhitespace;
 
     public Boolean getMultiLineEntry() {
         return multiLineEntry;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
@@ -28,6 +28,7 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatesWith;
 public class IsaacStringMatchQuestionDTO extends IsaacQuestionBaseDTO {
     private Boolean multiLineEntry;
     private Boolean preserveTrailingWhitespace;
+    private Boolean preserveLeadingWhitespace;
 
     public Boolean getMultiLineEntry() {
         return multiLineEntry;
@@ -43,5 +44,13 @@ public class IsaacStringMatchQuestionDTO extends IsaacQuestionBaseDTO {
 
     public void setPreserveTrailingWhitespace(final Boolean preserveTrailingWhitespace) {
         this.preserveTrailingWhitespace = preserveTrailingWhitespace;
+    }
+
+    public Boolean getPreserveLeadingWhitespace() {
+        return preserveLeadingWhitespace;
+    }
+
+    public void setPreserveLeadingWhitespace(final Boolean preserveLeadingWhitespace) {
+        this.preserveLeadingWhitespace = preserveLeadingWhitespace;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
@@ -35,8 +35,8 @@ import java.util.regex.Pattern;
  */
 public class IsaacStringMatchValidator implements IValidator {
     private static final Logger log = LoggerFactory.getLogger(IsaacStringMatchValidator.class);
-    private static final Pattern TRAILING_SPACES = Pattern.compile("\\s+$", Pattern.MULTILINE);
     private static final Pattern LEADING_SPACES = Pattern.compile("^\\s+", Pattern.MULTILINE);
+    private static final Pattern TRAILING_SPACES = Pattern.compile("\\s+$", Pattern.MULTILINE);
     
     @Override
     public final QuestionValidationResponse validateQuestionResponse(final Question question, final Choice answer) {
@@ -134,7 +134,7 @@ public class IsaacStringMatchValidator implements IValidator {
             userValue = userValue.toLowerCase();
         }
         if (null == preserveLeadingWhitespace || !preserveLeadingWhitespace) {
-            // Strip trailing whitespace by default:
+            // Strip leading whitespace by default:
             trustedValue = LEADING_SPACES.matcher(trustedValue).replaceAll("");
             userValue = LEADING_SPACES.matcher(userValue).replaceAll("");
         }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidatorTest.java
@@ -214,6 +214,85 @@ public class IsaacStringMatchValidatorTest {
     }
 
     /*
+   Test that leading whitespace on multiple lines is removed before matching by default.
+*/
+    @Test
+    public final void isaacStringMatchValidator_LeadingSpacesMultiline_CorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacStringMatchQuestion someStringMatchQuestion = new IsaacStringMatchQuestion();
+
+        List<Choice> answerList = Lists.newArrayList();
+        StringChoice someCorrectAnswer = new StringChoice();
+        someCorrectAnswer.setValue("THIS\nIS\nA\nTEST\nMULTILINE\nVALUE");
+        someCorrectAnswer.setCorrect(true);
+        someCorrectAnswer.setCaseInsensitive(true);
+        answerList.add(someCorrectAnswer);
+
+        someStringMatchQuestion.setChoices(answerList);
+
+        // Set up user answer, matches correct but with trailing spaces on each line:
+        StringChoice c = new StringChoice();
+        c.setValue("   THIS\n    IS\n    A\n    TEST\n    MULTILINE\n    VALUE");
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someStringMatchQuestion, c);
+        assertTrue(response.isCorrect());
+    }
+
+    /*
+       Test that leading whitespace on multiple lines is preserved when flag set.
+    */
+    @Test
+    public final void isaacStringMatchValidator_LeadingSpacesMultilinePreserved_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacStringMatchQuestion someStringMatchQuestion = new IsaacStringMatchQuestion();
+        someStringMatchQuestion.setPreserveLeadingWhitespace(true);
+
+        List<Choice> answerList = Lists.newArrayList();
+        StringChoice someCorrectAnswer = new StringChoice();
+        someCorrectAnswer.setValue("THIS\nIS\nA\nTEST\nMULTILINE\nVALUE");
+        someCorrectAnswer.setCorrect(true);
+        someCorrectAnswer.setCaseInsensitive(true);
+        answerList.add(someCorrectAnswer);
+
+        someStringMatchQuestion.setChoices(answerList);
+
+        // Set up user answer, matches correct but with trailing spaces on each line:
+        StringChoice c = new StringChoice();
+        c.setValue("    THIS\n    IS\n    A\n    TEST\n    MULTILINE\n    VALUE");
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someStringMatchQuestion, c);
+        assertFalse(response.isCorrect());
+    }
+
+    /*
+       Test that whitespace stripping does not remove newlines as well.
+    */
+    @Test
+    public final void isaacStringMatchValidator_TrailingSpacesNoNewlines_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacStringMatchQuestion someStringMatchQuestion = new IsaacStringMatchQuestion();
+
+        List<Choice> answerList = Lists.newArrayList();
+        StringChoice someCorrectAnswer = new StringChoice();
+        someCorrectAnswer.setValue("THIS\nIS\nA\nTEST\nMULTILINE\nVALUE");
+        someCorrectAnswer.setCorrect(true);
+        someCorrectAnswer.setCaseInsensitive(true);
+        answerList.add(someCorrectAnswer);
+
+        someStringMatchQuestion.setChoices(answerList);
+
+        // Set up user answer, matches correct but with trailing spaces on each line:
+        StringChoice c = new StringChoice();
+        c.setValue("THISISATESTMULTILINEVALUE");
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someStringMatchQuestion, c);
+        assertFalse(response.isCorrect());
+    }
+
+    /*
        Test that correct case-sensitive match takes priority over case-insensitive correct match.
     */
     @Test


### PR DESCRIPTION
I have reviewed the existing (CS) questions, and I cannot see any where an answer starts with a leading space character (though there are multiple choice and Parsons that do), so this shouldn't break anything. We already trimmed trailing whitespace.
This change trims whitespace from all lines of multi-line input.