### PR TITLE
Add a displayUnit to numeric questions which overrides requiresUnits

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacNumericQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacNumericQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@ public class IsaacNumericQuestion extends IsaacQuestionBase {
     private Integer significantFiguresMin;
     private Integer significantFiguresMax;
     private List<String> availableUnits;
+    private String displayUnit;
 
     /**
      * Gets the requireUnits.
@@ -115,5 +116,22 @@ public class IsaacNumericQuestion extends IsaacQuestionBase {
             return new ArrayList<String>();
         }
         return availableUnits;
+    }
+
+    /**
+     *  Get the unit to be displayed to the user instead of the available units dropdown.
+     *
+     * @return the unit string
+     */
+    public String getDisplayUnit() {
+        return displayUnit;
+    }
+
+    /**
+     * Set the unit to be displayed to the user instead of the available units dropdown.
+     * @param displayUnit - the unit to be displayed.
+     */
+    public void setDisplayUnit(String displayUnit) {
+        this.displayUnit = displayUnit;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,9 +36,8 @@ import static uk.ac.cam.cl.dtg.isaac.api.Constants.NUMERIC_QUESTION_DEFAULT_SIGN
 @ValidatesWith(IsaacNumericValidator.class)
 public class IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
     private Boolean requireUnits;
-    private Integer significantFiguresMin;
-    private Integer significantFiguresMax;
     private List<String> availableUnits;
+    private String displayUnit;
 
     /**
      * Gets the requireUnits.
@@ -98,49 +97,20 @@ public class IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
     }
 
     /**
-     * Gets the minimum allowed number of significant figures.
+     *  Get the unit to be displayed to the user instead of the available units dropdown.
      *
-     * @return the number of sig figs.
+     * @return the unit string
      */
-    @JsonIgnore
-    public int getSignificantFiguresMin() {
-        if (null == significantFiguresMin) {
-            return NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES;
-        }
-        return significantFiguresMin;
+    public String getDisplayUnit() {
+        return displayUnit;
     }
 
     /**
-     * Sets the minimum allowed number of significant figures.
-     *
-     * @param significantFigures
-     *            - minimum allowed number of significant figures
+     * Set the unit to be displayed to the user instead of the available units dropdown.
+     * @param displayUnit - the unit to be displayed.
      */
-    public void setSignificantFiguresMin(final Integer significantFigures) {
-        this.significantFiguresMin = significantFigures;
-    }
-
-    /**
-     * Gets the maximum allowed number of significant figures.
-     *
-     * @return the maximum allowed number of sig figs.
-     */
-    @JsonIgnore
-    public int getSignificantFiguresMax() {
-        if (null == significantFiguresMax) {
-            return NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES;
-        }
-        return significantFiguresMax;
-    }
-
-    /**
-     * Sets the maximum allowed number of significant figures.
-     *
-     * @param significantFigures
-     *            - maximum allowed number of significant figures
-     */
-    public void setSignificantFiguresMax(final Integer significantFigures) {
-        this.significantFiguresMax = significantFigures;
+    public void setDisplayUnit(String displayUnit) {
+        this.displayUnit = displayUnit;
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -121,10 +121,18 @@ public class IsaacNumericValidator implements IValidator {
         }
 
         try {
+            // Should this answer include units?
+            boolean shouldValidateWithUnits = isaacNumericQuestion.getRequireUnits();
+            if (shouldValidateWithUnits && null != isaacNumericQuestion.getDisplayUnit() && !isaacNumericQuestion.getDisplayUnit().isEmpty()) {
+                log.warn(String.format("Question has inconsistent units settings, overriding requiresUnits: %s! src: %s",
+                        question.getId(), question.getCanonicalSourceFile()));
+                shouldValidateWithUnits = false;
+            }
+
             if (null == answerFromUser.getValue() || answerFromUser.getValue().isEmpty()) {
                 return new QuantityValidationResponse(question.getId(), answerFromUser, false, new Content(
                         "You did not provide an answer."), false, false, new Date());
-            } else if (null == answerFromUser.getUnits() && (isaacNumericQuestion.getRequireUnits())) {
+            } else if (null == answerFromUser.getUnits() && shouldValidateWithUnits) {
                 return new QuantityValidationResponse(question.getId(), answerFromUser, false, new Content(
                         "You did not provide any units."), null, false, new Date());
             }
@@ -142,7 +150,7 @@ public class IsaacNumericValidator implements IValidator {
             }
 
             // Step 2 - then do correct answer numeric equivalence checking.
-            if (isaacNumericQuestion.getRequireUnits()) {
+            if (shouldValidateWithUnits) {
                 bestResponse = this.validateWithUnits(isaacNumericQuestion, answerFromUser);
             } else {
                 bestResponse = this.validateWithoutUnits(isaacNumericQuestion, answerFromUser);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -801,6 +801,7 @@ public class ContentIndexer {
                     if (choice instanceof Quantity) {
                         Quantity quantity = (Quantity) choice;
 
+                        // Check valid number:
                         try {
                             //noinspection ResultOfMethodCallIgnored
                             Double.parseDouble(quantity.getValue());
@@ -810,10 +811,21 @@ public class ContentIndexer {
                                             + ")  with value that cannot be interpreted as a number. "
                                             + "Users will never be able to match this answer.", indexProblemCache);
                         }
-                    } else if (q.getRequireUnits()) {
+
+                        if (!q.getRequireUnits() && (null != quantity.getUnits() && !quantity.getUnits().isEmpty())) {
+                            this.registerContentProblem(c, "Numeric Question: " + q.getId() +
+                                    " has a Quantity with units but does not require units!", indexProblemCache);
+                        }
+
+
+                    } else {
                         this.registerContentProblem(c, "Numeric Question: " + q.getId() + " has non-Quantity Choice ("
                                 + choice.getValue() + "). It must be deleted and a new Quantity Choice created.", indexProblemCache);
                     }
+                }
+                if (q.getRequireUnits() && (null != q.getDisplayUnit() && !q.getDisplayUnit().isEmpty())) {
+                    this.registerContentProblem(c, "Numeric Question: " + q.getId() + " has a displayUnit set but also requiresUnits!"
+                                    + " Units will be ignored for this question!", indexProblemCache);
                 }
 
             }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -603,6 +604,34 @@ public class IsaacNumericValidatorTest {
 
         // This should throw an exception:
         validator.validateQuestionResponse(numericQuestion, new Choice());
+    }
+
+    /*
+     Test displayUnit overrides requiresUnits.
+    */
+    @Test
+    public final void isaacNumericValidator_TestInconsistentDisplayUnitsOverride_UnitsIgnored() {
+        // Set up the question object:
+        IsaacNumericQuestion someNumericQuestion = new IsaacNumericQuestion();
+        someNumericQuestion.setRequireUnits(true);
+        someNumericQuestion.setDisplayUnit("SOME-FAKE-UNIT");
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity someCorrectAnswer = new Quantity(correctIntegerAnswer, "SOME-FAKE-UNIT");
+        someCorrectAnswer.setCorrect(true);
+        answerList.add(someCorrectAnswer);
+        someNumericQuestion.setChoices(answerList);
+
+        // Set up a user answer without units:
+        Quantity q = new Quantity(correctIntegerAnswer);
+        QuestionValidationResponse response = validator.validateQuestionResponse(someNumericQuestion, q);
+
+        // Check that units are ignored for validation:
+        assertTrue(response.isCorrect());
+        if (response instanceof QuantityValidationResponse) {
+            QuantityValidationResponse qResponse = (QuantityValidationResponse) response;
+            assertNull(qResponse.getCorrectUnits());
+        }
     }
 
     //  ---------- Tests from here test internal methods of the validator ----------


### PR DESCRIPTION
The aim is that the displayUnit gets shown to the user and so we do not need to validate the units since they are not asked for. Guarding against cases where units have been specified anyway makes up most of the changes.
Two new content errors are added to highlight these issues.

I also removed sig figs from the DTO, since they were JsonIgnored and they were not being used and it simplified the file a lot.

This will need frontend and editor work to (a) use the display units in the frontend and stop showing the dropdown in that case, and (b) allow it to be specified in the content editor whilst trying to ensure requiresUnits is not set at the same time, and that choices provided do not have units.
