### PR TITLE
Add default feedback for questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
@@ -129,6 +129,12 @@ public class IsaacFreeTextValidator implements IValidator {
                 log.error("QuestionId: " + question.getId() + " contains a choice which is not a FreeTextRule.");
             }
         }
+
+        // If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != freeTextQuestion.getDefaultFeedback()) {
+            feedback = freeTextQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), answer, isCorrectResponse, feedback, new Date());
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherValidator.java
@@ -121,6 +121,11 @@ public class IsaacGraphSketcherValidator implements IValidator, ISpecifier {
             }
         }
 
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != graphSketcherQuestion.getDefaultFeedback()) {
+            feedback = graphSketcherQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
@@ -130,6 +130,11 @@ public class IsaacItemQuestionValidator implements IValidator {
             }
         }
 
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != itemQuestion.getDefaultFeedback()) {
+            feedback = itemQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidator.java
@@ -162,6 +162,11 @@ public class IsaacParsonsValidator implements IValidator {
             }
         }
 
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != parsonsQuestion.getDefaultFeedback()) {
+            feedback = parsonsQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
@@ -119,6 +119,11 @@ public class IsaacStringMatchValidator implements IValidator {
             }
         }
 
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != stringMatchQuestion.getDefaultFeedback()) {
+            feedback = stringMatchQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), userAnswer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -399,6 +399,10 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
             }
         }
 
+        // STEP 5: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != chemistryQuestion.getDefaultFeedback()) {
+            feedback = chemistryQuestion.getDefaultFeedback();
+        }
         return new QuestionValidationResponse(chemistryQuestion.getId(), answer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
@@ -257,6 +257,11 @@ public class IsaacSymbolicLogicValidator implements IValidator {
             }
         }
 
+        // STEP 4: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != symbolicLogicQuestion.getDefaultFeedback()) {
+            feedback = symbolicLogicQuestion.getDefaultFeedback();
+        }
+
         // If we got this far and feedback is still null, they were wrong. There's no useful feedback we can give at this point.
 
         return new FormulaValidationResponse(symbolicLogicQuestion.getId(), answer, feedback, responseCorrect, responseMatchType.toString(), new Date());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
@@ -265,6 +265,11 @@ public class IsaacSymbolicValidator implements IValidator {
             }
         }
 
+        // STEP 4: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != symbolicQuestion.getDefaultFeedback()) {
+            feedback = symbolicQuestion.getDefaultFeedback();
+        }
+
         // If we got this far and feedback is still null, they were wrong. There's no useful feedback we can give at this point.
 
         return new FormulaValidationResponse(symbolicQuestion.getId(), answer, feedback, responseCorrect, responseMatchType.toString(), new Date());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/Question.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/Question.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,9 +19,8 @@ import java.util.List;
 import uk.ac.cam.cl.dtg.segue.dto.content.QuestionDTO;
 
 /**
- * Choice object The choice object is a specialized form of content and allows the storage of data relating to possible
- * answers to questions.
- * 
+ * Base class for all question types.
+ *
  */
 @DTOMapping(QuestionDTO.class)
 @JsonContentType("question")
