### PR TITLE
Prevent ETL from indexing invalid quizzes.

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -216,6 +216,9 @@ public class ContentIndexer {
                                 if (children.stream().anyMatch(c -> !(c instanceof IsaacQuizSection))) {
                                     log.debug("IsaacQuiz (" + flattenedContent.getId()
                                            + ") contains top-level non-quiz sections. Skipping.");
+                                    this.registerContentProblem(flattenedContent, "Index failure - Invalid "
+                                           + "content type among quiz sections. Quizzes can only contain quiz sections "
+                                           + "in the top-level children array.", indexProblemCache);
                                     continue;
                                 }
                             }


### PR DESCRIPTION
If a quiz's top-level children array contains anything that is not an isaacQuizSection, things can unexpectedly break downstream in surprising and confusing ways. This PR mitigates surprise and confusion.

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [ ] Peer-Reviewed
