### PR TITLE
Feature/record account user context

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBooking.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBooking.java
@@ -86,7 +86,6 @@ public class PgEventBooking implements EventBooking {
         this.updated = updated;
         this.created = created;
         if (additionalInformation != null) {
-            ObjectMapper mapper = new ObjectMapper();
             try {
                 this.additionalInformation = this.convertFromJsonbToMap(additionalInformation);
             } catch (IOException e) {
@@ -214,14 +213,14 @@ public class PgEventBooking implements EventBooking {
     private Map<String, String> convertFromJsonbToMap(Object objectToConvert) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         final String stringVersion = mapper.writeValueAsString(objectToConvert);
-        Map<String, String> iterimResult = mapper.readValue(stringVersion, HashMap.class);
+        Map<String, String> interimResult = mapper.readValue(stringVersion, HashMap.class);
 
         // this check is here to see if the map coming in is actually a jsonb map, if not assume it doesn't need to be
         // unpacked
-        if (iterimResult.containsKey("type") && iterimResult.get("type").equals("jsonb")) {
-            return mapper.readValue(iterimResult.get("value"), HashMap.class);
+        if (interimResult.containsKey("type") && interimResult.get("type").equals("jsonb")) {
+            return mapper.readValue(interimResult.get("value"), HashMap.class);
         }
 
-        return iterimResult;
+        return interimResult;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -40,7 +40,16 @@ import uk.ac.cam.cl.dtg.segue.api.monitors.SegueLoginMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics;
 import uk.ac.cam.cl.dtg.segue.api.monitors.TeacherPasswordResetMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.auth.AuthenticationProvider;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.*;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticationProviderMappingException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.DuplicateAccountException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.FailedToHashPasswordException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.IncorrectCredentialsProvidedException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidPasswordException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidTokenException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.MissingRequiredFieldException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoCredentialsAvailableException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.segue.comm.CommunicationException;
 import uk.ac.cam.cl.dtg.segue.comm.EmailMustBeVerifiedException;
 import uk.ac.cam.cl.dtg.segue.comm.EmailType;
@@ -90,13 +99,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.IsaacUserPreferences;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.LOCAL_AUTH_EMAIL_FIELDNAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.LOCAL_AUTH_GROUP_MANAGER_EMAIL_FIELDNAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.LOCAL_AUTH_GROUP_MANAGER_INITIATED_FIELDNAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueServerLogType;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueUserPreferences;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.USER_ID_FKEY_FIELDNAME;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * User facade.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -40,16 +40,7 @@ import uk.ac.cam.cl.dtg.segue.api.monitors.SegueLoginMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics;
 import uk.ac.cam.cl.dtg.segue.api.monitors.TeacherPasswordResetMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.auth.AuthenticationProvider;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticationProviderMappingException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.DuplicateAccountException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.FailedToHashPasswordException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.IncorrectCredentialsProvidedException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidPasswordException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidTokenException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.MissingRequiredFieldException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoCredentialsAvailableException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.*;
 import uk.ac.cam.cl.dtg.segue.comm.CommunicationException;
 import uk.ac.cam.cl.dtg.segue.comm.EmailMustBeVerifiedException;
 import uk.ac.cam.cl.dtg.segue.comm.EmailType;
@@ -62,6 +53,7 @@ import uk.ac.cam.cl.dtg.segue.dos.UserPreference;
 import uk.ac.cam.cl.dtg.segue.dos.users.RegisteredUser;
 import uk.ac.cam.cl.dtg.segue.dos.users.Role;
 import uk.ac.cam.cl.dtg.segue.dos.users.School;
+import uk.ac.cam.cl.dtg.segue.dos.users.UserContext;
 import uk.ac.cam.cl.dtg.segue.dos.users.UserSettings;
 import uk.ac.cam.cl.dtg.segue.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
@@ -98,8 +90,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.IsaacUserPreferences;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.LOCAL_AUTH_EMAIL_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.LOCAL_AUTH_GROUP_MANAGER_EMAIL_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.LOCAL_AUTH_GROUP_MANAGER_INITIATED_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueServerLogType;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueUserPreferences;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.USER_ID_FKEY_FIELDNAME;
 
 /**
  * User facade.
@@ -239,11 +236,13 @@ public class UsersFacade extends AbstractSegueFacade {
         // Extract the user preferences, which are validated before saving by userPreferenceObjectToList(...).
         Map<String, Map<String, Boolean>> userPreferences = userSettingsObjectFromClient.getUserPreferences();
 
-        if (null != registeredUser.getId()) {
+        List<UserContext> registeredUserContexts = userSettingsObjectFromClient.getRegisteredUserContexts();
 
+        if (null != registeredUser.getId()) {
             try {
                 return this.updateUserObject(request, response, registeredUser,
-                        userSettingsObjectFromClient.getPasswordCurrent(), newPassword, userPreferences);
+                        userSettingsObjectFromClient.getPasswordCurrent(), newPassword,
+                        userPreferences, registeredUserContexts);
             } catch (IncorrectCredentialsProvidedException e) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "Incorrect credentials provided.", e)
                         .toResponse();
@@ -728,7 +727,8 @@ public class UsersFacade extends AbstractSegueFacade {
      */
     private Response updateUserObject(final HttpServletRequest request, final HttpServletResponse response,
                                       final RegisteredUser userObjectFromClient, final String passwordCurrent, final String newPassword,
-                                      final Map<String, Map<String, Boolean>> userPreferenceObject)
+                                      final Map<String, Map<String, Boolean>> userPreferenceObject,
+                                      final List<UserContext> registeredUserContexts)
             throws IncorrectCredentialsProvidedException, NoCredentialsAvailableException, InvalidKeySpecException,
             NoSuchAlgorithmException {
         Validate.notNull(userObjectFromClient.getId());
@@ -785,6 +785,18 @@ public class UsersFacade extends AbstractSegueFacade {
                     && !userObjectFromClient.getRole().equals(existingUserFromDb.getRole())) {
                 return new SegueErrorResponse(Status.FORBIDDEN, "You do not have permission to change a users role.")
                         .toResponse();
+            }
+
+            if (registeredUserContexts != null) {
+                // We always set the last confirmed date from code rather than trusting the client
+                userObjectFromClient.setRegisteredContexts(registeredUserContexts);
+                userObjectFromClient.setRegisteredContextsLastConfirmed(new Date());
+            } else {
+                // Registered contexts should only ever be set via the registeredUserContexts object, so that it is the
+                // server that sets the time that they last confirmed their user context values.
+                // To ensure this, we overwrite the fields with the values already set in the db if registeredUserContexts is null
+                userObjectFromClient.setRegisteredContexts(existingUserFromDb.getRegisteredContexts());
+                userObjectFromClient.setRegisteredContextsLastConfirmed(existingUserFromDb.getRegisteredContextsLastConfirmed());
             }
 
             RegisteredUserDTO updatedUser = userManager.updateUserObject(userObjectFromClient, newPassword);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -62,6 +62,7 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval;
  */
 public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
     //private static final Logger log = LoggerFactory.getLogger(PgUsers.class);
+    private static final String POSTGRES_EXCEPTION_MESSAGE = "Postgres exception";
     private static final String JSONB_PROCESSING_ERROR_MESSAGE = "Postgres JSONb processing exception";
 
     private final PostgresSqlDb database;
@@ -105,7 +106,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             results.next();
             return results.getInt("TOTAL") != 0;
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }     
     }
 
@@ -148,7 +149,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             }
             return authenticationProviders;
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -182,7 +183,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
 
             return new UserAuthenticationSettings(userId, providersList, results.getBoolean("has_segue_account"), results.getBoolean("mfa_status"));
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -216,7 +217,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             }
             return userCredentialsExistence;
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -239,7 +240,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             
             return getById(results.getLong("user_id"));
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }    
     }
 
