### PR TITLE
Improved significant figures feedback

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
@@ -129,6 +129,12 @@ public class IsaacFreeTextValidator implements IValidator {
                 log.error("QuestionId: " + question.getId() + " contains a choice which is not a FreeTextRule.");
             }
         }
+
+        // If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != freeTextQuestion.getDefaultFeedback()) {
+            feedback = freeTextQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), answer, isCorrectResponse, feedback, new Date());
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherValidator.java
@@ -121,6 +121,11 @@ public class IsaacGraphSketcherValidator implements IValidator, ISpecifier {
             }
         }
 
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != graphSketcherQuestion.getDefaultFeedback()) {
+            feedback = graphSketcherQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
@@ -130,6 +130,11 @@ public class IsaacItemQuestionValidator implements IValidator {
             }
         }
 
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != itemQuestion.getDefaultFeedback()) {
+            feedback = itemQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidator.java
@@ -162,6 +162,11 @@ public class IsaacParsonsValidator implements IValidator {
             }
         }
 
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != parsonsQuestion.getDefaultFeedback()) {
+            feedback = parsonsQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
@@ -119,6 +119,11 @@ public class IsaacStringMatchValidator implements IValidator {
             }
         }
 
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != stringMatchQuestion.getDefaultFeedback()) {
+            feedback = stringMatchQuestion.getDefaultFeedback();
+        }
+
         return new QuestionValidationResponse(question.getId(), userAnswer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -399,6 +399,10 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
             }
         }
 
+        // STEP 5: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != chemistryQuestion.getDefaultFeedback()) {
+            feedback = chemistryQuestion.getDefaultFeedback();
+        }
         return new QuestionValidationResponse(chemistryQuestion.getId(), answer, responseCorrect, feedback, new Date());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
@@ -257,6 +257,11 @@ public class IsaacSymbolicLogicValidator implements IValidator {
             }
         }
 
+        // STEP 4: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != symbolicLogicQuestion.getDefaultFeedback()) {
+            feedback = symbolicLogicQuestion.getDefaultFeedback();
+        }
+
         // If we got this far and feedback is still null, they were wrong. There's no useful feedback we can give at this point.
 
         return new FormulaValidationResponse(symbolicLogicQuestion.getId(), answer, feedback, responseCorrect, responseMatchType.toString(), new Date());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
@@ -265,6 +265,11 @@ public class IsaacSymbolicValidator implements IValidator {
             }
         }
 
+        // STEP 4: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != symbolicQuestion.getDefaultFeedback()) {
+            feedback = symbolicQuestion.getDefaultFeedback();
+        }
+
         // If we got this far and feedback is still null, they were wrong. There's no useful feedback we can give at this point.
 
         return new FormulaValidationResponse(symbolicQuestion.getId(), answer, feedback, responseCorrect, responseMatchType.toString(), new Date());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/Question.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/Question.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,9 +19,8 @@ import java.util.List;
 import uk.ac.cam.cl.dtg.segue.dto.content.QuestionDTO;
 
 /**
- * Choice object The choice object is a specialized form of content and allows the storage of data relating to possible
- * answers to questions.
- * 
+ * Base class for all question types.
+ *
  */
 @DTOMapping(QuestionDTO.class)
 @JsonContentType("question")
