### PR TITLE
Upgrade Jetty to 9.4

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -6,7 +6,7 @@ COPY . /isaac-api
 RUN mvn package -Dmaven.test.skip=true
 
 # create clean jetty docker container
-FROM jetty:9.3.29-jre8 as server
+FROM jetty:9.4.42-jre8 as server
 USER root
 COPY --from=target /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-api.war
 RUN chmod 755 /var/lib/jetty/webapps/*

--- a/Dockerfile-etl
+++ b/Dockerfile-etl
@@ -6,7 +6,7 @@ COPY . /isaac-api
 RUN mvn package -Dmaven.test.skip=true -P etl
 
 # create clean jetty docker container
-FROM jetty:9.3.29-jre8 as server
+FROM jetty:9.4.42-jre8 as server
 USER root
 COPY --from=target /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-api.war
 RUN chmod 755 /var/lib/jetty/webapps/*

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <powermock.version>2.0.4</powermock.version>
         <swagger-ui-version>3.19.5</swagger-ui-version>
         <prometheus.version>0.8.0</prometheus.version>
-        <jetty-maven-version>9.3.29.v20201019</jetty-maven-version>
+        <jetty-version>9.4.42.v20210604</jetty-version>
         <jetty.port.api>8080</jetty.port.api>
         <jetty.port.etl>8090</jetty.port.etl>
         <web.xml>override-api-web.xml</web.xml>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
-            <version>${jetty-maven-version}</version>
+            <version>${jetty-version}</version>
         </dependency>
 
         <dependency>
@@ -371,14 +371,14 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>javax-websocket-server-impl</artifactId>
-            <version>9.3.29.v20201019</version>
+            <version>${jetty-version}</version>
         </dependency>
 
         <!--Jetty Websocket API server side dependency -->
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-server</artifactId>
-            <version>9.3.29.v20201019</version>
+            <version>${jetty-version}</version>
         </dependency>
 
         <!-- Graph checker code -->
@@ -472,7 +472,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty-maven-version}</version>
+                <version>${jetty-version}</version>
                 <configuration>
                     <webApp>
                         <contextPath>/isaac-api</contextPath>
@@ -564,7 +564,7 @@
                     <plugin>
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
-                        <version>${jetty-maven-version}</version>
+                        <version>${jetty-version}</version>
                         <configuration>
                             <webApp>
                                 <contextPath>/isaac-api</contextPath>

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -132,19 +132,14 @@ public final class Constants {
 
     // HMAC stuff
     /**
-     * Constant representing the key for the date signed property - used in HMAC calculations.
-     */
-    public static final String DATE_SIGNED = "DATE_SIGNED";
-
-    /**
      * Constant representing the key for the expiry date property - used in HMAC calculations.
      */
-    public static final String DATE_EXPIRES = "DATE_EXPIRES";
+    public static final String DATE_EXPIRES = "expires";
 
     /**
      * Constant representing the key for the additional date property - used in HMAC calculations.
      */
-    public static final String PARTIAL_LOGIN_FLAG = "partialLogin";
+    public static final String PARTIAL_LOGIN_FLAG = "partial";
 
     /**
      * Constant representing the key for the HMAC property - used in HMAC calculations.
@@ -164,7 +159,7 @@ public final class Constants {
     /**
      * Constant representing the key for the SESSION USER ID - used in HMAC calculations.
      */
