### PR TITLE
Enforce "this event is in the past" in a better way when booking events

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -1228,10 +1228,16 @@ public class EventBookingManager {
             enforceBookingDeadline) throws EmailMustBeVerifiedException, EventDeadlineException {
         Date now = new Date();
 
-        // check if if the end date has passed. Allowed to add to wait list after deadline.
-        if (event.getEndDate() != null && now.after(event.getEndDate())
-                || event.getDate() != null && now.after(event.getDate())) {
-            throw new EventDeadlineException("The event is in the past.");
+        // check if the end date has passed, if one is set:
+        if (event.getEndDate() != null) {
+            if (now.after(event.getEndDate())) {
+                throw new EventDeadlineException("The event is in the past.");
+            }
+        } else {
+            // if there is not an endDate, ensure the start has not passed:
+            if (event.getDate() != null && now.after(event.getDate())) {
+                throw new EventDeadlineException("The event is in the past.");
+            }
         }
 
         // if we are enforcing the booking deadline then enforce it.


### PR DESCRIPTION
Previously we checked whether the end date had passed, or whether the start date had passed. But some long-running events have booking deadlines during the event, where the start date has passed but the end date has not.
It makes sense to allow these bookings, but the old code did not.

If an event has an end date, use this and ignore the start date when working out if an event is in the past. Only if it does not have an end date should the start date be used.

Ian wonders whether, if there is a booking deadline, we should only look at that and enforce the "booking deadline before end" as a content error. But that might be more likely to break older events?