@@ -266,7 +267,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             return true;
             
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -288,7 +289,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             
             pst.execute();
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -319,7 +320,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
 
             return this.findOneUser(results);
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         } catch (JsonProcessingException e) {
             throw new SegueDatabaseException(JSONB_PROCESSING_ERROR_MESSAGE, e);
         }
@@ -337,7 +338,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             
             return this.findOneUser(results);
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         } catch (JsonProcessingException e) {
             throw new SegueDatabaseException(JSONB_PROCESSING_ERROR_MESSAGE, e);
         }
@@ -415,7 +416,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
 
             return this.findAllUsers(results);
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         } catch (JsonProcessingException e) {
             throw new SegueDatabaseException(JSONB_PROCESSING_ERROR_MESSAGE, e);
         }
@@ -446,7 +447,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             
             return this.findAllUsers(results);
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         } catch (JsonProcessingException e) {
             throw new SegueDatabaseException(JSONB_PROCESSING_ERROR_MESSAGE, e);
         }
@@ -467,7 +468,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
 
             return resultToReturn;
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -488,7 +489,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
 
             return resultToReturn;
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -505,7 +506,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             }
             return resultsToReturn;
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -527,7 +528,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             }
             return resultsToReturn;
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -543,7 +544,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             
             return this.findOneUser(results);
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         } catch (JsonProcessingException e) {
             throw new SegueDatabaseException(JSONB_PROCESSING_ERROR_MESSAGE, e);
         }
