### PR TITLE
Restore old desired behaviour to Orika Custom and Bidirectional mappers

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/AbstractPolymorphicBidirectionalConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/AbstractPolymorphicBidirectionalConverter.java
@@ -1,0 +1,34 @@
+package uk.ac.cam.cl.dtg.segue.dao.content;
+
+
+import ma.glasnost.orika.converter.BidirectionalConverter;
+import ma.glasnost.orika.metadata.Type;
+
+/**
+ * An Orika BidirectionalConverter that implements the old, polymorphic, canConvert check.
+ *
+ * @param <S> - source type
+ * @param <D> - destination type
+ */
+public abstract class AbstractPolymorphicBidirectionalConverter<S, D> extends BidirectionalConverter<S, D> {
+
+    @Override
+    public boolean canConvert(Type<?> sourceType, Type<?> destinationType) {
+        /* The behaviour of canConvert changed in Orika v1.5.0 to only convert exact class matches,
+           to fix an issue with converters acting too loosely on pairs of classes they were not
+           meant to convert.
+           The crux of the change was swapping from sourceType.isAssignableFrom() to sourceType.equals(),
+           which for our use case prevents the clever polymorphism we do with subtypes working in converters.
+
+           Since this is a bidirectional converter, we must check whether the reverse conversion is
+           possible too. It is not immediately obvious what the correct reverse check must be, and so this
+           check has been copied from the old Orika code.
+
+           See the commit that changed this behaviour here:
+           https://github.com/orika-mapper/orika/commit/554396579c96b3356c3c31ceb2e236cba0ffbaba
+         */
+        boolean forwardConvertable = this.sourceType.isAssignableFrom(sourceType) && this.destinationType.equals(destinationType);
+        boolean reverseConvertable = this.destinationType.isAssignableFrom(sourceType) && this.sourceType.equals(destinationType);
+        return forwardConvertable || reverseConvertable;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/AbstractPolymorphicConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/AbstractPolymorphicConverter.java
@@ -1,0 +1,28 @@
+package uk.ac.cam.cl.dtg.segue.dao.content;
+
+
+import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.metadata.Type;
+
+/**
+ * An Orika CustomConverter that implements the old, polymorphic, canConvert check.
+ *
+ * @param <S> - source type
+ * @param <D> - destination type
+ */
+public abstract class AbstractPolymorphicConverter<S, D> extends CustomConverter<S, D> {
+
+    @Override
+    public boolean canConvert(Type<?> sourceType, Type<?> destinationType) {
+        /* The behaviour of canConvert changed in Orika v1.5.0 to only convert exact class matches,
+           to fix an issue with converters acting too loosely on pairs of classes they were not
+           meant to convert.
+           The crux of the change was swapping from sourceType.isAssignableFrom() to sourceType.equals(),
+           which for our use case prevents the clever polymorphism we do with subtypes working in converters.
+
+           See the commit that changed this behaviour here:
+           https://github.com/orika-mapper/orika/commit/554396579c96b3356c3c31ceb2e236cba0ffbaba
+         */
+        return this.sourceType.isAssignableFrom(sourceType) && this.destinationType.equals(destinationType);
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceOrikaConverter.java
@@ -16,7 +16,6 @@
 package uk.ac.cam.cl.dtg.segue.dao.content;
 
 import ma.glasnost.orika.MappingContext;
-import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.metadata.Type;
 import uk.ac.cam.cl.dtg.segue.dos.content.ChemicalFormula;
 import uk.ac.cam.cl.dtg.segue.dos.content.Choice;
@@ -45,7 +44,7 @@ import uk.ac.cam.cl.dtg.segue.dto.content.StringChoiceDTO;
  * Responsible for converting Choice objects to their correct subtype.
  * 
  */
-public class ChoiceOrikaConverter extends BidirectionalConverter<Choice, ChoiceDTO> {
+public class ChoiceOrikaConverter extends AbstractPolymorphicBidirectionalConverter<Choice, ChoiceDTO> {
 
     /**
      * Constructs an Orika Converter specialises in selecting the correct subclass for choice objects.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseOrikaConverter.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.content;
 
-import ma.glasnost.orika.CustomConverter;
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.metadata.Type;
 import org.slf4j.Logger;
@@ -31,7 +30,7 @@ import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
  * Responsible for converting Content objects to their correct subtype.
  * 
  */
-public class ContentBaseOrikaConverter extends CustomConverter<ContentBase, ContentBaseDTO> {
+public class ContentBaseOrikaConverter extends AbstractPolymorphicConverter<ContentBase, ContentBaseDTO> {
     private static final Logger log = LoggerFactory.getLogger(ContentBaseOrikaConverter.class);
 
     private ContentMapper contentMapper;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ItemOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ItemOrikaConverter.java
@@ -16,7 +16,6 @@
 package uk.ac.cam.cl.dtg.segue.dao.content;
 
 import ma.glasnost.orika.MappingContext;
-import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.metadata.Type;
 import uk.ac.cam.cl.dtg.segue.dos.content.Item;
 import uk.ac.cam.cl.dtg.segue.dos.content.ParsonsItem;
@@ -27,7 +26,7 @@ import uk.ac.cam.cl.dtg.segue.dto.content.ParsonsItemDTO;
  * Converts Item objects to and from their DTO equivalents.
  *
  */
-public class ItemOrikaConverter extends BidirectionalConverter<Item, ItemDTO> {
+public class ItemOrikaConverter extends AbstractPolymorphicBidirectionalConverter<Item, ItemDTO> {
 
     /**
      * Constructs an Orika Converter specialises in selecting the correct subclass for choice objects.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/AnonymousUserQuestionAttemptsOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/AnonymousUserQuestionAttemptsOrikaConverter.java
@@ -17,9 +17,9 @@ package uk.ac.cam.cl.dtg.segue.dao.users;
 
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
-import ma.glasnost.orika.CustomConverter;
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.metadata.Type;
+import uk.ac.cam.cl.dtg.segue.dao.content.AbstractPolymorphicConverter;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
 
@@ -34,8 +34,8 @@ import java.util.Map;
  */
 public class AnonymousUserQuestionAttemptsOrikaConverter
         extends
-        CustomConverter<Map<String, Map<String, List<QuestionValidationResponse>>>, 
-        Map<String, Map<String, List<QuestionValidationResponseDTO>>>> {
+        AbstractPolymorphicConverter<Map<String, Map<String, List<QuestionValidationResponse>>>,
+                Map<String, Map<String, List<QuestionValidationResponseDTO>>>> {
 
     /**
      * Constructs an Orika Converter specialises in selecting the correct subclass for choice objects.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
@@ -16,8 +16,8 @@
 package uk.ac.cam.cl.dtg.segue.dao.users;
 
 import ma.glasnost.orika.MappingContext;
-import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.metadata.Type;
+import uk.ac.cam.cl.dtg.segue.dao.content.AbstractPolymorphicBidirectionalConverter;
 import uk.ac.cam.cl.dtg.segue.dos.QuantityValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dto.QuantityValidationResponseDTO;
@@ -30,7 +30,7 @@ import uk.ac.cam.cl.dtg.segue.dto.QuestionValidationResponseDTO;
  * 
  */
 public class QuestionValidationResponseOrikaConverter extends
-        BidirectionalConverter<QuestionValidationResponse, QuestionValidationResponseDTO> {
+        AbstractPolymorphicBidirectionalConverter<QuestionValidationResponse, QuestionValidationResponseDTO> {
 
     /**
      * Constructs an Orika Converter specialises in selecting the correct subclass for choice objects.


### PR DESCRIPTION
After updating to v1.5.x, the default behaviour of mappers became much stricter and did not correctly map all of our polymorphic subclasses in all cases.
This issue is the one described in orika-mapper/orika#171, and the fix is to override canConvert for CustomConverter and BidirectionalConverter with the old code as suggested in that issue.

I can't be sure that _all_ of these Converters need to be the polymorphic supporting version - but Item, Choice and QuestionValidationResponse definitely need to be for questions to continue functioning.
I also must have tested with a question type that did still work (namely multiple choice that use Choice and not a subclass) and only _some_ cases of our use of Orika were broken by the changes :/