@@ -29,6 +28,7 @@ public class Question extends Content {
 
     protected ContentBase answer;
     protected List<ContentBase> hints;
+    protected Content defaultFeedback;
 
 
     public Question() {
@@ -71,6 +71,25 @@ public class Question extends Content {
      */
     public final void setHints(final List<ContentBase> hints) {
         this.hints = hints;
+    }
+
+    /**
+     * Gets the default feedback to be used when no other feedback is generated..
+     *
+     * @return the defaultFeedback
+     */
+    public final Content getDefaultFeedback() {
+        return defaultFeedback;
+    }
+
+    /**
+     * Sets the default feedback to be used when no other feedback is generated.
+     *
+     * @param defaultFeedback
+     *            the defaultFeedback to set
+     */
+    public final void setDefaultFeedback(final Content defaultFeedback) {
+        this.defaultFeedback = defaultFeedback;
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +16,18 @@
 package uk.ac.cam.cl.dtg.segue.dto.content;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
 
 import java.util.List;
 
-import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
-
 /**
- * Choice object The choice object is a specialized form of content and allows the storage of data relating to possible
- * answers to questions.
+ * Base class for all question types.
  * 
  */
 public class QuestionDTO extends ContentDTO {
     protected ContentBaseDTO answer;
     protected List<ContentBaseDTO> hints;
+    protected ContentDTO defaultFeedback;
 
     // Set if the user is logged in and we have information.
     protected QuestionValidationResponseDTO bestAttempt;
@@ -78,6 +77,25 @@ public class QuestionDTO extends ContentDTO {
      */
     public void setHints(final List<ContentBaseDTO> hints) {
         this.hints = hints;
+    }
+
+    /**
+     * Gets the default feedback to be used when no other feedback is generated..
+     *
+     * @return the defaultFeedback
+     */
+    public final ContentDTO getDefaultFeedback() {
+        return defaultFeedback;
+    }
+
+    /**
+     * Sets the default feedback to be used when no other feedback is generated.
+     *
+     * @param defaultFeedback
+     *            the defaultFeedback to set
+     */
+    public final void setDefaultFeedback(final ContentDTO defaultFeedback) {
+        this.defaultFeedback = defaultFeedback;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/ChoiceQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/ChoiceQuestionValidator.java
@@ -41,8 +41,11 @@ public class ChoiceQuestionValidator implements IValidator {
         Validate.notNull(question);
         Validate.notNull(answer);
 
-        // check that the question is of type ChoiceQuestion before we go ahead
         ChoiceQuestion choiceQuestion;
+        // These variables store the important features of the response we'll send.
+        Content feedback = null;                        // The feedback we send the user
+        boolean responseCorrect = false;                // Whether we're right or wrong
+        // check that the question is of type ChoiceQuestion before we go ahead
         if (question instanceof ChoiceQuestion) {
             choiceQuestion = (ChoiceQuestion) question;
 
@@ -54,16 +57,21 @@ public class ChoiceQuestionValidator implements IValidator {
 
             for (Choice choice : choiceQuestion.getChoices()) {
                 if (choice.getValue().equals(answer.getValue())) {
-                    
-                    return new QuestionValidationResponse(question.getId(), answer, choice.isCorrect(),
-                            (Content) choice.getExplanation(), new Date());
+                    responseCorrect = choice.isCorrect();
+                    feedback = (Content) choice.getExplanation();
+                    break;
                 }
             }
 
             log.info("Unable to find choice for question ( " + question.getId() + " ) matching the answer supplied ("
-                    + answer + "). Returning that it is incorrect with out an explanation.");
+                    + answer + "). Returning that it is incorrect without an explanation.");
 
-            return new QuestionValidationResponse(question.getId(), answer, false, null, new Date());
+            // If we still have no feedback to give, use the question's default feedback if any to use:
+            if (feedbackIsNullOrEmpty(feedback) && null != choiceQuestion.getDefaultFeedback()) {
+                feedback = choiceQuestion.getDefaultFeedback();
+            }
+
+            return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
         } else {
             log.error("Expected to be able to cast the question as a ChoiceQuestion " + "but this cast failed.");
             throw new ClassCastException("Incorrect type of question received. Unable to validate.");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/ChoiceQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/ChoiceQuestionValidator.java
@@ -63,8 +63,11 @@ public class ChoiceQuestionValidator implements IValidator {
                 }
             }
 
-            log.info("Unable to find choice for question ( " + question.getId() + " ) matching the answer supplied ("
-                    + answer + "). Returning that it is incorrect without an explanation.");
+            if (null == feedback) {
+                // This should not happen for multiple choice questions.
+                log.warn("Unable to find choice for question ( " + question.getId() + " ) matching the answer supplied ("
+                        + answer.getValue() + ")!");
+            }
 
             // If we still have no feedback to give, use the question's default feedback if any to use:
             if (feedbackIsNullOrEmpty(feedback) && null != choiceQuestion.getDefaultFeedback()) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/IValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/IValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dos.content.Choice;
+import uk.ac.cam.cl.dtg.segue.dos.content.Content;
 import uk.ac.cam.cl.dtg.segue.dos.content.Question;
 
 import java.io.IOException;
@@ -118,5 +119,20 @@ public interface IValidator {
         HashMap<String, Object> response = mapper.readValue(responseString, HashMap.class);
 
         return response;
+    }
+
+    /**
+     *  Check if a feedback content object contains no meaningful feedback.
+     *
+     * @param feedback - content object to test
+     * @return whether the content object is empty
+     */
+    default boolean feedbackIsNullOrEmpty(final Content feedback) {
+        if (null == feedback) {
+            return true;
+        }
+        boolean valueEmpty = null == feedback.getValue() || feedback.getValue().isEmpty();
+        boolean childrenEmpty = null == feedback.getChildren() || feedback.getChildren().isEmpty();
+        return valueEmpty && childrenEmpty;
     }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -395,6 +395,34 @@ public class IsaacNumericValidatorTest {
         assertTrue(response_1sf.getExplanation().getTags().contains("sig_figs"));
     }
 
+    /*
+        Test default feedback is used when a known answer is matched and no explanation given.
+    */
+    @Test
+    public final void isaacNumericValidator_DefaultFeedbackAndCorrectNoExplanation_DefaultFeedbackReturned() {
+        // Set up the question object:
+        IsaacNumericQuestion someNumericQuestion = new IsaacNumericQuestion();
+        someNumericQuestion.setRequireUnits(false);
+        Content defaultFeedback = new Content("DEFAULT FEEDBACK!");
+        someNumericQuestion.setDefaultFeedback(defaultFeedback);
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity someCorrectAnswer = new Quantity("10");
+        someCorrectAnswer.setCorrect(true);
+        answerList.add(someCorrectAnswer);
+
+        someNumericQuestion.setChoices(answerList);
+
+        // Set up user answer:
+        Quantity q = new Quantity("10");
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someNumericQuestion, q);
+
+        assertTrue(response.isCorrect());
+        assertEquals(response.getExplanation(), defaultFeedback);
+    }
+
     //  ---------- Tests from here test invalid questions themselves ----------
 
     /*


### PR DESCRIPTION
Default feedback content can be specified for all question types and it will be used by validators that opt to use it whenever no other explanation feedback is generated. It is up to each validator to decide if and how to use it, since there are many types of existing blanket feedback and it may want to vary in specificity between question types (i.e. should it override sig fig error message, what about warnings about inbalanced chemical equations?).

I have implemented it for all existing question types, and it will be used for all of these when the explanation is null or contains no content (the latter is needed since the editor adds empty content for all choice explanations). This means that the default feedback will be used when no choice is matched, and also when a choice is matched but it has no explanation text. This means it can be used for correct choices and incorrect choices freely, but also be trivially overriden for any specific choice if desired.
Numeric questions have a more complicated validator structure than any other validator (the rest often offload the complicated parts to external validators), and so it needed its own method to check the response object and not just the feedback content object, but it works in much the same way.

I considered making the QuestionManager replace the empty feedback, but that doesn't work with e.g. the usual "Check your units" response from numeric questions, etc, and so whilst this method can't guarantee a validator will use the feedback, it does offer the greatest possible flexibility.