### PR TITLE
Item question feedback - added API support for matching subsets of an item choice

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
@@ -15,6 +15,8 @@
  */
 package uk.ac.cam.cl.dtg.isaac.quiz;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,12 +90,17 @@ public class IsaacItemQuestionValidator implements IValidator {
             if (!allowedItemIds.containsAll(submittedItemIds)) {
                 feedback = new Content("You did not provide a valid answer; it contained unrecognised items");
             }
+            if (submittedItemIds.size() != submittedChoice.getItems().size()) {
+                feedback = new Content("You did not provide a valid answer; it contained duplicate items");
+            }
         }
 
         // STEP 2: If they did, does their answer match a known answer?
 
         if (null == feedback && null != submittedItemIds) {
-            // Sort the choices so that we match incorrect choices last, taking precedence over correct ones.
+            /* Sort the choices so that we match incorrect choices last, taking precedence over correct ones, and
+               so that strict (entire set) match choices take precedence over subset match choices.
+             */
             List<Choice> orderedChoices = getOrderedChoices(itemQuestion.getChoices());
 
             // For all the choices on this question...
@@ -116,12 +123,22 @@ public class IsaacItemQuestionValidator implements IValidator {
                 }
 
                 // ... look for a match to the submitted answer:
-                if (itemChoice.getItems().size() != submittedChoice.getItems().size()) {
-                    continue;
-                }
+
                 Set<String> choiceItemIds = itemChoice.getItems().stream().map(Item::getId).collect(Collectors.toSet());
 
-                if (choiceItemIds.equals(submittedItemIds)) {
+                // Do not allow subset matching by default
+                boolean allowSubsetMatch = (null != itemChoice.isAllowSubsetMatch() && itemChoice.isAllowSubsetMatch());
+
+                /* If the intersection of the submitted and choice ids is equal to the submitted ones, then
+                   this means that:
+                    - submittedItemIds.size() <= choiceItemIds.size()
+                    - All submitted ids are within the set of choice ids
+                 */
+                if (allowSubsetMatch && Sets.intersection(submittedItemIds, choiceItemIds) == submittedItemIds) {
+                    responseCorrect = itemChoice.isCorrect();
+                    feedback = (Content) itemChoice.getExplanation();
+                    break;
+                } else if (choiceItemIds.size() == submittedItemIds.size() && choiceItemIds.equals(submittedItemIds)) {
                     // This is safe from duplication issues, since the list lengths are the same too.
                     responseCorrect = itemChoice.isCorrect();
                     feedback = (Content) itemChoice.getExplanation();
@@ -131,6 +148,48 @@ public class IsaacItemQuestionValidator implements IValidator {
         }
 
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
+    }
+
+    @Override
+    public List<Choice> getOrderedChoices(final List<Choice> choices) {
+        List<Choice> orderedChoices = Lists.newArrayList(choices);
+
+        /* First sort by whether subset matching is allowed or not - 'strict' match
+           item choices will appear before subset match ones.
+           Any Choices that are not ItemChoices will be ordered after 'strict' match
+           item choices.
+           Choices without a null value for allowSubsetMatch are considered 'strict'
+           for the ordering.
+         */
+        orderedChoices.sort((o1, o2) -> {
+            int o1Val = 1, o2Val = 1;
+            Boolean subsetMatch;
+            if (o1 instanceof ItemChoice) {
+                subsetMatch = ((ItemChoice) o1).isAllowSubsetMatch();
+                o1Val = (null != subsetMatch && subsetMatch) ? 1 : 0;
+            }
+            if (o2 instanceof ItemChoice) {
+                subsetMatch = ((ItemChoice) o2).isAllowSubsetMatch();
+                o2Val = (null != subsetMatch && subsetMatch) ? 1 : 0;
+            }
+            return o1Val - o2Val;
+        });
+
+        // Then sort in order of correctness
+        orderedChoices.sort((o1, o2) -> {
+            int o1Val = o1.isCorrect() ? 0 : 1;
+            int o2Val = o2.isCorrect() ? 0 : 1;
+            return o1Val - o2Val;
+        });
+
+        /* This should leave us with the following ordering:
+            0 Correct strict
+            1 Incorrect strict
+            2 Correct subset match
+            3 Incorrect subset match
+         */
+
+        return orderedChoices;
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
@@ -162,7 +162,8 @@ public class IsaacItemQuestionValidator implements IValidator {
            for the ordering.
          */
         orderedChoices.sort((o1, o2) -> {
-            int o1Val = 1, o2Val = 1;
+            int o1Val = 1;
+            int o2Val = 1;
             Boolean subsetMatch;
             if (o1 instanceof ItemChoice) {
                 subsetMatch = ((ItemChoice) o1).isAllowSubsetMatch();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
@@ -134,7 +134,7 @@ public class IsaacItemQuestionValidator implements IValidator {
                     - submittedItemIds.size() <= choiceItemIds.size()
                     - All submitted ids are within the set of choice ids
                  */
-                if (allowSubsetMatch && Sets.intersection(submittedItemIds, choiceItemIds) == submittedItemIds) {
+                if (allowSubsetMatch && Sets.intersection(submittedItemIds, choiceItemIds).equals(submittedItemIds)) {
                     responseCorrect = itemChoice.isCorrect();
                     feedback = (Content) itemChoice.getExplanation();
                     break;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
@@ -129,12 +129,12 @@ public class IsaacItemQuestionValidator implements IValidator {
                 // Do not allow subset matching by default
                 boolean allowSubsetMatch = (null != itemChoice.isAllowSubsetMatch() && itemChoice.isAllowSubsetMatch());
 
-                /* If the intersection of the submitted and choice ids is equal to the submitted ones, then
+                /* If the intersection of the submitted and choice ids is equal to the choice ones, then
                    this means that:
-                    - submittedItemIds.size() <= choiceItemIds.size()
-                    - All submitted ids are within the set of choice ids
+                    - choiceItemIds.size() <= submittedItemIds.size()
+                    - All choice ids are within the set of submitted ids
                  */
-                if (allowSubsetMatch && Sets.intersection(submittedItemIds, choiceItemIds).equals(submittedItemIds)) {
+                if (allowSubsetMatch && Sets.intersection(submittedItemIds, choiceItemIds).equals(choiceItemIds)) {
                     responseCorrect = itemChoice.isCorrect();
                     feedback = (Content) itemChoice.getExplanation();
                     break;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/ItemChoice.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/ItemChoice.java
@@ -44,7 +44,11 @@ public class ItemChoice extends Choice {
         this.items = items;
     }
 
-    public Boolean isAllowSubsetMatch() { return this.allowSubsetMatch; }
+    public Boolean isAllowSubsetMatch() {
+        return this.allowSubsetMatch;
+    }
 
-    public void setAllowSubsetMatch(final boolean allowSubsetMatch) { this.allowSubsetMatch = allowSubsetMatch; }
+    public void setAllowSubsetMatch(final boolean allowSubsetMatch) {
+        this.allowSubsetMatch = allowSubsetMatch;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/ItemChoice.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/ItemChoice.java
@@ -27,6 +27,7 @@ import java.util.List;
 @JsonContentType("itemChoice")
 public class ItemChoice extends Choice {
 
+    private Boolean allowSubsetMatch;
     private List<Item> items;
 
     /**
@@ -42,4 +43,8 @@ public class ItemChoice extends Choice {
     public void setItems(final List<Item> items) {
         this.items = items;
     }
+
+    public Boolean isAllowSubsetMatch() { return this.allowSubsetMatch; }
+
+    public void setAllowSubsetMatch(final boolean allowSubsetMatch) { this.allowSubsetMatch = allowSubsetMatch; }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/ItemChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/ItemChoiceDTO.java
@@ -23,6 +23,7 @@ import java.util.List;
  */
 public class ItemChoiceDTO extends ChoiceDTO {
 
+    private Boolean allowSubsetMatch;
     private List<ItemDTO> items;
 
     /**
@@ -39,4 +40,7 @@ public class ItemChoiceDTO extends ChoiceDTO {
         this.items = items;
     }
 
+    public Boolean isAllowSubsetMatch() { return this.allowSubsetMatch; }
+
+    public void setAllowSubsetMatch(final boolean allowSubsetMatch) { this.allowSubsetMatch = allowSubsetMatch; }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidatorTest.java
@@ -355,6 +355,23 @@ public class IsaacItemQuestionValidatorTest {
         assertEquals(response.getExplanation().getValue(), incorrectExplanation);
     }
 
+    /*
+       Test that duplicate items in an otherwise correct answer make it invalid.
+    */
+    @Test
+    public final void isaacItemQuestionValidator_DuplicateItems_ErrorMessageShown() {
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        Item submittedItem1 = new Item("id001", null);
+        Item submittedItem3 = new Item("id003", null);
+        c.setItems(ImmutableList.of(submittedItem1, submittedItem1, submittedItem3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someItemQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("duplicate items"));
+    }
+
     //  ---------- Tests from here test invalid questions themselves ----------
 
     /*

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidatorTest.java
@@ -185,7 +185,9 @@ public class IsaacItemQuestionValidatorTest {
         // Set up user answer that is a subset of both the correct and incorrect choice
         ItemChoice c = new ItemChoice();
         Item submittedItem1 = new Item("id001", null);
-        c.setItems(ImmutableList.of(submittedItem1));
+        Item submittedItem2 = new Item("id002", null);
+        Item submittedItem3 = new Item("id003", null);
+        c.setItems(ImmutableList.of(submittedItem1, submittedItem2, submittedItem3));
 
         // Test response:
         QuestionValidationResponse response = validator.validateQuestionResponse(someItemQuestion, c);
@@ -193,11 +195,11 @@ public class IsaacItemQuestionValidatorTest {
     }
 
     /*
-       Test that if the correct choice is a strict subset of the submitted answer, it is not marked as correct,
+       Test that if the correct choice is a strict subset of the submitted answer, it is marked as correct,
        if the correct choice is marked as subset match.
     */
     @Test
-    public final void isaacItemQuestionValidator_CorrectChoiceSubsetOfSubmitted_IncorrectResponseShouldBeReturned() {
+    public final void isaacItemQuestionValidator_CorrectChoiceSubsetOfSubmitted_CorrectResponseShouldBeReturned() {
 
         // Enable subset matching on the correct choice
         ((ItemChoice) someItemQuestion.getChoices().get(1)).setAllowSubsetMatch(true);
@@ -211,8 +213,7 @@ public class IsaacItemQuestionValidatorTest {
 
         // Test response:
         QuestionValidationResponse response = validator.validateQuestionResponse(someItemQuestion, c);
-        assertFalse(response.isCorrect());
-        assertNull(response.getExplanation());
+        assertTrue(response.isCorrect());
     }
 
     /*
@@ -257,10 +258,11 @@ public class IsaacItemQuestionValidatorTest {
     }
 
     /*
-       Test that a subset answer to a 'subset match enabled' choice is marked as correct.
+       Test that if the submitted answer is a strict subset of the correct choice, it is marked as incorrect,
+       if the correct choice is marked as subset match.
     */
     @Test
-    public final void isaacItemQuestionValidator_SubsetOfCorrectItems_CorrectResponseShouldBeReturned() {
+    public final void isaacItemQuestionValidator_SubmittedSubsetOfCorrectChoice_CorrectResponseShouldBeReturned() {
 
         // Set up the question object:
         IsaacItemQuestion itemQuestion = new IsaacItemQuestion();
@@ -278,14 +280,15 @@ public class IsaacItemQuestionValidatorTest {
 
         itemQuestion.setChoices(ImmutableList.of(subsetCorrectAnswer));
 
-        // Set up user answer
+        // Set up user answer as a subset of the correct choice items
         ItemChoice userAnswer = new ItemChoice();
         Item submittedItem1 = new Item("id001", null);
         userAnswer.setItems(ImmutableList.of(submittedItem1));
 
         // Test response:
         QuestionValidationResponse response = validator.validateQuestionResponse(itemQuestion, userAnswer);
-        assertTrue(response.isCorrect());
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
     }
 
     /*


### PR DESCRIPTION
The precedence of matching choices is currently as follows:
1. Correct strict match
2. Incorrect strict match
3. Correct subset match
4. Incorrect subset match

This made sense to me on the grounds that if an incorrect choice is a subset of a correct choice where the user can choose , then that question is badly written, and correct choices should always be matched before incorrect ones. Incorrect subset should always be last since it's quite harsh: essentially "mark this question wrong if any of the following are ticked". (This is no longer the case since the requested changes below)

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Peer-Reviewed
