### PR TITLE
Improved email instrumentation

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -195,6 +195,7 @@ public class EmailFacade extends AbstractSegueFacade {
             HashMap<String, String> previewMap = Maps.newHashMap();
             previewMap.put("subject", emailTemplateDTO.getSubject());
             previewMap.put("from", emailTemplateDTO.getOverrideFromAddress());
+            previewMap.put("fromName", emailTemplateDTO.getOverrideFromName());
             previewMap.put("replyTo", emailTemplateDTO.getReplyToEmailAddress());
             previewMap.put("replyToName", emailTemplateDTO.getReplyToName());
             previewMap.put("sender", emailTemplateDTO.getOverrideEnvelopeFrom());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -194,6 +194,10 @@ public class EmailFacade extends AbstractSegueFacade {
 
             HashMap<String, String> previewMap = Maps.newHashMap();
             previewMap.put("subject", emailTemplateDTO.getSubject());
+            previewMap.put("from", emailTemplateDTO.getOverrideFromAddress());
+            previewMap.put("replyTo", emailTemplateDTO.getReplyToEmailAddress());
+            previewMap.put("replyToName", emailTemplateDTO.getReplyToName());
+            previewMap.put("sender", emailTemplateDTO.getOverrideEnvelopeFrom());
 			previewMap.put("html", ecm.getHTMLMessage());
 			previewMap.put("plainText", ecm.getPlainTextMessage());
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
@@ -79,7 +79,7 @@ public final class SegueMetrics {
 
     // Email Metrics
     public static final Counter QUEUED_EMAIL = Counter.build()
-            .name("segue_queued_email_total").help("All emails queued since process start").labelNames("type").register();
+            .name("segue_queued_email_total").help("All emails queued since process start").labelNames("type", "sender").register();
 
     // Log Event Metrics
     public static final Counter LOG_EVENT = Counter.build()

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -107,7 +107,12 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
 
     @Override
     protected void addToQueue(final EmailCommunicationMessage email) {
-        QUEUED_EMAIL.labels(email.getEmailType().name()).inc();
+        // Label metrics with sender address, but Prometheus label cannot be null so need the default value here too:
+        String senderAddress = globalProperties.getProperty(MAIL_FROM_ADDRESS);
+        if (email.getOverrideFromAddress() != null && !email.getOverrideFromAddress().isEmpty()) {
+            senderAddress = email.getOverrideFromAddress();
+        }
+        QUEUED_EMAIL.labels(email.getEmailType().name(), senderAddress).inc();
         super.addToQueue(email);
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -318,8 +318,8 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
 
         try {
             UserPreference preference = userPreferenceManager.getUserPreference(SegueUserPreferences.EMAIL_PREFERENCE.name(), email.getEmailType().name(), userDTO.getId());
-            // If no preference is present, send the email. This is consistent with sendCustomEmail(...) above.
-            if (preference == null || preference.getPreferenceValue()) {
+            // If no preference is present, do not send the email.
+            if (preference != null && preference.getPreferenceValue()) {
                 logManager.logInternalEvent(userDTO, SegueServerLogType.SENT_EMAIL, eventDetails);
                 addToQueue(email);
                 return true;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -529,8 +529,6 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
      *
      * Note: This has to be a singleton because it manages all emails sent using this JVM.
      *
-     * @param database
-     * 			- the database to access preferences
      * @param properties
      * 			- the properties so we can generate email
      * @param emailCommunicator
@@ -539,8 +537,6 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
      * 			- the class providing email preferences
      * @param contentManager
      * 			- the content so we can access email templates
-     * @param authenticator
-     * 			- the authenticator
      * @param logManager
      * 			- the logManager to log email sent
      * @return an instance of the queue
@@ -548,10 +544,9 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Inject
     @Provides
     @Singleton
-    private static EmailManager getMessageCommunicationQueue(final IUserDataManager database,
-                                                             final PropertiesLoader properties, final EmailCommunicator emailCommunicator,
+    private static EmailManager getMessageCommunicationQueue(final PropertiesLoader properties, final EmailCommunicator emailCommunicator,
                                                              final AbstractUserPreferenceManager userPreferenceManager,
-                                                             final IContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex, final SegueLocalAuthenticator authenticator,
+                                                             final IContentManager contentManager,
                                                              final ILogManager logManager) {
 
         Map<String, String> globalTokens = Maps.newHashMap();

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
@@ -121,10 +121,9 @@ public class EmailManagerTest {
 
         mockPropertiesLoader = EasyMock.createMock(PropertiesLoader.class);
         EasyMock.expect(mockPropertiesLoader.getProperty("HOST_NAME")).andReturn("dev.isaacphysics.org").anyTimes();
-        EasyMock.expect(mockPropertiesLoader.getProperty("REPLY_TO_ADDRESS")).andReturn("test-reply@test.com")
-                .anyTimes();
-        EasyMock.expect(mockPropertiesLoader.getProperty("MAIL_NAME")).andReturn("Isaac Physics")
-                .anyTimes();
+        EasyMock.expect(mockPropertiesLoader.getProperty("REPLY_TO_ADDRESS")).andReturn("test-reply@test.com").anyTimes();
+        EasyMock.expect(mockPropertiesLoader.getProperty("MAIL_FROM_ADDRESS")).andReturn("no-reply@isaacphysics.org").anyTimes();
+        EasyMock.expect(mockPropertiesLoader.getProperty("MAIL_NAME")).andReturn("Isaac Physics").anyTimes();
 
         EasyMock.replay(mockPropertiesLoader);
 


### PR DESCRIPTION
Add better logging of where emails are being sent via to Prometheus, and add more detail to the admin email preview response.
For Prometheus, I think this is correct. Apparently null label values are not allowed and will cause NPEs, and so I had to load in the default from address to use if the override value is null. Perhaps this metrics stuff would be better in the actual sender class EmailCommunicator, but it was probabaly added before the queuing in the Manager for a reason.

Also clean up the creation of an EmailManager in Guice because it was messy.