### PR TITLE
Feature/content email sending

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -364,6 +364,7 @@ public final class Constants {
         RELEASE_USER_ASSOCIATION,
         REMOVE_USER_FROM_GROUP,
         REVOKE_USER_ASSOCIATION,
+        SEND_CUSTOM_MASS_EMAIL,
         SEND_MASS_EMAIL,
         SENT_EMAIL,
         USER_REGISTRATION,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -502,15 +502,15 @@ public class EmailFacade extends AbstractSegueFacade {
     /**
      * sendemailwithuserids allows sending an email to a given list of userids.
      *
-     * This method will return serialised html that displays an email object
+     * This method will return 200 ok
      *
      * @param request
      *            - so that we can allow only logged in users to view their own data.
      * @param emailTypeString
      *            - the type of e-mail that is being sent.
      * @param providedTemplate
-     *            - map which must contain the userIds and an EmailTemplateDTO
-     * @return Response object containing the serialized content object. (with no levels of recursion into the content)
+     *            - ContentEmailDTO as Json.
+     * @return 200 ok response
      */
     @POST
     @Path("/email/sendprovidedemailwithuserids/{emailtype}")

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -17,6 +17,7 @@ package uk.ac.cam.cl.dtg.segue.api;
 
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -46,6 +47,7 @@ import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
 import uk.ac.cam.cl.dtg.segue.dos.users.Role;
+import uk.ac.cam.cl.dtg.segue.dto.ContentEmailDTO;
 import uk.ac.cam.cl.dtg.segue.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.dto.content.EmailTemplateDTO;
@@ -492,6 +494,96 @@ public class EmailFacade extends AbstractSegueFacade {
         } catch (SegueResourceMisuseException e) {
             return SegueErrorResponse
                     .getRateThrottledResponse("You have exceeded the number of emails you are allowed to send per day.");
+        }
+
+        return Response.ok().build();
+    }
+
+    /**
+     * sendemailwithuserids allows sending an email to a given list of userids.
+     *
+     * This method will return serialised html that displays an email object
+     *
+     * @param request
+     *            - so that we can allow only logged in users to view their own data.
+     * @param emailTypeString
+     *            - the type of e-mail that is being sent.
+     * @param emailTemplates
+     *            - map which must contain the plaintextTemplate and htmlTemplate
+     * @return Response object containing the serialized content object. (with no levels of recursion into the content)
+     */
+    @POST
+    @Path("/email/sendcontentemailwithuserids/{emailtype}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @GZIP
+    @ApiOperation(value = "Send an email to a list of user IDs.")
+    public final Response sendContentEmailsToUserIds(@Context final HttpServletRequest request,
+                                              @PathParam("emailtype") final String emailTypeString,
+                                                     final ContentEmailDTO emailTemplates) {
+        if (Strings.isNullOrEmpty(emailTemplates.getPlaintextTemplate()) || Strings.isNullOrEmpty(emailTemplates.getHtmlTemplate()) || Strings.isNullOrEmpty(emailTemplates.getEmailSubject())) {
+            return SegueErrorResponse.getBadRequestResponse("Response must include plaintextTemplate, htmlTemplate and emailSubject");
+        }
+
+        final String plaintextTemplate = emailTemplates.getPlaintextTemplate();
+        final String htmlTemplate = emailTemplates.getHtmlTemplate();
+        final String emailSubject = emailTemplates.getEmailSubject();
+        final List<Long> userIds = emailTemplates.getUserIds();
+
+        EmailType emailType;
+        Set<RegisteredUserDTO> allSelectedUsers = Sets.newHashSet();
+
+        if (EnumUtils.isValidEnum(EmailType.class, emailTypeString)) {
+            emailType = EmailType.valueOf(emailTypeString);
+        } else {
+            log.warn("Unknown email type '" + emailTypeString + "' provided to admin endpoint!");
+            return new SegueErrorResponse(Status.BAD_REQUEST, "Unknown email type!").toResponse();
+        }
+
+        try {
+            RegisteredUserDTO sender = this.userManager.getCurrentRegisteredUser(request);
+            if (!isUserStaff(userManager, sender)) {
+                return SegueErrorResponse.getIncorrectRoleResponse();
+            }
+
+            for (Long userId : userIds) {
+                try {
+                    RegisteredUserDTO userDTO = this.userManager.getUserDTOById(userId);
+                    if (userDTO != null) {
+                        allSelectedUsers.add(userDTO);
+                    } else {
+                        // This should never be possible, since getUserDTOById throws rather than returning null.
+                        throw new NoUserException("No user found with this ID!");
+                    }
+                } catch (NoUserException e) {
+                    // Skip missing users rather than failing hard!
+                    log.error(String.format("Skipping email to non-existent user (%s)!", userId));
+                }
+            }
+
+            if (allSelectedUsers.size() == 0) {
+                SegueErrorResponse error = new SegueErrorResponse(Status.BAD_REQUEST,
+                        "There are no users in the groups you have selected!.");
+                log.error(error.getErrorMessage());
+                return error.toResponse();
+            }
+
+            emailManager.sendCustomContentEmail(sender, plaintextTemplate, htmlTemplate, emailSubject, new ArrayList<>(allSelectedUsers), emailType);
+        } catch (SegueDatabaseException e) {
+            SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
+                    "There was an error processing your request.");
+            log.error(error.getErrorMessage());
+            return error.toResponse();
+        } catch (IllegalArgumentException e) {
+            SegueErrorResponse error = new SegueErrorResponse(Status.BAD_REQUEST,
+                    "An unknown type of user was supplied.");
+            log.debug(error.getErrorMessage());
+        } catch (ContentManagerException e) {
+            SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
+                    "There was an error retrieving content.");
+            log.debug(error.getErrorMessage());
+        } catch (NoUserLoggedInException e2) {
+            return SegueErrorResponse.getNotLoggedInResponse();
         }
 
         return Response.ok().build();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -527,7 +527,7 @@ public class EmailFacade extends AbstractSegueFacade {
             return SegueErrorResponse.getBadRequestResponse("Response must include plaintextTemplate, htmlTemplate and emailSubject");
         }
 
-        final List<Long> UserIds = providedTemplate.getUserIds();
+        final List<Long> userIds = providedTemplate.getUserIds();
 
         EmailType emailType;
         Set<RegisteredUserDTO> allSelectedUsers = Sets.newHashSet();
@@ -547,16 +547,16 @@ public class EmailFacade extends AbstractSegueFacade {
 
             if (isUserAnEventManager(userManager, sender)) {
                 if (misuseMonitor.willHaveMisused(sender.getId().toString(),
-                        SendEmailMisuseHandler.class.getSimpleName(), UserIds.size())) {
+                        SendEmailMisuseHandler.class.getSimpleName(), userIds.size())) {
                     return SegueErrorResponse
                             .getRateThrottledResponse("You would have exceeded the number of emails you are allowed to send per day." +
                                     " No emails have been sent.");
                 }
                 misuseMonitor.notifyEvent(sender.getId().toString(),
-                        SendEmailMisuseHandler.class.getSimpleName(), UserIds.size());
+                        SendEmailMisuseHandler.class.getSimpleName(), userIds.size());
             }
 