@@ -29,6 +28,7 @@ public class Question extends Content {
 
     protected ContentBase answer;
     protected List<ContentBase> hints;
+    protected Content defaultFeedback;
 
 
     public Question() {
@@ -71,6 +71,25 @@ public class Question extends Content {
      */
     public final void setHints(final List<ContentBase> hints) {
         this.hints = hints;
+    }
+
+    /**
+     * Gets the default feedback to be used when no other feedback is generated..
+     *
+     * @return the defaultFeedback
+     */
+    public final Content getDefaultFeedback() {
+        return defaultFeedback;
+    }
+
+    /**
+     * Sets the default feedback to be used when no other feedback is generated.
+     *
+     * @param defaultFeedback
+     *            the defaultFeedback to set
+     */
+    public final void setDefaultFeedback(final Content defaultFeedback) {
+        this.defaultFeedback = defaultFeedback;
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +16,18 @@
 package uk.ac.cam.cl.dtg.segue.dto.content;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
 
 import java.util.List;
 
-import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
-
 /**
- * Choice object The choice object is a specialized form of content and allows the storage of data relating to possible
- * answers to questions.
+ * Base class for all question types.
  * 
  */
 public class QuestionDTO extends ContentDTO {
     protected ContentBaseDTO answer;
     protected List<ContentBaseDTO> hints;
+    protected ContentDTO defaultFeedback;
 
     // Set if the user is logged in and we have information.
     protected QuestionValidationResponseDTO bestAttempt;
@@ -78,6 +77,25 @@ public class QuestionDTO extends ContentDTO {
      */
     public void setHints(final List<ContentBaseDTO> hints) {
         this.hints = hints;
+    }
+
+    /**
+     * Gets the default feedback to be used when no other feedback is generated..
+     *
+     * @return the defaultFeedback
+     */
+    public final ContentDTO getDefaultFeedback() {
+        return defaultFeedback;
+    }
+
+    /**
+     * Sets the default feedback to be used when no other feedback is generated.
+     *
+     * @param defaultFeedback
+     *            the defaultFeedback to set
+     */
+    public final void setDefaultFeedback(final ContentDTO defaultFeedback) {
+        this.defaultFeedback = defaultFeedback;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/ChoiceQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/ChoiceQuestionValidator.java
@@ -41,8 +41,11 @@ public class ChoiceQuestionValidator implements IValidator {
         Validate.notNull(question);
         Validate.notNull(answer);
 
-        // check that the question is of type ChoiceQuestion before we go ahead
         ChoiceQuestion choiceQuestion;
+        // These variables store the important features of the response we'll send.
+        Content feedback = null;                        // The feedback we send the user
+        boolean responseCorrect = false;                // Whether we're right or wrong
+        // check that the question is of type ChoiceQuestion before we go ahead
         if (question instanceof ChoiceQuestion) {
             choiceQuestion = (ChoiceQuestion) question;
 
@@ -54,16 +57,21 @@ public class ChoiceQuestionValidator implements IValidator {
 
             for (Choice choice : choiceQuestion.getChoices()) {
                 if (choice.getValue().equals(answer.getValue())) {
-                    
-                    return new QuestionValidationResponse(question.getId(), answer, choice.isCorrect(),
-                            (Content) choice.getExplanation(), new Date());
+                    responseCorrect = choice.isCorrect();
+                    feedback = (Content) choice.getExplanation();
+                    break;
                 }
             }
 
             log.info("Unable to find choice for question ( " + question.getId() + " ) matching the answer supplied ("
-                    + answer + "). Returning that it is incorrect with out an explanation.");
+                    + answer + "). Returning that it is incorrect without an explanation.");
 
-            return new QuestionValidationResponse(question.getId(), answer, false, null, new Date());
+            // If we still have no feedback to give, use the question's default feedback if any to use:
+            if (feedbackIsNullOrEmpty(feedback) && null != choiceQuestion.getDefaultFeedback()) {
+                feedback = choiceQuestion.getDefaultFeedback();
+            }
+
+            return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
         } else {
             log.error("Expected to be able to cast the question as a ChoiceQuestion " + "but this cast failed.");
             throw new ClassCastException("Incorrect type of question received. Unable to validate.");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/IValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/quiz/IValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dos.content.Choice;
+import uk.ac.cam.cl.dtg.segue.dos.content.Content;
 import uk.ac.cam.cl.dtg.segue.dos.content.Question;
 
 import java.io.IOException;
@@ -118,5 +119,20 @@ public interface IValidator {
         HashMap<String, Object> response = mapper.readValue(responseString, HashMap.class);
 
         return response;
+    }
+
+    /**
+     *  Check if a feedback content object contains no meaningful feedback.
+     *
+     * @param feedback - content object to test
+     * @return whether the content object is empty
+     */
+    default boolean feedbackIsNullOrEmpty(final Content feedback) {
+        if (null == feedback) {
+            return true;
+        }
+        boolean valueEmpty = null == feedback.getValue() || feedback.getValue().isEmpty();
+        boolean childrenEmpty = null == feedback.getChildren() || feedback.getChildren().isEmpty();
+        return valueEmpty && childrenEmpty;
     }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -395,6 +395,34 @@ public class IsaacNumericValidatorTest {
         assertTrue(response_1sf.getExplanation().getTags().contains("sig_figs"));
     }
 
+    /*
+        Test default feedback is used when a known answer is matched and no explanation given.
+    */
+    @Test
+    public final void isaacNumericValidator_DefaultFeedbackAndCorrectNoExplanation_DefaultFeedbackReturned() {
+        // Set up the question object:
+        IsaacNumericQuestion someNumericQuestion = new IsaacNumericQuestion();
+        someNumericQuestion.setRequireUnits(false);
+        Content defaultFeedback = new Content("DEFAULT FEEDBACK!");
+        someNumericQuestion.setDefaultFeedback(defaultFeedback);
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity someCorrectAnswer = new Quantity("10");
+        someCorrectAnswer.setCorrect(true);
+        answerList.add(someCorrectAnswer);
+
+        someNumericQuestion.setChoices(answerList);
+
+        // Set up user answer:
+        Quantity q = new Quantity("10");
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someNumericQuestion, q);
+
+        assertTrue(response.isCorrect());
+        assertEquals(response.getExplanation(), defaultFeedback);
+    }
+
     //  ---------- Tests from here test invalid questions themselves ----------
 
     /*

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -167,16 +167,28 @@ public class IsaacNumericValidatorTest {
     @Test
     public final void isaacNumericValidator_IncorrectSigFigsCorrectUnit_IncorrectResponseShouldHappen() {
         // Set up user answer:
-        Quantity q = new Quantity("4", correctUnits);
+        Quantity q_tooFew = new Quantity("4", correctUnits);
 
         // Test response:
-        QuantityValidationResponse response = (QuantityValidationResponse) validator.validateQuestionResponse(numericQuestionWithUnits, q);
+        QuantityValidationResponse responseTooFew = (QuantityValidationResponse) validator.validateQuestionResponse(numericQuestionWithUnits, q_tooFew);
 
         // Check answer is wrong,
-        assertFalse(response.isCorrect());
-        assertFalse(response.getCorrectValue());
+        assertFalse(responseTooFew.isCorrect());
+        assertFalse(responseTooFew.getCorrectValue());
         // but units are right:
-        assertTrue(response.getCorrectUnits());
+        assertTrue(responseTooFew.getCorrectUnits());
+
+        // Set up user answer:
+        Quantity q_tooMany = new Quantity("42.000", correctUnits);
+
+        // Test response:
+        QuantityValidationResponse responseTooMany = (QuantityValidationResponse) validator.validateQuestionResponse(numericQuestionWithUnits, q_tooMany);
+
+        // Check answer is wrong,
+        assertFalse(responseTooMany.isCorrect());
+        assertFalse(responseTooMany.getCorrectValue());
+        // but units are right:
+        assertTrue(responseTooMany.getCorrectUnits());
     }
 
     /*
@@ -352,14 +364,14 @@ public class IsaacNumericValidatorTest {
         // Test response:
         QuestionValidationResponse response_3sf = validator.validateQuestionResponse(someNumericQuestion, q_3sf);
         assertFalse(response_3sf.isCorrect());
-        assertFalse(response_3sf.getExplanation().getValue().toLowerCase().contains("significant figures"));
+        assertFalse(response_3sf.getExplanation().getTags().contains("sig_figs"));
 
         // Set up a user answer:
         Quantity q_2sf = new Quantity("2.0");
         // Test response:
         QuestionValidationResponse response_2sf = validator.validateQuestionResponse(someNumericQuestion, q_2sf);
         assertFalse(response_2sf.isCorrect());
-        assertFalse(response_2sf.getExplanation().getValue().toLowerCase().contains("significant figures"));
+        assertFalse(response_2sf.getExplanation().getTags().contains("sig_figs"));
     }
 
     /*
@@ -393,6 +405,48 @@ public class IsaacNumericValidatorTest {
         QuestionValidationResponse response_1sf = validator.validateQuestionResponse(someNumericQuestion, q_1sf);
         assertFalse("expected 2 not to match 1.6875 to 2 or 3 sf", response_1sf.isCorrect());
         assertTrue(response_1sf.getExplanation().getTags().contains("sig_figs"));
+    }
+
+    /*
+    Test incorrect sig fig answers to questions allowing a range of significant figures.
+ */
+    @Test
+    public final void isaacNumericValidator_TestQuestionWithSigFigRange_SigFigResponses() {
+        // Set up the question object:
+        IsaacNumericQuestion someNumericQuestion = new IsaacNumericQuestion();
+        someNumericQuestion.setRequireUnits(false);
+        someNumericQuestion.setSignificantFiguresMin(2);
+        someNumericQuestion.setSignificantFiguresMax(3);
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity someCorrectAnswer = new Quantity("1.6875");
+        someCorrectAnswer.setCorrect(true);
+
+        answerList.add(someCorrectAnswer);
+        someNumericQuestion.setChoices(answerList);
+
+        // Set up a correct user answer with too many sig figs:
+        Quantity q_5sf_corr = new Quantity("1.6875");
+        // Test response is sig fig message:
+        QuestionValidationResponse response_5sf_corr = validator.validateQuestionResponse(someNumericQuestion, q_5sf_corr);
+        assertFalse("expected 1.6875 not to match 1.6875 to 2 or 3 sf", response_5sf_corr.isCorrect());
+        assertTrue(response_5sf_corr.getExplanation().getTags().contains("sig_figs"));
+        assertTrue(response_5sf_corr.getExplanation().getTags().contains("sig_figs_too_many"));
+
+        // Set up a wrong user answer with too many sig figs:
+        Quantity q_5sf_wrong = new Quantity("2.7986");
+        // Test response does not mention sig figs:
+        QuestionValidationResponse response_5sf_wrong = validator.validateQuestionResponse(someNumericQuestion, q_5sf_wrong);
+        assertFalse("expected 2.7986 not to match 1.6875", response_5sf_wrong.isCorrect());
+        assertFalse("expected 2.7986 without sig fig message", response_5sf_wrong.getExplanation().getTags().contains("sig_figs"));
+
+        // Set up a user answer:
+        Quantity q_1sf = new Quantity("5");
+        // Test response:
+        QuestionValidationResponse response_1sf = validator.validateQuestionResponse(someNumericQuestion, q_1sf);
+        assertFalse("expected 5 not to match 1.6875 to 2 or 3 sf", response_1sf.isCorrect());
+        assertTrue(response_1sf.getExplanation().getTags().contains("sig_figs"));
+        assertTrue(response_1sf.getExplanation().getTags().contains("sig_figs_too_few"));
     }
 
     /*
@@ -670,13 +724,17 @@ public class IsaacNumericValidatorTest {
         for (String number : numbersToTest) {
 
             for (Integer sigFig : sigFigsToPass) {
-                boolean validate = Whitebox.<Boolean>invokeMethod(test, "verifyCorrectNumberOfSignificantFigures", number, sigFig, sigFig);
-                assertTrue("Verifying sigfig success failed " + number + " " + sigFig, validate);
+                boolean tooFew = Whitebox.<Boolean>invokeMethod(test, "tooFewSignificantFigures", number, sigFig);
+                assertFalse("Unexpected too few sig fig for " + number + " @ " + sigFig + "sf", tooFew);
+                boolean tooMany = Whitebox.<Boolean>invokeMethod(test, "tooManySignificantFigures", number, sigFig);
+                assertFalse("Unexpected too many sig fig for " + number + " @ " + sigFig + "sf", tooMany);
             }
 
             for (Integer sigFig : sigFigsToFail) {
-                boolean validate = Whitebox.<Boolean>invokeMethod(test, "verifyCorrectNumberOfSignificantFigures", number, sigFig, sigFig);
-                assertFalse("Verifying sigfig failures failed " + number + " " + sigFig, validate);
+                boolean tooFew = Whitebox.<Boolean>invokeMethod(test, "tooFewSignificantFigures", number, sigFig);
+                boolean tooMany = Whitebox.<Boolean>invokeMethod(test, "tooManySignificantFigures", number, sigFig);
+                boolean incorrectSigFig = tooMany || tooFew;
+                assertTrue("Expected incorrect sig fig for " + number + " @ " + sigFig + "sf", incorrectSigFig);
             }
         }
     }


### PR DESCRIPTION
Instead of the old blanket sig fig response, now have a tag for too few sig figs which can be customised in the frontend if desired, but do not tag to warn about too many significant figures unless matched against a correct choice.

This extends #366 and so that should be merged first. Only the last commit is relevant to this specific change.