### PR TITLE
Allow multiple boolean search clauses to be matched against the same field

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/FastTrackManger.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/FastTrackManger.java
@@ -1,5 +1,6 @@
 package uk.ac.cam.cl.dtg.isaac.api.managers;
 
+import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -23,7 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.Maps.immutableEntry;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_GAMEBOARD_WHITELIST;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_LEVEL;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.FAST_TRACK_QUESTION_TYPE;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.QUESTION_TYPE;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.SEARCH_MAX_WINDOW_SIZE;
@@ -34,8 +36,6 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.TAGS_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.TITLE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_GAMEBOARD_WHITELIST;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.FASTTRACK_LEVEL;
 
 public class FastTrackManger {
     private static final Logger log = LoggerFactory.getLogger(FastTrackManger.class);
@@ -127,15 +127,15 @@ public class FastTrackManger {
     ) throws ContentManagerException {
         List<String> stringLevelFilters = levelFilters.stream().map(FASTTRACK_LEVEL::name).collect(Collectors.toList());
 
-        Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMap = Maps.newHashMap();
-        fieldsToMap.put(immutableEntry(
-                Constants.BooleanOperator.OR, TYPE_FIELDNAME), Arrays.asList(QUESTION_TYPE, FAST_TRACK_QUESTION_TYPE));
-        fieldsToMap.put(immutableEntry(
-                Constants.BooleanOperator.AND, TITLE_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX), Collections.singletonList(conceptTitle));
-        fieldsToMap.put(immutableEntry(
-                Constants.BooleanOperator.AND, TAGS_FIELDNAME), Collections.singletonList(boardTag));
-        fieldsToMap.put(immutableEntry(
-                Constants.BooleanOperator.OR, TAGS_FIELDNAME), stringLevelFilters);
+        List<IContentManager.BooleanSearchClause> fieldsToMap = Lists.newArrayList();
+        fieldsToMap.add(new IContentManager.BooleanSearchClause(
+                TYPE_FIELDNAME, Constants.BooleanOperator.OR, Arrays.asList(QUESTION_TYPE, FAST_TRACK_QUESTION_TYPE)));
+        fieldsToMap.add(new IContentManager.BooleanSearchClause(
+                TITLE_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, Constants.BooleanOperator.AND, Collections.singletonList(conceptTitle)));
+        fieldsToMap.add(new IContentManager.BooleanSearchClause(
+                TAGS_FIELDNAME, Constants.BooleanOperator.AND, Collections.singletonList(boardTag)));
+        fieldsToMap.add(new IContentManager.BooleanSearchClause(
+                TAGS_FIELDNAME, Constants.BooleanOperator.OR, stringLevelFilters));
 
         Map<String, Constants.SortOrder> sortInstructions = Maps.newHashMap();
         sortInstructions.put(ID_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX, Constants.SortOrder.ASC);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
@@ -15,7 +15,7 @@
  */
 package uk.ac.cam.cl.dtg.isaac.api.managers;
 
-import com.google.api.client.util.Maps;
+import com.google.api.client.util.Lists;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.slf4j.Logger;
@@ -47,7 +47,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.google.common.collect.Maps.immutableEntry;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.QUIZ_TYPE;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
@@ -97,11 +96,13 @@ public class QuizManager {
 
     public ResultsWrapper<ContentSummaryDTO> getAvailableQuizzes(boolean onlyVisibleToStudents, @Nullable Integer startIndex, @Nullable Integer limit) throws ContentManagerException {
 
-        Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch = Maps.newHashMap();
-        fieldsToMatch.put(immutableEntry(Constants.BooleanOperator.AND, TYPE_FIELDNAME), Collections.singletonList(QUIZ_TYPE));
+        List<IContentManager.BooleanSearchClause> fieldsToMatch = Lists.newArrayList();
+        fieldsToMatch.add(new IContentManager.BooleanSearchClause(
+                TYPE_FIELDNAME, Constants.BooleanOperator.AND, Collections.singletonList(QUIZ_TYPE)));
 
         if (onlyVisibleToStudents) {
-            fieldsToMatch.put(immutableEntry(Constants.BooleanOperator.AND, VISIBLE_TO_STUDENTS_FIELDNAME), Collections.singletonList(Boolean.toString(true)));
+            fieldsToMatch.add(new IContentManager.BooleanSearchClause(
+                    VISIBLE_TO_STUDENTS_FIELDNAME, Constants.BooleanOperator.AND, Collections.singletonList(Boolean.toString(true))));
         }
 
         ResultsWrapper<ContentDTO> content = this.contentService.findMatchingContent(null, fieldsToMatch, startIndex, limit);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -15,10 +15,36 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dao;
 
-import static com.google.common.collect.Maps.immutableEntry;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.FAST_TRACK_QUESTION_TYPE;
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.QUESTION_TYPE;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.Sets;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import ma.glasnost.orika.MapperFacade;
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.api.managers.URIManager;
+import uk.ac.cam.cl.dtg.isaac.dos.GameboardCreationMethod;
+import uk.ac.cam.cl.dtg.isaac.dos.GameboardDO;
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacWildcard;
+import uk.ac.cam.cl.dtg.isaac.dto.GameFilter;
+import uk.ac.cam.cl.dtg.isaac.dto.GameboardDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.GameboardItem;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
+import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
+import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 
 import java.io.IOException;
 import java.sql.Array;
@@ -39,39 +65,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Maps;
-import com.google.inject.name.Named;
-import ma.glasnost.orika.MapperFacade;
-
-import org.apache.commons.lang3.Validate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import uk.ac.cam.cl.dtg.isaac.api.managers.URIManager;
-import uk.ac.cam.cl.dtg.isaac.dos.GameboardCreationMethod;
-import uk.ac.cam.cl.dtg.isaac.dos.GameboardDO;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacWildcard;
-import uk.ac.cam.cl.dtg.isaac.dto.GameFilter;
-import uk.ac.cam.cl.dtg.isaac.dto.GameboardDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.GameboardItem;
-import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
-import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
-import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
-import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
-import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
-import com.google.api.client.util.Sets;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.inject.Inject;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.FAST_TRACK_QUESTION_TYPE;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.QUESTION_TYPE;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
 
 /**
  * This class is responsible for managing and persisting user data.
@@ -410,14 +407,13 @@ public class GameboardPersistenceManager {
 		GameboardDO gameboardDO = this.convertToGameboardDO(gameboardDTO);
 		
 		// build query the db to get full question information
-		Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMap = Maps.newHashMap();
+        List<IContentManager.BooleanSearchClause> fieldsToMap = com.google.api.client.util.Lists.newArrayList();
 
-        fieldsToMap.put(
-                immutableEntry(Constants.BooleanOperator.OR, Constants.ID_FIELDNAME + '.'
-                        + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX), gameboardDO.getQuestions());
+        fieldsToMap.add(new IContentManager.BooleanSearchClause(
+            Constants.ID_FIELDNAME + '.' + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX, Constants.BooleanOperator.OR, gameboardDO.getQuestions()));
 
-        fieldsToMap.put(immutableEntry(Constants.BooleanOperator.OR, Constants.TYPE_FIELDNAME),
-                Arrays.asList(QUESTION_TYPE, FAST_TRACK_QUESTION_TYPE));
+        fieldsToMap.add(new IContentManager.BooleanSearchClause(
+                TYPE_FIELDNAME, Constants.BooleanOperator.OR, Arrays.asList(QUESTION_TYPE, FAST_TRACK_QUESTION_TYPE)));
 
         // Search for questions that match the ids.       
         ResultsWrapper<ContentDTO> results;
@@ -708,13 +704,13 @@ public class GameboardPersistenceManager {
 		List<List<String>> questionIdBatches = Lists.partition(questionIds, GAMEBOARD_ITEM_MAP_BATCH_SIZE);
 		for (List<String> questionIdBatch : questionIdBatches) {
 			// build query the db to get full question information
-			Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMap = Maps.newHashMap();
-			fieldsToMap.put(
-					immutableEntry(Constants.BooleanOperator.OR, Constants.ID_FIELDNAME + '.'
-							+ Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX), questionIdBatch);
+            List<IContentManager.BooleanSearchClause> fieldsToMap = Lists.newArrayList();
+            fieldsToMap.add(new IContentManager.BooleanSearchClause(
+                    Constants.ID_FIELDNAME + '.' + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX,
+                    Constants.BooleanOperator.OR, questionIdBatch));
 
-			fieldsToMap.put(immutableEntry(Constants.BooleanOperator.OR, Constants.TYPE_FIELDNAME),
-					Arrays.asList(QUESTION_TYPE, FAST_TRACK_QUESTION_TYPE));
+			fieldsToMap.add(new IContentManager.BooleanSearchClause(
+			        TYPE_FIELDNAME, Constants.BooleanOperator.OR, Arrays.asList(QUESTION_TYPE, FAST_TRACK_QUESTION_TYPE)));
 
 			// Search for questions that match the ids.
 			ResultsWrapper<ContentDTO> results;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -407,7 +407,7 @@ public class GameboardPersistenceManager {
 		GameboardDO gameboardDO = this.convertToGameboardDO(gameboardDTO);
 		
 		// build query the db to get full question information
-        List<IContentManager.BooleanSearchClause> fieldsToMap = com.google.api.client.util.Lists.newArrayList();
+        List<IContentManager.BooleanSearchClause> fieldsToMap = Lists.newArrayList();
 
         fieldsToMap.add(new IContentManager.BooleanSearchClause(
             Constants.ID_FIELDNAME + '.' + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX, Constants.BooleanOperator.OR, gameboardDO.getQuestions()));

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -214,10 +214,8 @@ public final class Constants {
      * 
      */
     public enum BooleanOperator {
-        AND, OR, NOT, NESTED_AND, NESTED_OR, NESTED_NOT
+        AND, OR, NOT
     };
-    public static Set<BooleanOperator> NestedBooleanOperators =
-            ImmutableSet.of(BooleanOperator.NESTED_AND, BooleanOperator.NESTED_OR, BooleanOperator.NESTED_NOT);
 
     public static final String SCHOOLS_INDEX_BASE = "schools";
     public enum SCHOOLS_INDEX_TYPE {
@@ -422,8 +420,6 @@ public final class Constants {
     public static final String DIFFICULTY_FIELDNAME = "audience.difficulty";
     public static final String EXAM_BOARD_FIELDNAME = "audience.examBoard";
     public static final Set<String> NESTED_FIELDS =
-            // NOTE: if you are adding a nested field name that does not have the nested path audience, you will
-            // need to alter (at least) generateBoolMatchQuery to be a little smarter - possible, though
             ImmutableSet.of(STAGE_FIELDNAME, DIFFICULTY_FIELDNAME, EXAM_BOARD_FIELDNAME);
 
     public static final String USER_ID_FKEY_FIELDNAME = "userId";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
@@ -16,7 +16,7 @@
 
 package uk.ac.cam.cl.dtg.segue.api;
 
-import com.google.api.client.util.Maps;
+import com.google.api.client.util.Lists;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.swagger.annotations.Api;
@@ -42,10 +42,11 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-import static com.google.common.collect.Maps.immutableEntry;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.BooleanOperator;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_RESULTS_LIMIT;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
 
 /**
  * Glossary Facade
@@ -91,8 +92,9 @@ public class GlossaryFacade extends AbstractSegueFacade {
     public final Response getTerms(@QueryParam("start_index") final String startIndex,
                                    @QueryParam("limit") final String limit) {
 
-        Map<Map.Entry<BooleanOperator, String>, List<String>> fieldsToMatch = Maps.newHashMap();
-        fieldsToMatch.put(immutableEntry(BooleanOperator.AND, TYPE_FIELDNAME), Collections.singletonList("glossaryTerm"));
+        List<IContentManager.BooleanSearchClause> fieldsToMatch = Lists.newArrayList();
+        fieldsToMatch.add(new IContentManager.BooleanSearchClause(
+                TYPE_FIELDNAME, BooleanOperator.AND, Collections.singletonList("glossaryTerm")));
 
         ResultsWrapper<ContentDTO> c;
         try {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueContentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueContentFacade.java
@@ -49,7 +49,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_RESULTS_LIMIT;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.NUMBER_SECONDS_IN_ONE_DAY;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.NUMBER_SECONDS_IN_ONE_HOUR;
 
 /**
  * Segue Content Facade
@@ -102,8 +105,7 @@ public class SegueContentFacade extends AbstractSegueFacade {
      * @param version
      *            - the version of the content to search. If null it will default to the current live version.
      * @param fieldsToMatch
-     *            - Map representing fieldName -> field value mappings to search for. Note: tags is a special field name
-     *            and the list will be split by commas.
+     *            - List of Boolean search clauses that must be true for the returned content.
      * @param startIndex
      *            - the start index for the search results.
      * @param limit
@@ -111,7 +113,7 @@ public class SegueContentFacade extends AbstractSegueFacade {
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
     public final ResultsWrapper<ContentDTO> findMatchingContent(final String version,
-            final Map<Map.Entry<BooleanOperator, String>, List<String>> fieldsToMatch,
+            final List<IContentManager.BooleanSearchClause> fieldsToMatch,
             @Nullable final Integer startIndex, @Nullable final Integer limit) throws ContentManagerException {
 
         return contentService.findMatchingContent(version, fieldsToMatch, startIndex, limit);
@@ -121,14 +123,13 @@ public class SegueContentFacade extends AbstractSegueFacade {
      * This method will return a ResultsWrapper<ContentDTO> based on the parameters supplied. Providing the results in a
      * randomised order.
      * 
-     * This method is the same as {@link #findMatchingContentRandomOrder(String, Map, Integer, Integer, Long)} but uses
+     * This method is the same as {@link #findMatchingContentRandomOrder(String, List, Integer, Integer, Long)} but uses
      * a default random seed.
      * 
      * @param version
      *            - the version of the content to search. If null it will default to the current live version.
      * @param fieldsToMatch
-     *            - Map representing fieldName -> field value mappings to search for. Note: tags is a special field name
-     *            and the list will be split by commas.
+     *            - List of Boolean search clauses that must be true for the returned content.
      * @param startIndex
      *            - the start index for the search results.
      * @param limit
@@ -136,8 +137,7 @@ public class SegueContentFacade extends AbstractSegueFacade {
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
     public final ResultsWrapper<ContentDTO> findMatchingContentRandomOrder(@Nullable final String version,
-            final Map<Map.Entry<BooleanOperator, String>, List<String>> fieldsToMatch, final Integer startIndex,
-            final Integer limit) {
+                                                                           final List<IContentManager.BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit) {
         return this.findMatchingContentRandomOrder(version, fieldsToMatch, startIndex, limit, null);
     }
 
@@ -148,8 +148,7 @@ public class SegueContentFacade extends AbstractSegueFacade {
      * @param version
      *            - the version of the content to search. If null it will default to the current live version.
      * @param fieldsToMatch
-     *            - Map representing fieldName -> field value mappings to search for. Note: tags is a special field name
-     *            and the list will be split by commas.
+     *            - List of Boolean search clauses that must be true for the returned content.
      * @param startIndex
      *            - the start index for the search results.
      * @param limit
@@ -159,8 +158,8 @@ public class SegueContentFacade extends AbstractSegueFacade {
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
     public final ResultsWrapper<ContentDTO> findMatchingContentRandomOrder(@Nullable final String version,
-            final Map<Map.Entry<BooleanOperator, String>, List<String>> fieldsToMatch, final Integer startIndex,
-            final Integer limit, final Long randomSeed) {
+                                                                           final List<IContentManager.BooleanSearchClause> fieldsToMatch, final Integer startIndex,
+                                                                           final Integer limit, final Long randomSeed) {
 
         String newVersion = this.contentIndex;
         Integer newLimit = DEFAULT_RESULTS_LIMIT;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueContentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueContentFacade.java
@@ -136,8 +136,9 @@ public class SegueContentFacade extends AbstractSegueFacade {
      *            - the max number of results to return.
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
-    public final ResultsWrapper<ContentDTO> findMatchingContentRandomOrder(@Nullable final String version,
-                                                                           final List<IContentManager.BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit) {
+    public final ResultsWrapper<ContentDTO> findMatchingContentRandomOrder(
+            @Nullable final String version, final List<IContentManager.BooleanSearchClause> fieldsToMatch,
+            final Integer startIndex, final Integer limit) {
         return this.findMatchingContentRandomOrder(version, fieldsToMatch, startIndex, limit, null);
     }
 
@@ -157,9 +158,9 @@ public class SegueContentFacade extends AbstractSegueFacade {
      *            - to allow some control over the random order of the results.
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
-    public final ResultsWrapper<ContentDTO> findMatchingContentRandomOrder(@Nullable final String version,
-                                                                           final List<IContentManager.BooleanSearchClause> fieldsToMatch, final Integer startIndex,
-                                                                           final Integer limit, final Long randomSeed) {
+    public final ResultsWrapper<ContentDTO> findMatchingContentRandomOrder(
+            @Nullable final String version, final List<IContentManager.BooleanSearchClause> fieldsToMatch,
+            final Integer startIndex, final Integer limit, final Long randomSeed) {
 
         String newVersion = this.contentIndex;
         Integer newLimit = DEFAULT_RESULTS_LIMIT;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/NotificationPicker.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/NotificationPicker.java
@@ -15,19 +15,9 @@
  */
 package uk.ac.cam.cl.dtg.segue.api.managers;
 
-import static com.google.common.collect.Maps.immutableEntry;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
-
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
 import com.google.inject.Inject;
-
 import com.google.inject.name.Named;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.api.Constants.BooleanOperator;
@@ -35,14 +25,23 @@ import uk.ac.cam.cl.dtg.segue.dao.ResourceNotFoundException;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
-import uk.ac.cam.cl.dtg.segue.dos.PgUserNotifications;
 import uk.ac.cam.cl.dtg.segue.dos.IUserNotification;
 import uk.ac.cam.cl.dtg.segue.dos.IUserNotification.NotificationStatus;
 import uk.ac.cam.cl.dtg.segue.dos.IUserNotifications;
+import uk.ac.cam.cl.dtg.segue.dos.PgUserNotifications;
 import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.dto.content.NotificationDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
+
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
 
 /**
  * This class is responsible for selecting notifications from various sources so that users can be told about them.
@@ -81,12 +80,9 @@ public class NotificationPicker {
     public List<ContentDTO> getAvailableNotificationsForUser(final RegisteredUserDTO user)
             throws ContentManagerException, SegueDatabaseException {
         // get users notification record
-        Map<Entry<BooleanOperator, String>, List<String>> fieldsToMatch = Maps.newHashMap();
-        List<String> newArrayList = Lists.newArrayList();
-
-        newArrayList.add("notification");
-
-        fieldsToMatch.put(immutableEntry(BooleanOperator.AND, Constants.TYPE_FIELDNAME), newArrayList);
+        List<IContentManager.BooleanSearchClause> fieldsToMatch = Lists.newArrayList();
+        fieldsToMatch.add(new IContentManager.BooleanSearchClause(
+                TYPE_FIELDNAME, BooleanOperator.AND, Collections.singletonList("notification")));
 
         ResultsWrapper<ContentDTO> allContentNotifications = this.contentManager
                 .findByFieldNames(this.contentIndex, fieldsToMatch, 0, -1);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
@@ -15,7 +15,7 @@
  */
 package uk.ac.cam.cl.dtg.segue.api.services;
 
-import com.google.api.client.util.Maps;
+import com.google.api.client.util.Lists;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.immutableEntry;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.ID_FIELDNAME;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.NESTED_FIELDS;
@@ -48,14 +47,13 @@ public class ContentService {
      * This method will return a ResultsWrapper<ContentDTO> based on the parameters supplied.
      *
      * @param version       - the version of the content to search. If null it will default to the current live version.
-     * @param fieldsToMatch - Map representing fieldName -> field value mappings to search for. Note: tags is a special field name
-     *                      and the list will be split by commas.
+     * @param fieldsToMatch - List of Boolean search clauses that must be true for the returned content.
      * @param startIndex    - the start index for the search results.
      * @param limit         - the max number of results to return.
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
     public final ResultsWrapper<ContentDTO> findMatchingContent(final String version,
-                                                                final Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch,
+                                                                final List<IContentManager.BooleanSearchClause> fieldsToMatch,
                                                                 @Nullable final Integer startIndex, @Nullable final Integer limit) throws ContentManagerException {
 
         String newVersion = this.contentIndex;
@@ -117,26 +115,27 @@ public class ContentService {
      *
      * @param fieldsToMatch
      *            - expects a map of the form fieldname -> list of queries to match
-     * @return A map ready to be passed to a content provider
+     * @return A list of boolean search clauses to be passed to a content provider
      */
-    public static Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> generateDefaultFieldToMatch(
-        final Map<String, List<String>> fieldsToMatch) {
-        Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatchOutput = Maps.newHashMap();
+    public static List<IContentManager.BooleanSearchClause> generateDefaultFieldToMatch(final Map<String, List<String>> fieldsToMatch) {
+        List<IContentManager.BooleanSearchClause> fieldsToMatchOutput = Lists.newArrayList();
 
         for (Map.Entry<String, List<String>> pair : fieldsToMatch.entrySet()) {
-            Map.Entry<Constants.BooleanOperator, String> newEntry;
             if (pair.getKey().equals(ID_FIELDNAME)) {
-                newEntry = immutableEntry(Constants.BooleanOperator.OR, pair.getKey());
+                fieldsToMatchOutput.add(new IContentManager.BooleanSearchClause(
+                        pair.getKey(), Constants.BooleanOperator.OR, pair.getValue()));
+
             } else if (pair.getKey().equals(TYPE_FIELDNAME) && pair.getValue().size() > 1) {
                 // special case of when you want to allow more than one
-                newEntry = immutableEntry(Constants.BooleanOperator.OR, pair.getKey());
-            } else if (NESTED_FIELDS.contains(pair.getKey())) {
-                newEntry = immutableEntry(Constants.BooleanOperator.NESTED_OR, pair.getKey());
+                fieldsToMatchOutput.add(new IContentManager.BooleanSearchClause(
+                        pair.getKey(), Constants.BooleanOperator.OR, pair.getValue()));
+            } else if (NESTED_FIELDS.contains(pair.getKey())) { // these should match if either are true
+                fieldsToMatchOutput.add(new IContentManager.BooleanSearchClause(
+                        pair.getKey(), Constants.BooleanOperator.OR, pair.getValue()));
             } else {
-                newEntry = immutableEntry(Constants.BooleanOperator.AND, pair.getKey());
+                fieldsToMatchOutput.add(new IContentManager.BooleanSearchClause(
+                        pair.getKey(), Constants.BooleanOperator.AND, pair.getValue()));
             }
-
-            fieldsToMatchOutput.put(newEntry, pair.getValue());
         }
 
         return fieldsToMatchOutput;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
@@ -52,9 +52,10 @@ public class ContentService {
      * @param limit         - the max number of results to return.
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
-    public final ResultsWrapper<ContentDTO> findMatchingContent(final String version,
-                                                                final List<IContentManager.BooleanSearchClause> fieldsToMatch,
-                                                                @Nullable final Integer startIndex, @Nullable final Integer limit) throws ContentManagerException {
+    public final ResultsWrapper<ContentDTO> findMatchingContent(
+            final String version, final List<IContentManager.BooleanSearchClause> fieldsToMatch,
+            @Nullable final Integer startIndex, @Nullable final Integer limit
+    ) throws ContentManagerException {
 
         String newVersion = this.contentIndex;
         Integer newLimit = Constants.DEFAULT_RESULTS_LIMIT;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -349,26 +349,24 @@ public class GitContentManager implements IContentManager {
 
     @Override
     public final ResultsWrapper<ContentDTO> findByFieldNames(final String version,
-            final Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch,
-            final Integer startIndex, final Integer limit) throws ContentManagerException {
+                                                             final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit)
+            throws ContentManagerException {
 
         return this.findByFieldNames(version, fieldsToMatch, startIndex, limit, null);
     }
 
     @Override
     public final ResultsWrapper<ContentDTO> findByFieldNames(final String version,
-            final Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch,
-            final Integer startIndex, final Integer limit,
-            @Nullable final Map<String, Constants.SortOrder> sortInstructions) throws ContentManagerException {
+                                                             final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit,
+                                                             @Nullable final Map<String, Constants.SortOrder> sortInstructions) throws ContentManagerException {
         return this.findByFieldNames(version, fieldsToMatch, startIndex, limit, sortInstructions, null);
     }
 
     @Override
     public final ResultsWrapper<ContentDTO> findByFieldNames(final String version,
-            final Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch,
-            final Integer startIndex, final Integer limit,
-            @Nullable final Map<String, Constants.SortOrder> sortInstructions,
-            @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws ContentManagerException {
+                                                             final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit,
+                                                             @Nullable final Map<String, Constants.SortOrder> sortInstructions,
+                                                             @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws ContentManagerException {
         ResultsWrapper<ContentDTO> finalResults;
 
         final Map<String, Constants.SortOrder> newSortInstructions;
@@ -405,15 +403,15 @@ public class GitContentManager implements IContentManager {
 
     @Override
     public final ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(final String version,
-            final Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch,
-            final Integer startIndex, final Integer limit) throws ContentManagerException {
+                                                                        final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit)
+            throws ContentManagerException {
         return this.findByFieldNamesRandomOrder(version, fieldsToMatch, startIndex, limit, null);
     }
 
     @Override
     public final ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(final String version,
-            final Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch,
-            final Integer startIndex, final Integer limit, final Long randomSeed) throws ContentManagerException {
+                                                                        final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit, final Long randomSeed)
+    throws ContentManagerException {
         ResultsWrapper<ContentDTO> finalResults;
 
         ResultsWrapper<String> searchHits;
@@ -564,17 +562,16 @@ public class GitContentManager implements IContentManager {
         }
 
         // build query the db to get full content information
-        Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMap
-            = new HashMap<>();
+        List<BooleanSearchClause> fieldsToMap = Lists.newArrayList();
 
         List<String> relatedContentIds = Lists.newArrayList();
         for (ContentSummaryDTO summary : contentDTO.getRelatedContent()) {
             relatedContentIds.add(summary.getId());
         }
 
-        fieldsToMap.put(
-                Maps.immutableEntry(Constants.BooleanOperator.OR, Constants.ID_FIELDNAME + '.'
-                        + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX), relatedContentIds);
+        fieldsToMap.add(new BooleanSearchClause(
+                Constants.ID_FIELDNAME + '.' + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX,
+                Constants.BooleanOperator.OR, relatedContentIds));
 
         ResultsWrapper<ContentDTO> results = this.findByFieldNames(version, fieldsToMap, 0, relatedContentIds.size());
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -348,25 +348,27 @@ public class GitContentManager implements IContentManager {
     }
 
     @Override
-    public final ResultsWrapper<ContentDTO> findByFieldNames(final String version,
-                                                             final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit)
-            throws ContentManagerException {
-
+    public final ResultsWrapper<ContentDTO> findByFieldNames(
+            final String version, final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex,
+            final Integer limit
+    ) throws ContentManagerException {
         return this.findByFieldNames(version, fieldsToMatch, startIndex, limit, null);
     }
 
     @Override
-    public final ResultsWrapper<ContentDTO> findByFieldNames(final String version,
-                                                             final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit,
-                                                             @Nullable final Map<String, Constants.SortOrder> sortInstructions) throws ContentManagerException {
+    public final ResultsWrapper<ContentDTO> findByFieldNames(
+            final String version, final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex,
+            final Integer limit, @Nullable final Map<String, Constants.SortOrder> sortInstructions
+    ) throws ContentManagerException {
         return this.findByFieldNames(version, fieldsToMatch, startIndex, limit, sortInstructions, null);
     }
 
     @Override
-    public final ResultsWrapper<ContentDTO> findByFieldNames(final String version,
-                                                             final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit,
-                                                             @Nullable final Map<String, Constants.SortOrder> sortInstructions,
-                                                             @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws ContentManagerException {
+    public final ResultsWrapper<ContentDTO> findByFieldNames(
+            final String version, final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex,
+            final Integer limit, @Nullable final Map<String, Constants.SortOrder> sortInstructions,
+            @Nullable final Map<String, AbstractFilterInstruction> filterInstructions
+    ) throws ContentManagerException {
         ResultsWrapper<ContentDTO> finalResults;
 
         final Map<String, Constants.SortOrder> newSortInstructions;
@@ -402,16 +404,18 @@ public class GitContentManager implements IContentManager {
     }
 
     @Override
-    public final ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(final String version,
-                                                                        final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit)
-            throws ContentManagerException {
+    public final ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(
+            final String version, final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex,
+            final Integer limit
+    ) throws ContentManagerException {
         return this.findByFieldNamesRandomOrder(version, fieldsToMatch, startIndex, limit, null);
     }
 
     @Override
-    public final ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(final String version,
-                                                                        final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex, final Integer limit, final Long randomSeed)
-    throws ContentManagerException {
+    public final ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(
+            final String version, final List<BooleanSearchClause> fieldsToMatch, final Integer startIndex,
+            final Integer limit, final Long randomSeed
+    ) throws ContentManagerException {
         ResultsWrapper<ContentDTO> finalResults;
 
         ResultsWrapper<String> searchHits;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/IContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/IContentManager.java
@@ -143,9 +143,9 @@ public interface IContentManager {
      * @throws ContentManagerException
      *             - if there is an error retrieving the content requested.
      */
-    ResultsWrapper<ContentDTO> findByFieldNames(String version,
-                                                final List<BooleanSearchClause> fieldsToMatch, Integer startIndex,
-                                                Integer limit) throws ContentManagerException;
+    ResultsWrapper<ContentDTO> findByFieldNames(
+            String version, final List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit
+    ) throws ContentManagerException;
 
     /**
      * Method to allow bulk search of content based on the type field.
@@ -164,9 +164,10 @@ public interface IContentManager {
      * @throws ContentManagerException
      *             - if there is an error retrieving the content requested.
      */
-    ResultsWrapper<ContentDTO> findByFieldNames(String version,
-                                                List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit,
-                                                Map<String, SortOrder> sortInstructions) throws ContentManagerException;
+    ResultsWrapper<ContentDTO> findByFieldNames(
+            String version, List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit,
+            Map<String, SortOrder> sortInstructions
+    ) throws ContentManagerException;
 
     /**
      * Method to allow bulk search of content based on the type field.
@@ -187,10 +188,10 @@ public interface IContentManager {
      * @throws ContentManagerException
      *             - if there is an error retrieving the content requested.
      */
-    ResultsWrapper<ContentDTO> findByFieldNames(String version,
-                                                List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit,
-                                                Map<String, SortOrder> sortInstructions,
-                                                @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws ContentManagerException;
+    ResultsWrapper<ContentDTO> findByFieldNames(
+            String version, List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit,
+            Map<String, SortOrder> sortInstructions, @Nullable final Map<String, AbstractFilterInstruction> filterInstructions
+    ) throws ContentManagerException;
 
     /**
      * The same as findByFieldNames but the results list is returned in a randomised order.
@@ -207,8 +208,9 @@ public interface IContentManager {
      * @throws ContentManagerException
      *             - if there is an error retrieving the content requested.
      */
-    ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(String version,
-                                                           List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit) throws ContentManagerException;
+    ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(
+            String version, List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit
+    ) throws ContentManagerException;
 
     /**
      * The same as findByFieldNames but the results list is returned in a randomised order.
@@ -227,9 +229,9 @@ public interface IContentManager {
      * @throws ContentManagerException
      *             - if there is an error retrieving the content requested.
      */
-    ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(String version,
-                                                           List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit,
-                                                           @Nullable Long randomSeed) throws ContentManagerException;
+    ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(
+            String version, List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit, @Nullable Long randomSeed
+    ) throws ContentManagerException;
 
     /**
      * Allows fullText search using the internal search provider.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/IContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/IContentManager.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.content;
 
-import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.api.Constants.BooleanOperator;
 import uk.ac.cam.cl.dtg.segue.api.Constants.SortOrder;
 import uk.ac.cam.cl.dtg.segue.dos.content.Content;
@@ -30,7 +29,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 /**
@@ -39,6 +37,26 @@ import java.util.Set;
  * @author Stephen Cummins
  */
 public interface IContentManager {
+
+    class BooleanSearchClause {
+        private String field;
+        private BooleanOperator operator;
+        private List<String> values;
+        public BooleanSearchClause(final String field, final BooleanOperator operator, final List<String> values) {
+            this.field = field;
+            this.operator = operator;
+            this.values = values;
+        }
+        public String getField() {
+            return this.field;
+        }
+        public BooleanOperator getOperator() {
+            return this.operator;
+        }
+        public List<String> getValues() {
+            return this.values;
+        }
+    }
 
     /**
      * Goes to the configured Database and attempts to find a content item with the specified ID. This returns the
@@ -116,7 +134,7 @@ public interface IContentManager {
      * @param version
      *            - version of the content to search.
      * @param fieldsToMatch
-     *            - Map which is used for field matching.
+     *            - List of boolean clauses used for field matching.
      * @param startIndex
      *            - the index of the first item to return.
      * @param limit
@@ -126,8 +144,8 @@ public interface IContentManager {
      *             - if there is an error retrieving the content requested.
      */
     ResultsWrapper<ContentDTO> findByFieldNames(String version,
-            final Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch, Integer startIndex,
-            Integer limit) throws ContentManagerException;
+                                                final List<BooleanSearchClause> fieldsToMatch, Integer startIndex,
+                                                Integer limit) throws ContentManagerException;
 
     /**
      * Method to allow bulk search of content based on the type field.
@@ -135,7 +153,7 @@ public interface IContentManager {
      * @param version
      *            - version of the content to search.
      * @param fieldsToMatch
-     *            - Map which is used for field matching.
+     *            - List of boolean clauses used for field matching.
      * @param startIndex
      *            - the index of the first item to return.
      * @param limit
@@ -147,8 +165,8 @@ public interface IContentManager {
      *             - if there is an error retrieving the content requested.
      */
     ResultsWrapper<ContentDTO> findByFieldNames(String version,
-            Map<Entry<BooleanOperator, String>, List<String>> fieldsToMatch, Integer startIndex, Integer limit,
-            Map<String, SortOrder> sortInstructions) throws ContentManagerException;
+                                                List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit,
+                                                Map<String, SortOrder> sortInstructions) throws ContentManagerException;
 
     /**
      * Method to allow bulk search of content based on the type field.
@@ -156,7 +174,7 @@ public interface IContentManager {
      * @param version
      *            - version of the content to search.
      * @param fieldsToMatch
-     *            - Map which is used for field matching.
+     *            - List of boolean clauses used for field matching.
      * @param startIndex
      *            - the index of the first item to return.
      * @param limit
@@ -170,9 +188,9 @@ public interface IContentManager {
      *             - if there is an error retrieving the content requested.
      */
     ResultsWrapper<ContentDTO> findByFieldNames(String version,
-            Map<Entry<BooleanOperator, String>, List<String>> fieldsToMatch, Integer startIndex, Integer limit,
-            Map<String, SortOrder> sortInstructions,
-            @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws ContentManagerException;
+                                                List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit,
+                                                Map<String, SortOrder> sortInstructions,
+                                                @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws ContentManagerException;
 
     /**
      * The same as findByFieldNames but the results list is returned in a randomised order.
@@ -180,7 +198,7 @@ public interface IContentManager {
      * @param version
      *            - version of the content to search.
      * @param fieldsToMatch
-     *            - Map which is used for field matching.
+     *            - List of boolean clauses used for field matching.
      * @param startIndex
      *            - the index of the first item to return.
      * @param limit
@@ -190,8 +208,7 @@ public interface IContentManager {
      *             - if there is an error retrieving the content requested.
      */
     ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(String version,
-            Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch, Integer startIndex,
-            Integer limit) throws ContentManagerException;
+                                                           List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit) throws ContentManagerException;
 
     /**
      * The same as findByFieldNames but the results list is returned in a randomised order.
@@ -199,7 +216,7 @@ public interface IContentManager {
      * @param version
      *            - version of the content to search.
      * @param fieldsToMatch
-     *            - Map which is used for field matching.
+     *            - List of boolean clauses used for field matching.
      * @param startIndex
      *            - the index of the first item to return.
      * @param limit
@@ -211,8 +228,8 @@ public interface IContentManager {
      *             - if there is an error retrieving the content requested.
      */
     ResultsWrapper<ContentDTO> findByFieldNamesRandomOrder(String version,
-            Map<Entry<BooleanOperator, String>, List<String>> fieldsToMatch, Integer startIndex, Integer limit,
-            @Nullable Long randomSeed) throws ContentManagerException;
+                                                           List<BooleanSearchClause> fieldsToMatch, Integer startIndex, Integer limit,
+                                                           @Nullable Long randomSeed) throws ContentManagerException;
 
     /**
      * Allows fullText search using the internal search provider.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
@@ -429,12 +429,10 @@ public class ElasticSearchProvider implements ISearchProvider {
             // Each search clause is its own boolean query that gets added to the master query as a must match clause
             BoolQueryBuilder query = QueryBuilders.boolQuery();
 
-            boolean atLeastOneShouldMatch = false;
             // Add the clause to the query value by value
             for (String value : searchClause.getValues()) {
                 if (Constants.BooleanOperator.OR.equals(searchClause.getOperator())) {
                     query.should(QueryBuilders.matchQuery(searchClause.getField(), value));
-                    atLeastOneShouldMatch = true;
                 } else if (Constants.BooleanOperator.AND.equals(searchClause.getOperator())) {
                     query.must(QueryBuilders.matchQuery(searchClause.getField(), value));
                 } else if (Constants.BooleanOperator.NOT.equals(searchClause.getOperator())) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
@@ -444,7 +444,7 @@ public class ElasticSearchProvider implements ISearchProvider {
             }
 
             // The way we're using this query, if we have a "should" the document needs to match at least one of the options.
-            if (atLeastOneShouldMatch) {
+            if (Constants.BooleanOperator.OR.equals(searchClause.getOperator())) {
                 query.minimumShouldMatch(1);
             }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
@@ -18,7 +18,7 @@ package uk.ac.cam.cl.dtg.segue.search;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.api.Constants.BooleanOperator;
+import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
 import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
 
 import javax.annotation.Nullable;
@@ -26,7 +26,6 @@ import javax.validation.constraints.NotNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * Interface describing behaviour of search providers.
@@ -71,9 +70,9 @@ public interface ISearchProvider {
      * @return Results
      */
     ResultsWrapper<String> matchSearch(final String indexBase, final String indexType,
-            final Map<Map.Entry<Constants.BooleanOperator, String>, List<String>> fieldsToMatch, final int startIndex,
-            final int limit, final Map<String, Constants.SortOrder> sortInstructions,
-            @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+                                       final List<IContentManager.BooleanSearchClause> fieldsToMatch, final int startIndex, final int limit,
+                                       final Map<String, Constants.SortOrder> sortInstructions,
+                                       @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
 
     /**
      * Executes a fuzzy search on an array of fields and will consider the fieldsThatMustMatchMap.
@@ -143,7 +142,7 @@ public interface ISearchProvider {
      * @param indexType
      *            - type of index as registered with search provider.
      * @param fieldsToMatch
-     *            - Map of Map<Map.Entry<Constants.BooleanOperator, String>, List<String>>
+     *            - List of boolean clauses used for field matching.
      * @param startIndex
      *            - start index for results
      * @param limit
@@ -155,8 +154,8 @@ public interface ISearchProvider {
      * @return results in a random order for a given match search.
      */
     ResultsWrapper<String> randomisedMatchSearch(String indexBase, String indexType,
-            Map<Entry<BooleanOperator, String>, List<String>> fieldsToMatch, 
-            int startIndex, int limit, Long randomSeed, Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+                                                 List<IContentManager.BooleanSearchClause> fieldsToMatch, int startIndex, int limit, Long randomSeed,
+                                                 Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
 
     /**
      * Query for a list of Results that exactly match a given id.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
@@ -69,10 +69,12 @@ public interface ISearchProvider {
      *            - the map of how to sort each field of interest.
      * @return Results
      */
-    ResultsWrapper<String> matchSearch(final String indexBase, final String indexType,
-                                       final List<IContentManager.BooleanSearchClause> fieldsToMatch, final int startIndex, final int limit,
-                                       final Map<String, Constants.SortOrder> sortInstructions,
-                                       @Nullable final Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+    ResultsWrapper<String> matchSearch(
+            final String indexBase, final String indexType,
+            final List<IContentManager.BooleanSearchClause> fieldsToMatch, final int startIndex, final int limit,
+            final Map<String, Constants.SortOrder> sortInstructions,
+            @Nullable final Map<String, AbstractFilterInstruction> filterInstructions
+    ) throws SegueSearchException;
 
     /**
      * Executes a fuzzy search on an array of fields and will consider the fieldsThatMustMatchMap.
@@ -97,10 +99,12 @@ public interface ISearchProvider {
      *            - array (var args) of fields to search using the searchString
      * @return results
      */
-    ResultsWrapper<String> fuzzySearch(final String indexBase, final String indexType, final String searchString,
+    ResultsWrapper<String> fuzzySearch(
+            final String indexBase, final String indexType, final String searchString,
             final Integer startIndex, final Integer limit, final Map<String, List<String>> fieldsThatMustMatch,
-                                       @Nullable final Map<String, AbstractFilterInstruction> filterInstructions,
-                                       final String... fields) throws SegueSearchException;
+            @Nullable final Map<String, AbstractFilterInstruction> filterInstructions,
+            final String... fields
+    ) throws SegueSearchException;
 
     public ResultsWrapper<String> nestedMatchSearch(
             final String indexBase, final String indexType, final Integer startIndex, final Integer limit,
@@ -130,9 +134,10 @@ public interface ISearchProvider {
      * @param filterInstructions - instructions for filtering the results
      * @return results
      */
-    ResultsWrapper<String> termSearch(final String indexBase, final String indexType, final String searchterms,
-                                      final String field, final int startIndex, final int limit,
-                                      final Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+    ResultsWrapper<String> termSearch(
+            final String indexBase, final String indexType, final String searchterms, final String field,
+            final int startIndex, final int limit, final Map<String, AbstractFilterInstruction> filterInstructions
+    ) throws SegueSearchException;
 
     /**
      * RandomisedPaginatedMatchSearch The same as paginatedMatchSearch but the results are returned in a random order.
@@ -153,9 +158,10 @@ public interface ISearchProvider {
      *            - post search filter instructions e.g. remove content of a certain type.
      * @return results in a random order for a given match search.
      */
-    ResultsWrapper<String> randomisedMatchSearch(String indexBase, String indexType,
-                                                 List<IContentManager.BooleanSearchClause> fieldsToMatch, int startIndex, int limit, Long randomSeed,
-                                                 Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+    ResultsWrapper<String> randomisedMatchSearch(
+            String indexBase, String indexType, List<IContentManager.BooleanSearchClause> fieldsToMatch,
+            int startIndex, int limit, Long randomSeed, Map<String, AbstractFilterInstruction> filterInstructions
+    ) throws SegueSearchException;
 
     /**
      * Query for a list of Results that exactly match a given id.
@@ -176,8 +182,10 @@ public interface ISearchProvider {
      *            - post search filter instructions e.g. remove content of a certain type.
      * @return A list of results that match the id prefix.
      */
-    ResultsWrapper<String> findByExactMatch(String indexBase, String indexType, String fieldname, String needle,
-                                            int startIndex, int limit, @Nullable Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+    ResultsWrapper<String> findByExactMatch(
+            String indexBase, String indexType, String fieldname, String needle, int startIndex, int limit,
+            @Nullable Map<String, AbstractFilterInstruction> filterInstructions
+    ) throws SegueSearchException;
 
     /**
      * Query for a list of Results that match a given id prefix.
@@ -200,8 +208,10 @@ public interface ISearchProvider {
      *            - post search filter instructions e.g. remove content of a certain type.
      * @return A list of results that match the id prefix.
      */
-    ResultsWrapper<String> findByPrefix(String indexBase, String indexType, String fieldname, String prefix,
-            int startIndex, int limit, @Nullable Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+    ResultsWrapper<String> findByPrefix(
+            String indexBase, String indexType, String fieldname, String prefix, int startIndex, int limit,
+            @Nullable Map<String, AbstractFilterInstruction> filterInstructions
+    ) throws SegueSearchException;
     
     /**
      * Find content by a regex.
@@ -222,8 +232,10 @@ public interface ISearchProvider {
      *            - post search filter instructions e.g. remove content of a certain type.
      * @return A list of results that match the id prefix.
      */
-    ResultsWrapper<String> findByRegEx(String indexBase, String indexType, String fieldname, String regex, int startIndex,
-            int limit, @Nullable Map<String, AbstractFilterInstruction> filterInstructions) throws SegueSearchException;
+    ResultsWrapper<String> findByRegEx(
+            String indexBase, String indexType, String fieldname, String regex, int startIndex, int limit,
+            @Nullable Map<String, AbstractFilterInstruction> filterInstructions
+    ) throws SegueSearchException;
 
     /*
      * TODO: We need to change the return type of these two methods to avoid having ES specific things


### PR DESCRIPTION
To get the question filter to match questions with "statics" or "dynamics" and  of type "problem_solving" or "books" we need two separate boolean clauses on the "tags" field.
To achieve this I created a BooleanSearchClause record class (rather than including a tuples library) and told ElasticSearchProvider how to construct a bool match query from a list of these records.
That method is a lot more straightforward now and even the nested queries can be simplified by only treating them differently just before adding the clause to the master query.
I then followed the compiler's complaints to update the fieldsToMatch data structure to the new list of BooleanSearchClauses.

It would have been slightly nicer to review if I would have remembered to commit between the refactoring and the fixing of generateBoolMatchQuery, sorry!

I have tested our major routes to search content quite thoroughly and as the logic is now easier to comprehend I'm confident it is correct.
During the transforming of the clause data structure, the only section of work that was not checked by the compiler was making sure the correct boolean operator was copied over - I have manually double checked those and they are fine.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
