### PR TITLE
Augment quiz attempt view for teacher with feedback

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1283,7 +1283,9 @@ public class QuizFacade extends AbstractIsaacFacade {
                     "That student has not completed this quiz assignment.").toResponse();
             }
 
-            quizAttempt = augmentAttempt(quizAttempt, assignment, true);
+            IsaacQuizDTO quiz = quizManager.findQuiz(quizAttempt.getQuizId());
+
+            quizAttempt = quizQuestionManager.augmentFeedbackFor(quizAttempt, quiz, QuizFeedbackMode.DETAILED_FEEDBACK);
 
             return Response.ok(quizAttempt)
                 .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -40,6 +40,7 @@ import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizSectionDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAssignmentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAttemptDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.QuizAttemptFeedbackDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizFeedbackDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizUserFeedbackDTO;
 import uk.ac.cam.cl.dtg.segue.api.Constants.SegueServerLogType;
@@ -1285,11 +1286,11 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             IsaacQuizDTO quiz = quizManager.findQuiz(quizAttempt.getQuizId());
 
-            quizAttempt.setUserSummary(userManager.convertToUserSummaryObject(student));
-
             quizAttempt = quizQuestionManager.augmentFeedbackFor(quizAttempt, quiz, QuizFeedbackMode.DETAILED_FEEDBACK);
 
