### PR TITLE
Improvement/quiz feedback granularity fix

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1031,7 +1031,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group);
 
-            Map<RegisteredUserDTO, QuizFeedbackDTO> feedbackMap = quizQuestionManager.getAssignmentFeedback(quiz, assignment, groupMembers);
+            Map<RegisteredUserDTO, QuizFeedbackDTO> feedbackMap = quizQuestionManager.getAssignmentManagerFeedback(quiz, assignment, groupMembers);
 
             List<QuizUserFeedbackDTO> userFeedback = new ArrayList<>();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1031,7 +1031,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group);
 
-            Map<RegisteredUserDTO, QuizFeedbackDTO> feedbackMap = quizQuestionManager.getAssignmentManagerFeedback(quiz, assignment, groupMembers);
+            Map<RegisteredUserDTO, QuizFeedbackDTO> feedbackMap = quizQuestionManager.getAssignmentTeacherFeedback(quiz, assignment, groupMembers);
 
             List<QuizUserFeedbackDTO> userFeedback = new ArrayList<>();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
@@ -192,7 +192,7 @@ public class QuizQuestionManager {
      * @param users
      *            - the users to get feedback for.
      */
-    public Map<RegisteredUserDTO, QuizFeedbackDTO> getAssignmentManagerFeedback(IsaacQuizDTO quiz, QuizAssignmentDTO assignment, List<RegisteredUserDTO> users) throws ContentManagerException, SegueDatabaseException {
+    public Map<RegisteredUserDTO, QuizFeedbackDTO> getAssignmentTeacherFeedback(IsaacQuizDTO quiz, QuizAssignmentDTO assignment, List<RegisteredUserDTO> users) throws ContentManagerException, SegueDatabaseException {
         Collection<QuestionDTO> questionsToAugment = GameManager.getAllMarkableQuestionPartsDFSOrder(quiz);
         List<IsaacQuizSectionDTO> sections = quizManager.extractSectionObjects(quiz);
         augmentQuizTotals(quiz, questionsToAugment);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
@@ -217,7 +217,7 @@ public class QuizQuestionManager {
 
             // Calculate the scores.
             Map<QuestionDTO, QuestionValidationResponse> answerMap = extractAnswers(questionsToAugment, answers.get(user.getId()));
-            return getIndividualQuizFeedback(sections, assignment.getQuizFeedbackMode(), questionsToAugment, answerMap);
+            return getIndividualQuizFeedback(sections, QuizFeedbackMode.DETAILED_FEEDBACK, questionsToAugment, answerMap);
         }));
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
@@ -192,7 +192,7 @@ public class QuizQuestionManager {
      * @param users
      *            - the users to get feedback for.
      */
-    public Map<RegisteredUserDTO, QuizFeedbackDTO> getAssignmentFeedback(IsaacQuizDTO quiz, QuizAssignmentDTO assignment, List<RegisteredUserDTO> users) throws ContentManagerException, SegueDatabaseException {
+    public Map<RegisteredUserDTO, QuizFeedbackDTO> getAssignmentManagerFeedback(IsaacQuizDTO quiz, QuizAssignmentDTO assignment, List<RegisteredUserDTO> users) throws ContentManagerException, SegueDatabaseException {
         Collection<QuestionDTO> questionsToAugment = GameManager.getAllMarkableQuestionPartsDFSOrder(quiz);
         List<IsaacQuizSectionDTO> sections = quizManager.extractSectionObjects(quiz);
         augmentQuizTotals(quiz, questionsToAugment);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -222,7 +222,7 @@ public class QuizFacadeTest extends AbstractFacadeTest {
             requiresLogin(),
             as(studentsTeachersOrAdmin(),
                 prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignment)).andReturn(studentGroup)),
-                prepare(quizQuestionManager, m -> expect(m.getAssignmentFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
+                prepare(quizQuestionManager, m -> expect(m.getAssignmentManagerFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
                     .andReturn(ImmutableMap.of(student, studentFeedback, secondStudent, otherStudentFeedback))),
                 prepare(associationManager, m -> {
                     expect(m.enforceAuthorisationPrivacy(currentUser(), getUserSummaryFor(student))).andAnswer(grantAccess(true));
@@ -237,7 +237,7 @@ public class QuizFacadeTest extends AbstractFacadeTest {
             forbiddenForEveryoneElse(),
             as(studentsTeachersOrAdmin(),
                 prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignment)).andReturn(studentGroup)),
-                prepare(quizQuestionManager, m -> expect(m.getAssignmentFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
+                prepare(quizQuestionManager, m -> expect(m.getAssignmentManagerFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
                     .andReturn(ImmutableMap.of(student, studentFeedback, secondStudent, otherStudentFeedback))),
                 prepare(associationManager, m -> {
                     expect(m.enforceAuthorisationPrivacy(currentUser(), getUserSummaryFor(student))).andAnswer(grantAccess(true));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -222,7 +222,7 @@ public class QuizFacadeTest extends AbstractFacadeTest {
             requiresLogin(),
             as(studentsTeachersOrAdmin(),
                 prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignment)).andReturn(studentGroup)),
-                prepare(quizQuestionManager, m -> expect(m.getAssignmentManagerFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
+                prepare(quizQuestionManager, m -> expect(m.getAssignmentTeacherFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
                     .andReturn(ImmutableMap.of(student, studentFeedback, secondStudent, otherStudentFeedback))),
                 prepare(associationManager, m -> {
                     expect(m.enforceAuthorisationPrivacy(currentUser(), getUserSummaryFor(student))).andAnswer(grantAccess(true));
@@ -237,7 +237,7 @@ public class QuizFacadeTest extends AbstractFacadeTest {
             forbiddenForEveryoneElse(),
             as(studentsTeachersOrAdmin(),
                 prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignment)).andReturn(studentGroup)),
-                prepare(quizQuestionManager, m -> expect(m.getAssignmentManagerFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
+                prepare(quizQuestionManager, m -> expect(m.getAssignmentTeacherFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
                     .andReturn(ImmutableMap.of(student, studentFeedback, secondStudent, otherStudentFeedback))),
                 prepare(associationManager, m -> {
                     expect(m.enforceAuthorisationPrivacy(currentUser(), getUserSummaryFor(student))).andAnswer(grantAccess(true));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManagerTest.java
@@ -264,7 +264,7 @@ public class QuizQuestionManagerTest extends AbstractManagerTest {
                 entry -> singletonList(entry.getValue()))))
         ));
 
-        Map<RegisteredUserDTO, QuizFeedbackDTO> feedback = quizQuestionManager.getAssignmentFeedback(studentQuiz, studentAssignment, groupMembers);
+        Map<RegisteredUserDTO, QuizFeedbackDTO> feedback = quizQuestionManager.getAssignmentManagerFeedback(studentQuiz, studentAssignment, groupMembers);
 
         assertFalse(feedback.get(secondStudent).isComplete());
         assertStudentMarks(feedback.get(student));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManagerTest.java
@@ -264,7 +264,7 @@ public class QuizQuestionManagerTest extends AbstractManagerTest {
                 entry -> singletonList(entry.getValue()))))
         ));
 
-        Map<RegisteredUserDTO, QuizFeedbackDTO> feedback = quizQuestionManager.getAssignmentManagerFeedback(studentQuiz, studentAssignment, groupMembers);
+        Map<RegisteredUserDTO, QuizFeedbackDTO> feedback = quizQuestionManager.getAssignmentTeacherFeedback(studentQuiz, studentAssignment, groupMembers);
 
         assertFalse(feedback.get(secondStudent).isComplete());
         assertStudentMarks(feedback.get(student));


### PR DESCRIPTION
The teacher and above only `getAssignmentTeacherFeedback` method now always returns the most granular (`QuizFeedbackMode.DETAILED_FEEDBACK`) feedback. This was previously dependent on the quiz assignment feedback mode and hence when that changed the teacher feedback for the assignment didn't have the expected data returned.

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Security - Access Control - Check authorisation on every new endpoint
- [ ] Peer-Reviewed