@@ -608,7 +609,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
                 conn.setAutoCommit(true);
             }
         } catch (SQLException e1) {
-            throw new SegueDatabaseException("Postgres exception", e1);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e1);
         } catch (JsonProcessingException e1) {
             throw new SegueDatabaseException(JSONB_PROCESSING_ERROR_MESSAGE, e1);
         }
@@ -641,7 +642,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
                 conn.setAutoCommit(true);
             }
         } catch (SQLException e1) {
-            throw new SegueDatabaseException("Postgres exception", e1);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e1);
         }
     }
 
@@ -661,7 +662,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             pst.setLong(2, user.getId());
             pst.execute();
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -675,7 +676,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             pst.setLong(1, user.getId());
             pst.execute();
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         }
     }
 
@@ -746,7 +747,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             }
 
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         } catch (JsonProcessingException e) {
             throw new SegueDatabaseException(JSONB_PROCESSING_ERROR_MESSAGE, e);
         }
@@ -768,7 +769,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
         try (Connection conn = database.getDatabaseConnection()) {
             return this.updateUser(conn, userToCreate);
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
+            throw new SegueDatabaseException(POSTGRES_EXCEPTION_MESSAGE, e);
         } catch (JsonProcessingException e) {
             throw new SegueDatabaseException(JSONB_PROCESSING_ERROR_MESSAGE, e);
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -53,8 +53,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SchoolInfoStatus;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * @author Stephen Cummins

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/ExamBoard.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/ExamBoard.java
@@ -18,6 +18,6 @@ package uk.ac.cam.cl.dtg.segue.dos.users;
 /**
  * Enum of valid exam boards users may have.
  */
-public enum ExamBoard {
+public enum ExamBoard { // TODO MT AUDIENCE_CONTEXT_CLEANUP - this along with the DO/DTO/DB field
     AQA, OCR, OTHER
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/RegisteredUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/RegisteredUser.java
@@ -15,10 +15,11 @@
  */
 package uk.ac.cam.cl.dtg.segue.dos.users;
 
-import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.List;
 
 /**
  * Data Object to represent a user of the system. This object will be persisted in the database.
@@ -37,6 +38,8 @@ public class RegisteredUser extends AbstractSegueUser {
     private String schoolId;
     private String schoolOther;
     private ExamBoard examBoard;
+    private List<UserContext> registeredContexts;
+    private Date registeredContextsLastConfirmed;
 
     private String emailVerificationToken;
     private String emailToVerify;
@@ -444,6 +447,22 @@ public class RegisteredUser extends AbstractSegueUser {
      */
     public void setSessionToken(final Integer sessionToken) {
         this.sessionToken = sessionToken;
+    }
+
+    public List<UserContext> getRegisteredContexts() {
+        return registeredContexts;
+    }
+
+    public void setRegisteredContexts(List<UserContext> registeredContexts) {
+        this.registeredContexts = registeredContexts;
+    }
+
+    public Date getRegisteredContextsLastConfirmed() {
+        return registeredContextsLastConfirmed;
+    }
+
+    public void setRegisteredContextsLastConfirmed(Date registeredContextsLastConfirmed) {
+        this.registeredContextsLastConfirmed = registeredContextsLastConfirmed;
     }
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/UserContext.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/UserContext.java
@@ -1,27 +1,27 @@
 package uk.ac.cam.cl.dtg.segue.dos.users;
 
 public class UserContext {
-    public enum STAGE {gcse, a_level, further_a, university, none}
-    public enum EXAM_BOARD {AQA, OCR, CIE, EDEXCEL, EDUCAS, WJEC, OTHER, NONE}
+    public enum Stage {gcse, a_level, further_a, university, none}
+    public enum ExamBoard {AQA, OCR, CIE, EDEXCEL, EDUCAS, WJEC, OTHER, NONE}
 
-    private STAGE stage;
-    private EXAM_BOARD examBoard;
+    private Stage stage;
+    private ExamBoard examBoard;
 
     public UserContext() {;}
 
-    public STAGE getStage() {
+    public Stage getStage() {
         return stage;
     }
 
-    public void setStage(STAGE stage) {
+    public void setStage(Stage stage) {
         this.stage = stage;
     }
 
-    public EXAM_BOARD getExamBoard() {
+    public ExamBoard getExamBoard() {
         return examBoard;
     }
 
-    public void setExamBoard(EXAM_BOARD examBoard) {
+    public void setExamBoard(ExamBoard examBoard) {
         this.examBoard = examBoard;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/UserContext.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/UserContext.java
@@ -1,0 +1,27 @@
+package uk.ac.cam.cl.dtg.segue.dos.users;
+
+public class UserContext {
+    public enum STAGE {gcse, a_level, further_a, university, none}
+    public enum EXAM_BOARD {AQA, OCR, CIE, EDEXCEL, EDUCAS, WJEC, OTHER, NONE}
+
+    private STAGE stage;
+    private EXAM_BOARD examBoard;
+
+    public UserContext() {;}
+
+    public STAGE getStage() {
+        return stage;
+    }
+
+    public void setStage(STAGE stage) {
+        this.stage = stage;
+    }
+
+    public EXAM_BOARD getExamBoard() {
+        return examBoard;
+    }
+
+    public void setExamBoard(EXAM_BOARD examBoard) {
+        this.examBoard = examBoard;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/UserSettings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/UserSettings.java
@@ -15,10 +15,11 @@
  */
 package uk.ac.cam.cl.dtg.segue.dos.users;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * A collection of user settings objects.
@@ -32,17 +33,24 @@ public class UserSettings {
 	private RegisteredUser registeredUser;
 	private String passwordCurrent;
 	private Map<String, Map<String, Boolean>> userPreferences;
+	private List<UserContext> registeredUserContexts;
 
     /**
      * A collection of user settings objects.
      * @param registeredUser - the user data
      * @param userPreferences - a list of email preferences
-     */
+     * @param registeredUserContexts -
+	 * a list of registered user contexts, i.e. {stage=a_level, exam_board=AQA}.
+	 * It is set separately from the user so that we can record the time it was last set or acknowledged on the server.
+	 */
     @JsonCreator
     public UserSettings(@JsonProperty("registeredUser") final RegisteredUser registeredUser,
-						@JsonProperty("userPreferences") final Map<String, Map<String, Boolean>> userPreferences) {
+						@JsonProperty("userPreferences") final Map<String, Map<String, Boolean>> userPreferences,
+						@JsonProperty("registeredUserContexts") final List<UserContext> registeredUserContexts
+	) {
         this.registeredUser = registeredUser;
 		this.userPreferences = userPreferences;
+		this.registeredUserContexts = registeredUserContexts;
     }
 
 	/**
@@ -90,5 +98,13 @@ public class UserSettings {
 		this.userPreferences = userPreferences;
 	}
 
+	@JsonProperty("registeredUserContexts")
+	public List<UserContext> getRegisteredUserContexts() {
+		return registeredUserContexts;
+	}
 
+	@JsonProperty("registeredUserContexts")
+	public void setRegisteredUserContexts(List<UserContext> registeredUserContexts) {
+		this.registeredUserContexts = registeredUserContexts;
+	}
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/RegisteredUserDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/RegisteredUserDTO.java
@@ -15,15 +15,16 @@
  */
 package uk.ac.cam.cl.dtg.segue.dto.users;
 
-import java.util.Date;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.ac.cam.cl.dtg.segue.dos.users.EmailVerificationStatus;
 import uk.ac.cam.cl.dtg.segue.dos.users.ExamBoard;
 import uk.ac.cam.cl.dtg.segue.dos.users.Gender;
 import uk.ac.cam.cl.dtg.segue.dos.users.Role;
+import uk.ac.cam.cl.dtg.segue.dos.users.UserContext;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Data Transfer Object to represent a user of the system. This object will be persisted in the database.
@@ -43,6 +44,8 @@ public class RegisteredUserDTO extends AbstractSegueUserDTO {
     private String schoolId;
     private String schoolOther;
     private ExamBoard examBoard;
+    private List<UserContext> registeredContexts;
+    private Date registeredContextsLastConfirmed;
 
     private boolean firstLogin = false;
     private Date lastUpdated;
@@ -396,6 +399,22 @@ public class RegisteredUserDTO extends AbstractSegueUserDTO {
      */
     public void setLastSeen(final Date lastSeen) {
         this.lastSeen = lastSeen;
+    }
+
+    public List<UserContext> getRegisteredContexts() {
+        return registeredContexts;
+    }
+
+    public void setRegisteredContexts(List<UserContext> registeredContexts) {
+        this.registeredContexts = registeredContexts;
+    }
+
+    public Date getRegisteredContextsLastConfirmed() {
+        return registeredContextsLastConfirmed;
+    }
+
+    public void setRegisteredContextsLastConfirmed(Date registeredContextsLastConfirmed) {
+        this.registeredContextsLastConfirmed = registeredContextsLastConfirmed;
     }
 
     @Override

--- a/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
+++ b/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
@@ -695,6 +695,8 @@ CREATE TABLE public.users (
     school_id text,
     school_other text,
     exam_board text,
+    registered_contexts jsonb[] DEFAULT array[]::jsonb[] NOT NULL,
+    registered_contexts_last_confirmed timestamp without time zone;
     last_updated timestamp without time zone,
     email_verification_status character varying(255),
     last_seen timestamp without time zone,

--- a/src/main/resources/db_scripts/users_add_registered_context.sql
+++ b/src/main/resources/db_scripts/users_add_registered_context.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.users
+    ADD COLUMN registered_contexts jsonb[] DEFAULT array[]::jsonb[] NOT NULL,
+    ADD COLUMN registered_contexts_last_confirmed timestamp without time zone;


### PR DESCRIPTION
These are the changes necessary to record the user's context on their account. The slightly unusual data structure is there for us to record that a teacher can teach GCSE to the OCR spec and A Level to the AQA spec.

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- ~Added enough Logging to monitor expected behaviour change~
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Security - Access Control - Check authorisation on every new endpoint
- [x] DB schema changes - postgres-rutherford-create-script updated
- [x] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
