### PR TITLE
Add boolean notation user preference to My account page

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -176,7 +176,7 @@ public final class Constants {
     }};
 
     public enum IsaacUserPreferences {
-        SUBJECT_INTEREST, BETA_FEATURE, EXAM_BOARD
+        SUBJECT_INTEREST, BETA_FEATURE, EXAM_BOARD, BOOLEAN_NOTATION
     }
 
     /**


### PR DESCRIPTION
Frontend change [here](https://github.com/isaacphysics/isaac-react-app/pull/425).

This needs to be added to `segue-config.cs` as well (I believe), under user preferences: `BOOLEAN_NOTATION = ENG,MATH`