### PR TITLE
Upgrade Orika to version 1.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>ma.glasnost.orika</groupId>
             <artifactId>orika-core</artifactId>
-            <version>1.4.5</version>
+            <version>1.5.4</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/AudienceOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/AudienceOrikaConverter.java
@@ -1,6 +1,7 @@
 package uk.ac.cam.cl.dtg.segue.dao.content;
 
 import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.metadata.Type;
 
 import java.util.List;
@@ -17,9 +18,11 @@ import java.util.stream.Collectors;
  */
 public class AudienceOrikaConverter
         extends CustomConverter<List<Map<String, List<String>>>, List<Map<String, List<String>>>> {
+
     @Override
     public List<Map<String, List<String>>> convert(
-            List<Map<String, List<String>>> maps, Type<? extends List<Map<String, List<String>>>> type) {
+            List<Map<String, List<String>>> maps, Type<? extends List<Map<String, List<String>>>> type,
+            MappingContext _context) {
         if (maps == null) {return null;}
 
         // This is horrible to read but it is a deep copy of the data structure - better safe than sorry.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceOrikaConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.content;
 
+import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.metadata.Type;
 import uk.ac.cam.cl.dtg.segue.dos.content.ChemicalFormula;
@@ -55,7 +56,8 @@ public class ChoiceOrikaConverter extends BidirectionalConverter<Choice, ChoiceD
     }
 
     @Override
-    public ChoiceDTO convertTo(final Choice source, final Type<ChoiceDTO> destinationType) {
+    public ChoiceDTO convertTo(final Choice source, final Type<ChoiceDTO> destinationType,
+                               MappingContext _context) {
         if (null == source) {
             return null;
         }
@@ -88,7 +90,8 @@ public class ChoiceOrikaConverter extends BidirectionalConverter<Choice, ChoiceD
     }
 
     @Override
-    public Choice convertFrom(final ChoiceDTO source, final Type<Choice> destinationType) {
+    public Choice convertFrom(final ChoiceDTO source, final Type<Choice> destinationType,
+                              MappingContext _context) {
         if (null == source) {
             return null;
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseOrikaConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,15 +15,15 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.content;
 
+import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.metadata.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import uk.ac.cam.cl.dtg.segue.dos.content.Content;
 import uk.ac.cam.cl.dtg.segue.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
-import ma.glasnost.orika.CustomConverter;
-import ma.glasnost.orika.metadata.Type;
 
 /**
  * ContentBaseOrikaConverter A specialist converter class to work with the Orika automapper library.
@@ -47,7 +47,8 @@ public class ContentBaseOrikaConverter extends CustomConverter<ContentBase, Cont
     }
 
     @Override
-    public ContentBaseDTO convert(final ContentBase source, final Type<? extends ContentBaseDTO> destinationType) {
+    public ContentBaseDTO convert(final ContentBase source, final Type<? extends ContentBaseDTO> destinationType,
+                                  MappingContext _context) {
 
         if (null == source) {
             return null;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ItemOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ItemOrikaConverter.java
@@ -15,6 +15,7 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.content;
 
+import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.metadata.Type;
 import uk.ac.cam.cl.dtg.segue.dos.content.Item;
@@ -37,7 +38,7 @@ public class ItemOrikaConverter extends BidirectionalConverter<Item, ItemDTO> {
     }
 
     @Override
-    public ItemDTO convertTo(final Item source, final Type<ItemDTO> destinationType) {
+    public ItemDTO convertTo(final Item source, final Type<ItemDTO> destinationType, MappingContext _context) {
         if (null == source) {
             return null;
         }
@@ -53,7 +54,7 @@ public class ItemOrikaConverter extends BidirectionalConverter<Item, ItemDTO> {
     }
 
     @Override
-    public Item convertFrom(final ItemDTO source, final Type<Item> destinationType) {
+    public Item convertFrom(final ItemDTO source, final Type<Item> destinationType, MappingContext _context) {
         if (null == source) {
             return null;
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/AnonymousUserQuestionAttemptsOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/AnonymousUserQuestionAttemptsOrikaConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,16 +15,16 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.users;
 
-import java.util.List;
-import java.util.Map;
-
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
-
+import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.metadata.Type;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
-import ma.glasnost.orika.CustomConverter;
-import ma.glasnost.orika.metadata.Type;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * AnonymousQuestionAttemptsOrikaConverter A specialist converter class to work with the Orika automapper library.
@@ -48,7 +48,8 @@ public class AnonymousUserQuestionAttemptsOrikaConverter
     @Override
     public Map<String, Map<String, List<QuestionValidationResponseDTO>>> convert(
             final Map<String, Map<String, List<QuestionValidationResponse>>> source,
-            final Type<? extends Map<String, Map<String, List<QuestionValidationResponseDTO>>>> destinationType) {
+            final Type<? extends Map<String, Map<String, List<QuestionValidationResponseDTO>>>> destinationType,
+            MappingContext _context) {
         // convert in one direction
         if (null == source) {
             return null;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,12 +15,13 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.users;
 
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.converter.BidirectionalConverter;
+import ma.glasnost.orika.metadata.Type;
 import uk.ac.cam.cl.dtg.segue.dos.QuantityValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dto.QuantityValidationResponseDTO;
 import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
-import ma.glasnost.orika.converter.BidirectionalConverter;
-import ma.glasnost.orika.metadata.Type;
 
 /**
  * QuestionValidationResponseOrikaConverter A specialist converter class to work with the Orika automapper library.
@@ -41,7 +42,8 @@ public class QuestionValidationResponseOrikaConverter extends
 
     @Override
     public QuestionValidationResponseDTO convertTo(final QuestionValidationResponse source,
-            final Type<QuestionValidationResponseDTO> destinationType) {
+                                                   final Type<QuestionValidationResponseDTO> destinationType,
+                                                   MappingContext _context) {
         if (null == source) {
             return null;
         }
@@ -59,7 +61,8 @@ public class QuestionValidationResponseOrikaConverter extends
 
     @Override
     public QuestionValidationResponse convertFrom(final QuestionValidationResponseDTO source,
-            final Type<QuestionValidationResponse> destinationType) {
+                                                  final Type<QuestionValidationResponse> destinationType,
+                                                  MappingContext _context) {
         if (null == source) {
             return null;
         }


### PR DESCRIPTION
This is an attempt to fix the issues with the mappers not initialising themselves correctly. The conversion methods now take an extra argument which is not well documented; it _seems_ to be safe to ignore it as I have done here, but I am not sure how safe this is.

I had *a lot* of trouble with IntelliJ and Java not being able to build an complaining about the new method signatures, but Maven being fine with them when Maven triggered the build and not IntelliJ. So I did "File" -> "Invalidate caches" in IntelliJ, restarted and it stopped warning me about them. Try this only after attemping to run it first, and it will only be a problem if you had the `1.4.5` version of Orika somewhere on the classpath before.