-            for (Long userId : UserIds) {
+            for (Long userId : userIds) {
                 try {
                     RegisteredUserDTO userDTO = this.userManager.getUserDTOById(userId);
                     if (userDTO != null) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -528,6 +528,7 @@ public class EmailFacade extends AbstractSegueFacade {
         final String plaintextTemplate = emailTemplates.getPlaintextTemplate();
         final String htmlTemplate = emailTemplates.getHtmlTemplate();
         final String emailSubject = emailTemplates.getEmailSubject();
+        final String overrideFromAddress = emailTemplates.getOverrideFromAddress();
         final List<Long> userIds = emailTemplates.getUserIds();
 
         EmailType emailType;
@@ -568,7 +569,7 @@ public class EmailFacade extends AbstractSegueFacade {
                 return error.toResponse();
             }
 
-            emailManager.sendCustomContentEmail(sender, plaintextTemplate, htmlTemplate, emailSubject, new ArrayList<>(allSelectedUsers), emailType);
+            emailManager.sendCustomContentEmail(sender, plaintextTemplate, htmlTemplate, emailSubject, overrideFromAddress, new ArrayList<>(allSelectedUsers), emailType);
         } catch (SegueDatabaseException e) {
             SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
                     "There was an error processing your request.");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -542,7 +542,7 @@ public class EmailFacade extends AbstractSegueFacade {
 
         try {
             RegisteredUserDTO sender = this.userManager.getCurrentRegisteredUser(request);
-            if (!isUserStaff(userManager, sender)) {
+            if (!isUserAnAdminOrEventManager(userManager, sender)) {
                 return SegueErrorResponse.getIncorrectRoleResponse();
             }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -521,13 +521,13 @@ public class EmailFacade extends AbstractSegueFacade {
     public final Response sendContentEmailsToUserIds(@Context final HttpServletRequest request,
                                               @PathParam("emailtype") final String emailTypeString,
                                                      final ContentEmailDTO emailTemplates) {
-        if (Strings.isNullOrEmpty(emailTemplates.getPlaintextTemplate()) || Strings.isNullOrEmpty(emailTemplates.getHtmlTemplate()) || Strings.isNullOrEmpty(emailTemplates.getEmailSubject())) {
+        if (Strings.isNullOrEmpty(emailTemplates.getPlainTextContent()) || Strings.isNullOrEmpty(emailTemplates.getHtmlContent()) || Strings.isNullOrEmpty(emailTemplates.getSubject())) {
             return SegueErrorResponse.getBadRequestResponse("Response must include plaintextTemplate, htmlTemplate and emailSubject");
         }
 
-        final String plaintextTemplate = emailTemplates.getPlaintextTemplate();
-        final String htmlTemplate = emailTemplates.getHtmlTemplate();
-        final String emailSubject = emailTemplates.getEmailSubject();
+        final String plaintextTemplate = emailTemplates.getPlainTextContent();
+        final String htmlTemplate = emailTemplates.getHtmlContent();
+        final String emailSubject = emailTemplates.getSubject();
         final String overrideFromAddress = emailTemplates.getOverrideFromAddress();
         final List<Long> userIds = emailTemplates.getUserIds();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -278,13 +278,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
     /**
      * @param sendingUser
      * 				- the user object for the user sending the email
-     * @param plaintextTemplate
-     * 				- the plainText of the email
-     * @param htmlTemplate
-     *              - the html of the email
-     * @param allSelectedUsers
-     * 				- the users to send email to
-     * @param emailSubject
+     * @param emailTemplate
      *              - the subject of the email
      * @param emailType
      * 				- the type of email to send (affects who receives it)
@@ -293,19 +287,9 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
      * @throws ContentManagerException
      * 				- a content management exception
      */
-    public void sendCustomContentEmail(final RegisteredUserDTO sendingUser, final String plaintextTemplate, final String htmlTemplate,
-                                final String emailSubject, final String overrideFromAddress, final List<RegisteredUserDTO> allSelectedUsers, final EmailType emailType) throws SegueDatabaseException,
+    public void sendCustomContentEmail(final RegisteredUserDTO sendingUser, final EmailTemplateDTO emailTemplate, final List<RegisteredUserDTO> allSelectedUsers, final EmailType emailType) throws SegueDatabaseException,
             ContentManagerException {
         Validate.notNull(allSelectedUsers);
-        Validate.notNull(plaintextTemplate);
-        Validate.notNull(htmlTemplate);
-        Validate.notNull(emailSubject);
-
-        EmailTemplateDTO emailContent = new EmailTemplateDTO();
-        emailContent.setSubject(emailSubject);
-        emailContent.setPlainTextContent(plaintextTemplate);
-        emailContent.setHtmlContent(htmlTemplate);
-        emailContent.setOverrideFromAddress(overrideFromAddress);
 
 
         int numberOfFilteredUsers = 0;
@@ -319,7 +303,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
 
             sanitizeEmailParameters(p);
 
-            EmailCommunicationMessage e = constructMultiPartEmail(user.getId(), user.getEmail(), emailContent, p,
+            EmailCommunicationMessage e = constructMultiPartEmail(user.getId(), user.getEmail(), emailTemplate, p,
                     emailType, null);
 
             // add to the queue
@@ -333,7 +317,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
         allSelectedUsers.stream().map(RegisteredUserDTO::getId).forEach(ids::add);
 
         ImmutableMap<String, Object> eventDetails = new ImmutableMap.Builder<String, Object>().put(USER_ID_LIST_FKEY_FIELDNAME, ids)
-                .put("htmlTemplate", htmlTemplate)
+                .put("htmlTemplate", emailTemplate.getHtmlContent())
                 .put(CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA())
                 .put("numberFiltered", numberOfFilteredUsers)
                 .put("type", emailType).build();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -287,8 +287,9 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
      * @throws ContentManagerException
      * 				- a content management exception
      */
-    public void sendCustomContentEmail(final RegisteredUserDTO sendingUser, final EmailTemplateDTO emailTemplate, final List<RegisteredUserDTO> allSelectedUsers, final EmailType emailType) throws SegueDatabaseException,
-            ContentManagerException {
+    public void sendCustomContentEmail(final RegisteredUserDTO sendingUser, final EmailTemplateDTO emailTemplate,
+                                       final List<RegisteredUserDTO> allSelectedUsers,
+                                       final EmailType emailType) throws SegueDatabaseException, ContentManagerException {
         Validate.notNull(allSelectedUsers);
 
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -273,6 +273,74 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
         log.info(String.format("Admin user (%s) added %d emails to the queue. %d were filtered.", sendingUser.getEmail(),
                 allSelectedUsers.size() - numberOfFilteredUsers, numberOfFilteredUsers));
     }
+
+
+    /**
+     * @param sendingUser
+     * 				- the user object for the user sending the email
+     * @param plaintextTemplate
+     * 				- the plainText of the email
+     * @param htmlTemplate
+     *              - the html of the email
+     * @param allSelectedUsers
+     * 				- the users to send email to
+     * @param emailSubject
+     *              - the subject of the email
+     * @param emailType
+     * 				- the type of email to send (affects who receives it)
+     * @throws SegueDatabaseException
+     * 				- a segue database exception
+     * @throws ContentManagerException
+     * 				- a content management exception
+     */
+    public void sendCustomContentEmail(final RegisteredUserDTO sendingUser, final String plaintextTemplate, final String htmlTemplate,
+                                final String emailSubject, final List<RegisteredUserDTO> allSelectedUsers, final EmailType emailType) throws SegueDatabaseException,
+            ContentManagerException {
+        Validate.notNull(allSelectedUsers);
+        Validate.notNull(plaintextTemplate);
+        Validate.notNull(htmlTemplate);
+        Validate.notNull(emailSubject);
+
+        EmailTemplateDTO emailContent = new EmailTemplateDTO();
+        emailContent.setSubject(emailSubject);
+        emailContent.setPlainTextContent(plaintextTemplate);
+        emailContent.setHtmlContent(htmlTemplate);
+
+
+        int numberOfFilteredUsers = 0;
+        for (RegisteredUserDTO user : allSelectedUsers) {
+            Properties p = new Properties();
+            p.putAll(this.globalStringTokens);
+
+            // Add all properties in the user DTO (preserving types) so they are available to email templates.
+            Map userPropertiesMap = new org.apache.commons.beanutils.BeanMap(user);
+            p.putAll(this.flattenTokenMap(userPropertiesMap, Maps.newHashMap(), ""));
+
+            sanitizeEmailParameters(p);
+
+            EmailCommunicationMessage e = constructMultiPartEmail(user.getId(), user.getEmail(), emailContent, p,
+                    emailType, null);
+
+            // add to the queue
+            boolean emailAddedToSendQueue = this.filterByPreferencesAndAddToQueue(user, e);
+            if (!emailAddedToSendQueue) {
+                numberOfFilteredUsers++;
+            }
+        }
+
+        List<Long> ids = Lists.newArrayList();
+        allSelectedUsers.stream().map(RegisteredUserDTO::getId).forEach(ids::add);
+
+        ImmutableMap<String, Object> eventDetails = new ImmutableMap.Builder<String, Object>().put(USER_ID_LIST_FKEY_FIELDNAME, ids)
+                .put("htmlTemplate", htmlTemplate)
+                .put(CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA())
+                .put("numberFiltered", numberOfFilteredUsers)
+                .put("type", emailType).build();
+
+        this.logManager.logInternalEvent(sendingUser, SegueServerLogType.SEND_CUSTOM_MASS_EMAIL, eventDetails);
+        log.info(String.format("Admin user (%s) added %d emails to the queue. %d were filtered.", sendingUser.getEmail(),
+                allSelectedUsers.size() - numberOfFilteredUsers, numberOfFilteredUsers));
+    }
     
     
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -294,7 +294,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
      * 				- a content management exception
      */
     public void sendCustomContentEmail(final RegisteredUserDTO sendingUser, final String plaintextTemplate, final String htmlTemplate,
-                                final String emailSubject, final List<RegisteredUserDTO> allSelectedUsers, final EmailType emailType) throws SegueDatabaseException,
+                                final String emailSubject, final String overrideFromAddress, final List<RegisteredUserDTO> allSelectedUsers, final EmailType emailType) throws SegueDatabaseException,
             ContentManagerException {
         Validate.notNull(allSelectedUsers);
         Validate.notNull(plaintextTemplate);
@@ -305,6 +305,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
         emailContent.setSubject(emailSubject);
         emailContent.setPlainTextContent(plaintextTemplate);
         emailContent.setHtmlContent(htmlTemplate);
+        emailContent.setOverrideFromAddress(overrideFromAddress);
 
 
         int numberOfFilteredUsers = 0;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -339,7 +339,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
                 .put("type", emailType).build();
 
         this.logManager.logInternalEvent(sendingUser, SegueServerLogType.SEND_CUSTOM_MASS_EMAIL, eventDetails);
-        log.info(String.format("Admin user (%s) added %d emails to the queue. %d were filtered.", sendingUser.getEmail(),
+        log.info(String.format("User (%s) added %d emails to the queue. %d were filtered.", sendingUser.getEmail(),
                 allSelectedUsers.size() - numberOfFilteredUsers, numberOfFilteredUsers));
     }
     

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/ContentEmailDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/ContentEmailDTO.java
@@ -1,13 +1,11 @@
 package uk.ac.cam.cl.dtg.segue.dto;
 
+import uk.ac.cam.cl.dtg.segue.dto.content.EmailTemplateDTO;
+
 import java.util.List;
 
-public class ContentEmailDTO {
+public class ContentEmailDTO extends EmailTemplateDTO {
     private List<Long> userIds;
-    private String plaintextTemplate;
-    private String htmlTemplate;
-    private String emailSubject;
-    private String overrideFromAddress;
 
     /**
      * Default constructor.
@@ -20,37 +18,5 @@ public class ContentEmailDTO {
 
     public void setUserIds(List<Long> userIds) {
         this.userIds = userIds;
-    }
-
-    public String getPlaintextTemplate() {
-        return plaintextTemplate;
-    }
-
-    public void setPlaintextTemplate(String plaintextTemplate) {
-        this.plaintextTemplate = plaintextTemplate;
-    }
-
-    public String getHtmlTemplate() {
-        return htmlTemplate;
-    }
-
-    public void setHtmlTemplate(String htmlTemplate) {
-        this.htmlTemplate = htmlTemplate;
-    }
-
-    public String getEmailSubject() {
-        return emailSubject;
-    }
-
-    public void setEmailSubject(String emailSubject) {
-        this.emailSubject = emailSubject;
-    }
-
-    public String getOverrideFromAddress() {
-        return overrideFromAddress;
-    }
-
-    public void setOverrideFromAddress(final String overrideFromAddress) {
-        this.overrideFromAddress = overrideFromAddress;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/ContentEmailDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/ContentEmailDTO.java
@@ -1,0 +1,47 @@
+package uk.ac.cam.cl.dtg.segue.dto;
+
+import java.util.List;
+
+public class ContentEmailDTO {
+    private List<Long> userIds;
+    private String plaintextTemplate;
+    private String htmlTemplate;
+    private String emailSubject;
+
+    /**
+     * Default constructor.
+     */
+    public ContentEmailDTO() {}
+
+    public List<Long> getUserIds() {
+        return userIds;
+    }
+
+    public void setUserIds(List<Long> userIds) {
+        this.userIds = userIds;
+    }
+
+    public String getPlaintextTemplate() {
+        return plaintextTemplate;
+    }
+
+    public void setPlaintextTemplate(String plaintextTemplate) {
+        this.plaintextTemplate = plaintextTemplate;
+    }
+
+    public String getHtmlTemplate() {
+        return htmlTemplate;
+    }
+
+    public void setHtmlTemplate(String htmlTemplate) {
+        this.htmlTemplate = htmlTemplate;
+    }
+
+    public String getEmailSubject() {
+        return emailSubject;
+    }
+
+    public void setEmailSubject(String emailSubject) {
+        this.emailSubject = emailSubject;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/ContentEmailDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/ContentEmailDTO.java
@@ -4,8 +4,9 @@ import uk.ac.cam.cl.dtg.segue.dto.content.EmailTemplateDTO;
 
 import java.util.List;
 
-public class ContentEmailDTO extends EmailTemplateDTO {
+public class ContentEmailDTO {
     private List<Long> userIds;
+    private EmailTemplateDTO emailTemplate;
 
     /**
      * Default constructor.
@@ -18,5 +19,13 @@ public class ContentEmailDTO extends EmailTemplateDTO {
 
     public void setUserIds(List<Long> userIds) {
         this.userIds = userIds;
+    }
+
+    public EmailTemplateDTO getEmailTemplate() {
+        return emailTemplate;
+    }
+
+    public void setEmailTemplate(EmailTemplateDTO emailTemplate) {
+        this.emailTemplate = emailTemplate;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/ContentEmailDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/ContentEmailDTO.java
@@ -7,6 +7,7 @@ public class ContentEmailDTO {
     private String plaintextTemplate;
     private String htmlTemplate;
     private String emailSubject;
+    private String overrideFromAddress;
 
     /**
      * Default constructor.
@@ -43,5 +44,13 @@ public class ContentEmailDTO {
 
     public void setEmailSubject(String emailSubject) {
         this.emailSubject = emailSubject;
+    }
+
+    public String getOverrideFromAddress() {
+        return overrideFromAddress;
+    }
+
+    public void setOverrideFromAddress(final String overrideFromAddress) {
+        this.overrideFromAddress = overrideFromAddress;
     }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
@@ -650,6 +650,60 @@ public class EmailManagerTest {
     }
 
     /**
+     * Check we don't send custom content emails to users with null / preference
+     */
+    @Test
+    public void sendCustomContentEmail_checkNullProperties_replacedWithEmptyString() {
+
+        EmailManager manager = new EmailManager(emailCommunicator, userPreferenceManager, mockPropertiesLoader,
+                mockContentManager, logManager, generateGlobalTokenMap());
+
+        List<RegisteredUserDTO> allSelectedUsers = Lists.newArrayList();
+        allSelectedUsers.add(userDTOWithNulls);
+        allSelectedUsers.add(userDTOWithNulls);
+
+        UserPreference userPreference = new UserPreference(userDTOWithNulls.getId(), SegueUserPreferences.EMAIL_PREFERENCE.name(), "ASSIGNMENTS", false);
+        try {
+            EasyMock.expect(userPreferenceManager.getUserPreference(SegueUserPreferences.EMAIL_PREFERENCE.name(), "ASSIGNMENTS", userDTOWithNulls.getId())).andReturn(userPreference);
+            EasyMock.expect(userPreferenceManager.getUserPreference(SegueUserPreferences.EMAIL_PREFERENCE.name(), "ASSIGNMENTS", userDTOWithNulls.getId())).andReturn(userPreference);
+        } catch (SegueDatabaseException e1) {
+            e1.printStackTrace();
+            Assert.fail();
+        }
+        EasyMock.replay(userPreferenceManager);
+
+        ContentDTO htmlTemplate = createDummyContentTemplate("{{content}}");
+        String htmlContent = "hi {{givenName}}<br><br>This is a test";
+        String plainTextContent = "hi {{givenName}}\n\nThis is a test";
+        String subject = "Test email";
+
+        try {
+
+            EasyMock.expect(mockContentManager.getContentById(CONTENT_VERSION, "email-template-html"))
+                    .andReturn(htmlTemplate).times(allSelectedUsers.size());
+
+            EasyMock.expect(mockContentManager.getContentById(CONTENT_VERSION, "email-template-ascii"))
+                    .andReturn(htmlTemplate).times(allSelectedUsers.size());
+
+            EasyMock.expect(mockContentManager.getCurrentContentSHA()).andReturn(CONTENT_VERSION).atLeastOnce();
+
+            EasyMock.replay(mockContentManager);
+        } catch (ContentManagerException e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+
+        try {
+            manager.sendCustomContentEmail(userDTOWithNulls, plainTextContent, htmlContent, subject, null, allSelectedUsers, EmailType.ASSIGNMENTS);
+        } catch (SegueDatabaseException e) {
+            Assert.fail();
+        } catch (ContentManagerException e) {
+            Assert.fail();
+        }
+
+    }
+
+    /**
      * Make sure that when the templates are published:false, that the method reacts appropriately.
      */
     @Test

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
@@ -677,6 +677,11 @@ public class EmailManagerTest {
         String plainTextContent = "hi {{givenName}}\n\nThis is a test";
         String subject = "Test email";
 
+        EmailTemplateDTO emailTemplate = new EmailTemplateDTO();
+        emailTemplate.setHtmlContent(htmlContent);
+        emailTemplate.setPlainTextContent(plainTextContent);
+        emailTemplate.setSubject(subject);
+
         try {
 
             EasyMock.expect(mockContentManager.getContentById(CONTENT_VERSION, "email-template-html"))
@@ -694,7 +699,7 @@ public class EmailManagerTest {
         }
 
         try {
-            manager.sendCustomContentEmail(userDTOWithNulls, plainTextContent, htmlContent, subject, null, allSelectedUsers, EmailType.ASSIGNMENTS);
+            manager.sendCustomContentEmail(userDTOWithNulls, emailTemplate, allSelectedUsers, EmailType.ASSIGNMENTS);
         } catch (SegueDatabaseException e) {
             Assert.fail();
         } catch (ContentManagerException e) {


### PR DESCRIPTION
The facade method itself is lifted from the admin email sending endpoint directly above it. I believe we accept the required props for sending this new custom email, but perhaps we'd like it to be more generic and accept `overrideFromName` etc - I could rewrite the endpoint to take say a list of userIds plus an EmailTemplateDTO, most of which would be empty aside from the (html/plaintext)Content but this may futureproof any changes the content teams might ask for

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