-            return Response.ok(quizAttempt)
+            QuizAttemptFeedbackDTO quizAttemptFeedback = new QuizAttemptFeedbackDTO(userManager.convertToUserSummaryObject(student), quizAttempt);
+
+            return Response.ok(quizAttemptFeedback)
                 .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
                 .build();
         } catch (NoUserLoggedInException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1285,10 +1285,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             IsaacQuizDTO quiz = quizManager.findQuiz(quizAttempt.getQuizId());
 
-            UserSummaryDTO userSummary = associationManager.enforceAuthorisationPrivacy(user,
-                    userManager.convertToUserSummaryObject(student));
-
-            quizAttempt.setUserSummary(userSummary);
+            quizAttempt.setUserSummary(userManager.convertToUserSummaryObject(student));
 
             quizAttempt = quizQuestionManager.augmentFeedbackFor(quizAttempt, quiz, QuizFeedbackMode.DETAILED_FEEDBACK);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1285,6 +1285,11 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             IsaacQuizDTO quiz = quizManager.findQuiz(quizAttempt.getQuizId());
 
+            UserSummaryDTO userSummary = associationManager.enforceAuthorisationPrivacy(user,
+                    userManager.convertToUserSummaryObject(student));
+
+            quizAttempt.setUserSummary(userSummary);
+
             quizAttempt = quizQuestionManager.augmentFeedbackFor(quizAttempt, quiz, QuizFeedbackMode.DETAILED_FEEDBACK);
 
             return Response.ok(quizAttempt)

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAttemptDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAttemptDTO.java
@@ -17,6 +17,7 @@ package uk.ac.cam.cl.dtg.isaac.dto;
 
 import uk.ac.cam.cl.dtg.isaac.dos.QuizFeedbackMode;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryDTO;
 
 import javax.annotation.Nullable;
 import java.util.Date;
@@ -34,6 +35,7 @@ public class QuizAttemptDTO implements IHasQuizSummary {
     @Nullable private Date completedDate;
     @Nullable private IsaacQuizDTO quiz; // For passing a users answers etc.
     @Nullable private QuizAssignmentDTO quizAssignment; // For info on setter etc.
+    @Nullable private UserSummaryDTO userSummary; // Attempts user's summary,
     private QuizFeedbackMode feedbackMode;
 
     /**
@@ -123,6 +125,15 @@ public class QuizAttemptDTO implements IHasQuizSummary {
 
     public void setQuizAssignmentId(@Nullable Long quizAssignmentId) {
         this.quizAssignmentId = quizAssignmentId;
+    }
+
+    @Nullable
+    public UserSummaryDTO getUserSummary() {
+        return userSummary;
+    }
+
+    public void setUserSummary(@Nullable UserSummaryDTO userSummary) {
+        this.userSummary = userSummary;
     }
 
     public Date getStartDate() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAttemptDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAttemptDTO.java
@@ -17,7 +17,6 @@ package uk.ac.cam.cl.dtg.isaac.dto;
 
 import uk.ac.cam.cl.dtg.isaac.dos.QuizFeedbackMode;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentSummaryDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryDTO;
 
 import javax.annotation.Nullable;
 import java.util.Date;
@@ -35,7 +34,6 @@ public class QuizAttemptDTO implements IHasQuizSummary {
     @Nullable private Date completedDate;
     @Nullable private IsaacQuizDTO quiz; // For passing a users answers etc.
     @Nullable private QuizAssignmentDTO quizAssignment; // For info on setter etc.
-    @Nullable private UserSummaryDTO userSummary; // Attempts user's summary,
     private QuizFeedbackMode feedbackMode;
 
     /**
@@ -125,15 +123,6 @@ public class QuizAttemptDTO implements IHasQuizSummary {
 
     public void setQuizAssignmentId(@Nullable Long quizAssignmentId) {
         this.quizAssignmentId = quizAssignmentId;
-    }
-
-    @Nullable
-    public UserSummaryDTO getUserSummary() {
-        return userSummary;
-    }
-
-    public void setUserSummary(@Nullable UserSummaryDTO userSummary) {
-        this.userSummary = userSummary;
     }
 
     public Date getStartDate() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAttemptFeedbackDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAttemptFeedbackDTO.java
@@ -1,0 +1,29 @@
+package uk.ac.cam.cl.dtg.isaac.dto;
+
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryDTO;
+
+public class QuizAttemptFeedbackDTO {
+    private UserSummaryDTO user;
+    private QuizAttemptDTO attempt;
+
+    public QuizAttemptFeedbackDTO(UserSummaryDTO user, QuizAttemptDTO attempt) {
+        this.user = user;
+        this.attempt = attempt;
+    }
+
+    public UserSummaryDTO getUser() {
+        return user;
+    }
+
+    public void setUser(final UserSummaryDTO user) {
+        this.user = user;
+    }
+
+    public QuizAttemptDTO getAttempt() {
+        return attempt;
+    }
+
+    public void setAttempt(final QuizAttemptDTO attempt) {
+        this.attempt = attempt;
+    }
+}

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -266,7 +266,7 @@ public class QuizFacadeTest extends AbstractFacadeTest {
 
     @Test
     public void getQuizAssignmentAttempt() {
-        IsaacQuizDTO augmentedQuiz = new IsaacQuizDTO();
+        QuizAttemptDTO augmentedQuiz = new QuizAttemptDTO();
         forEndpoint(() -> quizFacade.getQuizAssignmentAttempt(request, studentAssignment.getId(), student.getId()),
             requiresLogin(),
             as(studentsTeachersOrAdmin(),
@@ -290,13 +290,13 @@ public class QuizFacadeTest extends AbstractFacadeTest {
                 prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignment)).andReturn(studentGroup)),
                 prepare(associationManager, m -> expect(m.hasPermission(currentUser(), student)).andReturn(true)),
                 prepare(quizAttemptManager, m -> expect(m.getByQuizAssignmentAndUser(studentAssignment, student)).andReturn(completedAttempt)),
-                prepare(quizQuestionManager, m -> expect(m.augmentQuestionsForUser(studentQuiz, completedAttempt, true)).andReturn(augmentedQuiz)),
-                prepare(assignmentService, m -> {
-                    m.augmentAssignerSummaries(Collections.singletonList(studentAssignment));
-                    expectLastCall();
-                }),
+                prepare(quizQuestionManager, m -> expect(m.augmentFeedbackFor(completedAttempt, studentQuiz, QuizFeedbackMode.DETAILED_FEEDBACK)).andReturn(augmentedQuiz)),
+//                prepare(assignmentService, m -> {
+//                    m.augmentAssignerSummaries(Collections.singletonList(studentAssignment));
+//                    expectLastCall();
+//                }),
                 succeeds(),
-                check(response -> assertEquals(((QuizAttemptDTO) response.getEntity()).getQuiz(), augmentedQuiz))
+                check(response -> assertEquals(((QuizAttemptDTO) response.getEntity()).getQuiz(), augmentedQuiz.getQuiz()))
             ),
             forbiddenForEveryoneElse()
         );

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -30,6 +30,7 @@ import uk.ac.cam.cl.dtg.isaac.dos.QuizFeedbackMode;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAssignmentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAttemptDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.QuizAttemptFeedbackDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizFeedbackDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizUserFeedbackDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
@@ -292,7 +293,7 @@ public class QuizFacadeTest extends AbstractFacadeTest {
                 prepare(quizAttemptManager, m -> expect(m.getByQuizAssignmentAndUser(studentAssignment, student)).andReturn(completedAttempt)),
                 prepare(quizQuestionManager, m -> expect(m.augmentFeedbackFor(completedAttempt, studentQuiz, QuizFeedbackMode.DETAILED_FEEDBACK)).andReturn(augmentedQuiz)),
                 succeeds(),
-                check(response -> assertEquals(((QuizAttemptDTO) response.getEntity()).getQuiz(), augmentedQuiz.getQuiz()))
+                check(response -> assertEquals(((QuizAttemptFeedbackDTO) response.getEntity()).getAttempt().getQuiz(), augmentedQuiz.getQuiz()))
             ),
             forbiddenForEveryoneElse()
         );


### PR DESCRIPTION
Adds feedback to existing teacher accessible endpoint, so teachers can see a student attempt at a quiz: https://github.com/isaacphysics/isaac-react-app/pull/424

**BLOCKED on privacy policy changes**