### PR TITLE
Add audience and display to DOs and DTOs

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/AudienceOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/AudienceOrikaConverter.java
@@ -1,0 +1,30 @@
+package uk.ac.cam.cl.dtg.segue.dao.content;
+
+import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.metadata.Type;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * AudienceOrikaConverter A specialist converter class to work with the Orika automapper library.
+ *
+ * Responsible for converting the intended audience data structure from DO to DTO.
+ * This converter will be adopted by Orika whenever it introspects a conversion between these specific types (not only
+ * for the audience field). Its implementation is generic so that is fine.
+ * It seems ORIKA is not good at converting between highly nested data structures.
+ */
+public class AudienceOrikaConverter
+        extends CustomConverter<List<Map<String, List<String>>>, List<Map<String, List<String>>>> {
+    @Override
+    public List<Map<String, List<String>>> convert(
+            List<Map<String, List<String>>> maps, Type<? extends List<Map<String, List<String>>>> type) {
+        if (maps == null) {return null;}
+
+        // This is horrible to read but it is a deep copy of the data structure - better safe than sorry.
+        return maps.stream().map(m -> m.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().stream().collect(Collectors.toList()))))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
@@ -379,27 +379,13 @@ public class ContentMapper {
             log.info("Creating instance of content auto mapper.");
             MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
 
-            ContentBaseOrikaConverter contentConverter = new ContentBaseOrikaConverter(this);
-            ChoiceOrikaConverter choiceConverter = new ChoiceOrikaConverter();
-            ItemOrikaConverter itemConverter = new ItemOrikaConverter();
-
-            QuestionValidationResponseOrikaConverter questionValidationResponseConverter 
-                = new QuestionValidationResponseOrikaConverter();
-
-            AnonymousUserQuestionAttemptsOrikaConverter anonymousUserOrikaConverter 
-                = new AnonymousUserQuestionAttemptsOrikaConverter();
-
             ConverterFactory converterFactory = mapperFactory.getConverterFactory();
-
-            converterFactory.registerConverter(contentConverter);
-            converterFactory.registerConverter(choiceConverter);
-            converterFactory.registerConverter(itemConverter);
-            converterFactory.registerConverter(questionValidationResponseConverter);
-            converterFactory.registerConverter("anonymousUserAttemptsToDTOConverter", anonymousUserOrikaConverter);
-
-            // special rules
-//            mapperFactory.classMap(AnonymousUser.class, AnonymousUserDTO.class).fieldMap("temporaryQuestionAttempts")
-//                    .converter("anonymousUserAttemptsToDTOConverter").add().byDefault().register();
+            converterFactory.registerConverter(new ContentBaseOrikaConverter(this));
+            converterFactory.registerConverter(new ChoiceOrikaConverter());
+            converterFactory.registerConverter(new ItemOrikaConverter());
+            converterFactory.registerConverter(new QuestionValidationResponseOrikaConverter());
+            converterFactory.registerConverter(new AnonymousUserQuestionAttemptsOrikaConverter());
+            converterFactory.registerConverter(new AudienceOrikaConverter());
 
             this.autoMapper = mapperFactory.getMapperFacade();
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/ContentBase.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/ContentBase.java
@@ -15,10 +15,12 @@
  */
 package uk.ac.cam.cl.dtg.segue.dos.content;
 
-import java.util.Set;
-
-import uk.ac.cam.cl.dtg.segue.dao.TrimWhitespaceDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import uk.ac.cam.cl.dtg.segue.dao.TrimWhitespaceDeserializer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents any content related data that can be stored by the api
@@ -27,12 +29,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * deserialized using a custom serializer (ContentBaseDeserializer).
  */
 public abstract class ContentBase {
-
     protected String id;
     protected String type;
     protected Set<String> tags;
     protected String canonicalSourceFile;
     protected String version;
+    protected List<Map<String, List<String>>> audience;
+    protected Map<String, List<String>> display;
 
     public String getId() {
         return id;
@@ -73,6 +76,22 @@ public abstract class ContentBase {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public List<Map<String, List<String>>> getAudience() {
+        return audience;
+    }
+
+    public void setAudience(List<Map<String, List<String>>> audience) {
+        this.audience = audience;
+    }
+
+    public Map<String, List<String>> getDisplay() {
+        return display;
+    }
+
+    public void setDisplay(Map<String, List<String>> display) {
+        this.display = display;
     }
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/ContentBaseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/ContentBaseDTO.java
@@ -15,14 +15,14 @@
  */
 package uk.ac.cam.cl.dtg.segue.dto.content;
 
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import uk.ac.cam.cl.dtg.segue.dao.TrimWhitespaceDeserializer;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.api.client.util.Sets;
+import uk.ac.cam.cl.dtg.segue.dao.TrimWhitespaceDeserializer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents any content related data that can be stored by the api.
@@ -37,6 +37,8 @@ public abstract class ContentBaseDTO {
     protected Set<String> tags;
     protected String canonicalSourceFile;
     protected String version;
+    protected List<Map<String, List<String>>> audience;
+    protected Map<String, List<String>> display;
 
     /**
      * Default constructor.
@@ -141,6 +143,22 @@ public abstract class ContentBaseDTO {
      */
     public void setVersion(final String version) {
         this.version = version;
+    }
+
+    public List<Map<String, List<String>>> getAudience() {
+        return audience;
+    }
+
+    public void setAudience(List<Map<String, List<String>>> audience) {
+        this.audience = audience;
+    }
+
+    public Map<String, List<String>> getDisplay() {
+        return display;
+    }
+
+    public void setDisplay(Map<String, List<String>> display) {
+        this.display = display;
     }
 
     @Override


### PR DESCRIPTION
Registered a new Orika converter to match the deeply nested audience data structure. Orika correctly uses this converter when dealing with the audience field.

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- ~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~
- [ ] Peer-Reviewed
