### PR TITLE
Make the GuiceConfigurationModules factories for their own injectors

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
@@ -15,11 +15,8 @@
  */
 package uk.ac.cam.cl.dtg.isaac.configuration;
 
-import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.swagger.jaxrs.config.BeanConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.api.AssignmentFacade;
 import uk.ac.cam.cl.dtg.isaac.api.EventsFacade;
 import uk.ac.cam.cl.dtg.isaac.api.GameboardsFacade;
@@ -59,9 +56,7 @@ public class IsaacApplicationRegister extends Application {
      */
     public IsaacApplicationRegister() {
         singletons = new HashSet<>();
-        SegueGuiceConfigurationModule segueGuiceConfigurationModule = new SegueGuiceConfigurationModule();
-        
-        injector = Guice.createInjector(segueGuiceConfigurationModule);
+        injector = SegueGuiceConfigurationModule.getGuiceInjector();
         
         setupSwaggerApiAdvertiser();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/SegueContextNotifier.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/SegueContextNotifier.java
@@ -1,20 +1,16 @@
 package uk.ac.cam.cl.dtg.segue.api.managers;
 
-import java.util.Collection;
-import java.util.List;
-
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-
+import com.google.api.client.util.Lists;
+import com.google.inject.Injector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import uk.ac.cam.cl.dtg.segue.api.monitors.IMetricsExporter;
 import uk.ac.cam.cl.dtg.segue.configuration.SegueGuiceConfigurationModule;
 
-import com.google.api.client.util.Lists;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * SegueContextListener
@@ -37,7 +33,7 @@ public class SegueContextNotifier implements ServletContextListener {
      * of any context messages.
      */
     public SegueContextNotifier() {
-        injector = Guice.createInjector(new SegueGuiceConfigurationModule());
+        injector = SegueGuiceConfigurationModule.getGuiceInjector();
 
         // Instantiate metrics exporter on process startup
         metricsExporter = injector.getInstance(IMetricsExporter.class);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/userAlerts/UserAlertsWebSocketServlet.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/userAlerts/UserAlertsWebSocketServlet.java
@@ -1,6 +1,5 @@
 package uk.ac.cam.cl.dtg.segue.api.userAlerts;
 
-import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
@@ -17,7 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.HOST_NAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 import static uk.ac.cam.cl.dtg.util.RequestIPExtractor.getClientIpAddr;
 
 /**
@@ -30,7 +29,7 @@ public class UserAlertsWebSocketServlet extends WebSocketServlet {
     private static final Logger log = LoggerFactory.getLogger(UserAlertsWebSocketServlet.class);
     private static final int BAD_REQUEST = 400;
     private static final int FORBIDDEN = 403;
-    private static Injector injector = Guice.createInjector(new SegueGuiceConfigurationModule());
+    private static final Injector injector = SegueGuiceConfigurationModule.getGuiceInjector();
     private final String hostName = injector.getInstance(PropertiesLoader.class).getProperty(HOST_NAME);
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -21,7 +21,9 @@ import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.MapBinder;
@@ -150,6 +152,8 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.EnvironmentType.*;
  */
 public class SegueGuiceConfigurationModule extends AbstractModule implements ServletContextListener {
     private static final Logger log = LoggerFactory.getLogger(SegueGuiceConfigurationModule.class);
+
+    private static Injector injector = null;
 
     private static PropertiesLoader globalProperties = null;
 
@@ -1147,5 +1151,17 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
 
         postgresDB.close();
         postgresDB = null;
+    }
+
+    /**
+     * Factory method for providing a single Guice Injector class.
+     *
+     * @return a Guice Injector configured with this SegueGuiceConfigurationModule.
+     */
+    public static synchronized Injector getGuiceInjector() {
+        if (null == injector) {
+            injector = Guice.createInjector(new SegueGuiceConfigurationModule());
+        }
+        return injector;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ETLConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ETLConfigurationModule.java
@@ -1,7 +1,9 @@
 package uk.ac.cam.cl.dtg.segue.etl;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -21,13 +23,14 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.UnknownHostException;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_LINUX_CONFIG_LOCATION;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * Created by Ian on 21/10/2016.
  */
 class ETLConfigurationModule extends AbstractModule {
     private static final Logger log = LoggerFactory.getLogger(ETLConfigurationModule.class);
+    private static Injector injector = null;
     private static PropertiesLoader globalProperties = null;
     private static ContentMapper mapper = null;
     private static Client elasticSearchClient = null;
@@ -98,7 +101,6 @@ class ETLConfigurationModule extends AbstractModule {
 
 
     }
-
 
     /**
      * This provides a singleton of the contentVersionController for the segue facade.
@@ -178,5 +180,17 @@ class ETLConfigurationModule extends AbstractModule {
         }
 
         return schoolIndexer;
+    }
+
+    /**
+     * Factory method for providing a single Guice Injector class.
+     *
+     * @return a Guice Injector configured with this ETLConfigurationModule.
+     */
+    public static synchronized Injector getGuiceInjector() {
+        if (null == injector) {
+            injector = Guice.createInjector(new ETLConfigurationModule());
+        }
+        return injector;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SegueETLApplicationRegister.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SegueETLApplicationRegister.java
@@ -46,10 +46,8 @@ public class SegueETLApplicationRegister extends Application {
      * Default constructor.
      */
     public SegueETLApplicationRegister() {
-        singletons = new HashSet<Object>();
-        ETLConfigurationModule etlConfigurationModule = new ETLConfigurationModule();
-
-        injector = Guice.createInjector(etlConfigurationModule);
+        singletons = new HashSet<>();
+        injector = ETLConfigurationModule.getGuiceInjector();
 
         setupSwaggerApiAdvertiser();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SegueETLContextNotifier.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SegueETLContextNotifier.java
@@ -1,13 +1,11 @@
 package uk.ac.cam.cl.dtg.segue.etl;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-
+import com.google.inject.Injector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 
 /**
  * SegueContextListener
@@ -31,9 +29,7 @@ public class SegueETLContextNotifier implements ServletContextListener {
     @Override
     public void contextInitialized(final ServletContextEvent sce) {
         log.info("Segue Application Informed of server start up. Registering listeners.");
-        ETLConfigurationModule etlConfigurationModule = new ETLConfigurationModule();
-
-        Injector injector = Guice.createInjector(etlConfigurationModule);
+        Injector injector = ETLConfigurationModule.getGuiceInjector();
 
         // Make sure the ETLManager has been created, forcing latest content to be indexed.
         injector.getInstance(ETLManager.class);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/DatabaseScriptExecutionJob.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/DatabaseScriptExecutionJob.java
@@ -15,12 +15,10 @@
  */
 package uk.ac.cam.cl.dtg.segue.scheduler;
 
-import com.google.inject.Guice;
 import org.apache.commons.io.IOUtils;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.segue.configuration.SegueGuiceConfigurationModule;
@@ -42,7 +40,7 @@ public class DatabaseScriptExecutionJob implements Job {
      */
     public DatabaseScriptExecutionJob() {
         // horrible dependency injection hack this job class needs to be able to independently access the database
-        ds = Guice.createInjector(new SegueGuiceConfigurationModule()).getInstance(PostgresSqlDb.class);
+        ds = SegueGuiceConfigurationModule.getGuiceInjector().getInstance(PostgresSqlDb.class);
     }
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SchedulerClusterDataSource.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SchedulerClusterDataSource.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.segue.scheduler;
 
-import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.quartz.utils.ConnectionProvider;
 import uk.ac.cam.cl.dtg.segue.configuration.SegueGuiceConfigurationModule;
@@ -35,7 +34,7 @@ public class SchedulerClusterDataSource implements ConnectionProvider {
 
     public SchedulerClusterDataSource() {
         // horrible dependency injection hack because quartz insists on initialising its own db connection class.
-        injector = Guice.createInjector(new SegueGuiceConfigurationModule());
+        injector = SegueGuiceConfigurationModule.getGuiceInjector();
         ds = injector.getInstance(PostgresSqlDb.class);
     }
 


### PR DESCRIPTION
This is one, albeit not that nice, way of ensuring only one Guice injector is created. It avoids an extra factory class by making the configuration module the factory for the injector.
The ETL injector was only created twice, but I still made it use the same pattern for consistency.

In theory, this makes all the static singletons in the configuration modules redundant because there is only one instance of the injector and so just being a singleton - without the need for the static pattern - is enough. (Guice singletons are only singletons per-injector instance, and not globally, unless you use the static pattern).
I left it all as-is, though, because if we didn't want overengineering, we wouldn't be using Java ¯\_(ツ)_/¯

It's worth noting that the reason we want a Guice (Injector) Factory at all is because each scheduled job needs a new injector every time it runs, and this rapidly gets out of hand if the injector is not reused or shared. We plan to add several more jobs soon which will exacerbate the issue, but we already had more than 5 injectors created on startup so it was already pretty bad. 

I refrained from making a new `JuiceFactory` class, so be grateful on that front :P