### PR TITLE
Check properties of registeredContext aren't null before calling them

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -738,9 +738,9 @@ public class EventsFacade extends AbstractIsaacFacade {
                 resultRow.add(resultAdditionalInformation.get("yearGroup"));
                 resultRow.add(resultAdditionalInformation.get("jobTitle"));
                 resultRow.add(String.join(" ", resultUser.getRegisteredContexts().stream()
-                        .map(uc -> uc.getStage().name()).collect(Collectors.toSet())));
+                        .map(uc -> uc.getStage() != null ? uc.getStage().name() : "").collect(Collectors.toSet())));
                 resultRow.add(String.join(" ", resultUser.getRegisteredContexts().stream()
-                        .map(uc -> uc.getExamBoard().name()).collect(Collectors.toSet())));
+                        .map(uc -> uc.getExamBoard() != null ? uc.getExamBoard().name() : "").collect(Collectors.toSet())));
                 resultRow.add(resultAdditionalInformation.get("experienceLevel"));
                 resultRow.add(resultAdditionalInformation.get("medicalRequirements"));
                 resultRow.add(resultAdditionalInformation.get("accessibilityRequirements"));


### PR DESCRIPTION
This feels a bit wrong, but given we use the endpoint without knowing the site we have to return the examBoard even when it either isn't set (fine) or is set to null (bad) in the registeredContext on Phy. I added a null check for the stage too to be safe. Is this a reasonable way to do an inline null check in Java or should I use the nullable check from utils?