-    public static final String SESSION_USER_ID = "currentUserId";
+    public static final String SESSION_USER_ID = "id";
 
     /**
      * Constant representing the key for the SESSION TOKEN - used in HMAC calculations.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -1645,10 +1645,11 @@ public class UserAccountManager implements IUserAccountManager {
 
         // no session exists so create one.
         if (request.getSession().getAttribute(ANONYMOUS_USER) == null) {
-            user = new AnonymousUser(request.getSession().getId());
+            String anonymousUserId = getAnonymousUserIdFromRequest(request);
+            user = new AnonymousUser(anonymousUserId);
             user.setDateCreated(new Date());
             // add the user reference to the session
-            request.getSession().setAttribute(ANONYMOUS_USER, user.getSessionId());
+            request.getSession().setAttribute(ANONYMOUS_USER, anonymousUserId);
             this.temporaryUserCache.storeAnonymousUser(user);
 
         } else {
@@ -1671,6 +1672,16 @@ public class UserAccountManager implements IUserAccountManager {
             }
         }
         return user;
+    }
+
+    /**
+     * Hide the Jetty internals of session IDs and return an anonymous user ID.
+     * @param request - to extract the Jetty session ID
+     * @return - a String suitable for use as an anonymous identifier
+     */
+    private String getAnonymousUserIdFromRequest(final HttpServletRequest request) {
+        // TODO - could prepend with API segue version?
+        return request.getSession().getId().replace("node0", "");
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -339,7 +339,7 @@ public class UserAuthenticationManager {
         try {
             currentSessionInformation = this.getSegueSessionFromRequest(request);
         } catch (IOException e1) {
-            log.error("Error parsing session information to retrieve user.");
+            log.debug("Error parsing session information to retrieve user.");
             return null;
         } catch (InvalidSessionException e) {
             log.debug("We cannot read the session information. It probably doesn't exist");
@@ -976,6 +976,10 @@ public class UserAuthenticationManager {
         }
 
         // Check the expiry time has not passed:
+        if (null == sessionDate) {
+            log.debug("No session date provided by cookie, invalid!");
+            return false;
+        }
         Calendar sessionExpiryDate = Calendar.getInstance();
         try {
             sessionExpiryDate.setTime(sessionDateFormat.parse(sessionDate));
@@ -989,7 +993,7 @@ public class UserAuthenticationManager {
 
         // Check no one has tampered with the cookie:
         if (!hasValidHmac(sessionInformation)) {
-            log.debug("Invalid HMAC detected for user id " + userId);
+            log.warn(String.format("Invalid Cookie HMAC detected for user id (%s)!", userId));
             return false;
         }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -931,7 +931,7 @@ public class UserAuthenticationManager {
             Map<String, String> sessionInformation = sessionInformationBuilder.build();
 
             Cookie authCookie = new Cookie(SEGUE_AUTH_COOKIE,
-                    serializationMapper.writeValueAsString(sessionInformation));
+                    Base64.encodeBase64String(serializationMapper.writeValueAsString(sessionInformation).getBytes()));
             authCookie.setMaxAge(sessionExpiryTimeInSeconds);
             authCookie.setPath("/");
             authCookie.setHttpOnly(true);
@@ -1101,7 +1101,7 @@ public class UserAuthenticationManager {
         }
 
         @SuppressWarnings("unchecked")
-        Map<String, String> sessionInformation = this.serializationMapper.readValue(segueAuthCookie.getValue(),
+        Map<String, String> sessionInformation = this.serializationMapper.readValue(Base64.decodeBase64(segueAuthCookie.getValue()),
                 HashMap.class);
 
         return sessionInformation;
@@ -1131,7 +1131,7 @@ public class UserAuthenticationManager {
         }
 
         @SuppressWarnings("unchecked")
-        Map<String, String> sessionInformation = this.serializationMapper.readValue(segueAuthCookie.getValue(),
+        Map<String, String> sessionInformation = this.serializationMapper.readValue(Base64.decodeBase64(segueAuthCookie.getValue()),
                 HashMap.class);
 
         return sessionInformation;

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import ma.glasnost.orika.MapperFacade;
+import org.apache.commons.codec.binary.Base64;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -721,7 +722,7 @@ public class UserManagerTest {
     private Cookie[] getCookieArray(Map<String, String> sessionInformation) throws JsonProcessingException {
         ObjectMapper om = new ObjectMapper();
         Cookie[] cookieWithSessionInfo = { new Cookie(Constants.SEGUE_AUTH_COOKIE,
-                om.writeValueAsString(sessionInformation)) };
+                Base64.encodeBase64String(om.writeValueAsString(sessionInformation).getBytes())) };
         return cookieWithSessionInfo;
     }
 }


### PR DESCRIPTION
Please see the commit messages for a detailed breakdown of the necessary changes made. Note the changes to cookie format necessitated by the upgrade.

On reflection, I think we can actually cope by ignoring the node naming business entirely; it is no different to the current session stuff on multiple APIs, so we can just ignore the `node0` parts and I think it will all still work just fine.
