### PR TITLE
Add deprecated attribute to Content and all subclasses

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
@@ -81,7 +81,9 @@ public class IsaacEventPage extends Content {
 						  @JsonProperty("layout") String layout,
 						  @JsonProperty("children") List<ContentBase> children,
 						  @JsonProperty("relatedContent") List<String> relatedContent,
-						  @JsonProperty("version") boolean published, @JsonProperty("tags") Set<String> tags,
+						  @JsonProperty("version") boolean published,
+						  @JsonProperty("deprecated") Boolean deprecated,
+						  @JsonProperty("tags") Set<String> tags,
 						  @JsonProperty("date") Date date, @JsonProperty("end_date") Date end_date,
 						  @JsonProperty("bookingDeadline") Date bookingDeadline,
 						  @JsonProperty("prepWorkDeadline") Date prepWorkDeadline,
@@ -94,7 +96,7 @@ public class IsaacEventPage extends Content {
 						  @JsonProperty("groupReservationLimit") Integer groupReservationLimit,
 						  @JsonProperty("allowGroupReservations") Boolean allowGroupReservations) {
 		super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null,
-			null, relatedContent, published, tags, null);
+			null, relatedContent, published, deprecated, tags, null);
 
 		this.date = date;
 		this.end_date = end_date;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFeaturedProfile.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFeaturedProfile.java
@@ -54,6 +54,7 @@ public class IsaacFeaturedProfile extends Content {
 			@JsonProperty("attribution") String attribution,
 			@JsonProperty("relatedContent") List<String> relatedContent,
 			@JsonProperty("version") boolean published,
+			@JsonProperty("deprecated") Boolean deprecated,
 			@JsonProperty("tags") Set<String> tags,
 			@JsonProperty("level") Integer level,
 			@JsonProperty("emailAddress") String emailAddress,
@@ -61,7 +62,7 @@ public class IsaacFeaturedProfile extends Content {
 			@JsonProperty("homepage") String homepage) {
 		super(id, title, subtitle, type, author, encoding,
 				canonicalSourceFile, layout, children, value, attribution,
-				relatedContent, published, tags, level);
+				relatedContent, published, deprecated, tags, level);
 
 		this.emailAddress = emailAddress;
 		this.image = image;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPod.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPod.java
@@ -40,7 +40,8 @@ public class IsaacPod extends Content {
 
 	@JsonCreator
 	public IsaacPod(
-			@JsonProperty("id") String id, @JsonProperty("title") String title,
+			@JsonProperty("id") String id,
+			@JsonProperty("title") String title,
 			@JsonProperty("subtitle") String subtitle,
 			@JsonProperty("type") String type,
 			@JsonProperty("author") String author,
@@ -52,6 +53,7 @@ public class IsaacPod extends Content {
 			@JsonProperty("attribution") String attribution,
 			@JsonProperty("relatedContent") List<String> relatedContent,
 			@JsonProperty("version") boolean published,
+			@JsonProperty("deprecated") Boolean deprecated,
 			@JsonProperty("tags") Set<String> tags,
 			@JsonProperty("level") Integer level,
 			@JsonProperty("emailAddress") String emailAddress,
@@ -59,7 +61,7 @@ public class IsaacPod extends Content {
 			@JsonProperty("url") String url) {
 		super(id, title, subtitle, type, author, encoding,
 				canonicalSourceFile, layout, children, value, attribution,
-				relatedContent, published, tags, level);
+				relatedContent, published, deprecated, tags, level);
 
 		this.url = url;
 		this.image = image;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
@@ -46,11 +46,12 @@ public class IsaacQuestionPage extends SeguePage {
             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBase> children,
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") boolean published,
+            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level,
             @JsonProperty("difficulty") Integer difficulty, @JsonProperty("passMark") Float passMark,
             @JsonProperty("supersededBy") String supersededBy) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
 
         this.passMark = passMark;
         this.supersededBy = supersededBy;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
@@ -52,13 +52,14 @@ public class IsaacQuiz extends SeguePage {
             @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent,
             @JsonProperty("version") boolean published,
+            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
             @JsonProperty("visibleToStudents") boolean visibleToStudents,
             @JsonProperty("rubric") Content rubric){
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, tags, level);
+                relatedContent, published, deprecated, tags, level);
 
         this.visibleToStudents = visibleToStudents;
         this.rubric = rubric;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuizSection.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuizSection.java
@@ -42,9 +42,10 @@ public class IsaacQuizSection extends Content {
                             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBase> children,
                             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
                             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") boolean published,
+                            @JsonProperty("deprecated") Boolean deprecated,
                             @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacWildcard.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacWildcard.java
@@ -44,10 +44,11 @@ public class IsaacWildcard extends Content {
             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBase> children,
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") boolean published,
+            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level,
             @JsonProperty("description") String description, @JsonProperty("url") String url) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
 
         this.description = description;
         this.url = url;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -110,6 +110,7 @@ public class IsaacEventPageDTO extends ContentDTO {
                              @JsonProperty("children") List<ContentBaseDTO> children,
                              @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
                              @JsonProperty("version") boolean published,
+                             @JsonProperty("deprecated") Boolean deprecated,
                              @JsonProperty("tags") Set<String> tags,
                              @JsonProperty("date") Date date,
                              @JsonProperty("end_date") Date end_date,
@@ -124,7 +125,7 @@ public class IsaacEventPageDTO extends ContentDTO {
                              @JsonProperty("groupReservationLimit") Integer groupReservationLimit,
                              @JsonProperty("allowGroupReservations") Boolean allowGroupReservations) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null, null,
-                relatedContent, published, tags, null);
+                relatedContent, published, deprecated, tags, null);
 
         this.date = date;
         this.end_date = end_date;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFeaturedProfileDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFeaturedProfileDTO.java
@@ -46,11 +46,12 @@ public class IsaacFeaturedProfileDTO extends ContentDTO {
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("version") boolean published, @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("level") Integer level, @JsonProperty("src") String src,
             @JsonProperty("altText") String altText, @JsonProperty("emailAddress") String emailAddress,
             @JsonProperty("image") ImageDTO image, @JsonProperty("homepage") String homepage) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
 
         this.emailAddress = emailAddress;
         this.image = image;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
@@ -50,13 +50,14 @@ public class IsaacPodDTO extends ContentDTO {
 			@JsonProperty("attribution") String attribution,
 			@JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
 			@JsonProperty("version") boolean published,
+			@JsonProperty("deprecated") Boolean deprecated,
 			@JsonProperty("tags") Set<String> tags,
 			@JsonProperty("level") Integer level,
 			@JsonProperty("image") ImageDTO image,
 			@JsonProperty("url") String url) {
 		super(id, title, subtitle, type, author, encoding,
 				canonicalSourceFile, layout, children, value, attribution,
-				relatedContent, published, tags, level);
+				relatedContent, published, deprecated, tags, level);
 
 		this.url = url;
 		this.image = image;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
@@ -45,11 +45,12 @@ public class IsaacQuestionPageDTO extends SeguePageDTO {
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("published") Boolean published, @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("level") Integer level, @JsonProperty("difficulty") Integer difficulty,
             @JsonProperty("passMark") Float passMark, @JsonProperty("supersededBy") String supersededBy) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
 
         this.passMark = passMark;
         this.supersededBy = supersededBy;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
@@ -61,6 +61,7 @@ public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleO
             @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("version") boolean published,
+            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
             @JsonProperty("visibleToStudents") boolean visibleToStudents,
@@ -68,7 +69,7 @@ public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleO
             @JsonProperty("rubric") ContentDTO rubric) {
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, tags, level);
+                relatedContent, published, deprecated, tags, level);
 
         this.visibleToStudents = visibleToStudents;
         this.defaultFeedbackMode = defaultFeedbackMode;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizSectionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizSectionDTO.java
@@ -41,10 +41,11 @@ public class IsaacQuizSectionDTO extends SeguePageDTO {
                                @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
                                @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
                                @JsonProperty("published") Boolean published, @JsonProperty("tags") Set<String> tags,
+                               @JsonProperty("deprecated") Boolean deprecated,
                                @JsonProperty("level") Integer level) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacWildcardDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacWildcardDTO.java
@@ -46,12 +46,13 @@ public class IsaacWildcardDTO extends ContentDTO {
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("version") boolean published, @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("level") Integer level, @JsonProperty("src") String src,
             @JsonProperty("altText") String altText, @JsonProperty("emailAddress") String emailAddress,
             @JsonProperty("image") Image image, @JsonProperty("description") String description,
             @JsonProperty("url") String url) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
 
         this.description = description;
         this.url = url;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/Content.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/Content.java
@@ -48,6 +48,7 @@ public class Content extends ContentBase {
     protected String attribution;
     protected List<String> relatedContent;
     protected Boolean published;
+    protected Boolean deprecated;
     protected Integer level;
     protected String searchableContent;
 
@@ -59,7 +60,8 @@ public class Content extends ContentBase {
             @JsonProperty("children") List<ContentBase> children, @JsonProperty("value") String value,
             @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") Boolean published,
-            @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
+            @JsonProperty("deprecated") Boolean deprecated, @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("level") Integer level) {
         this.id = id;
         this.title = title;
         this.subtitle = subtitle;
@@ -72,6 +74,7 @@ public class Content extends ContentBase {
         this.attribution = attribution;
         this.relatedContent = relatedContent;
         this.published = published;
+        this.deprecated = deprecated;
         this.children = children;
         this.tags = tags;
         this.level = level;
@@ -200,6 +203,18 @@ public class Content extends ContentBase {
      */
     public final void setChildren(List<ContentBase> children) {
         this.children = children;
+    }
+
+    public Boolean getDeprecated() {
+        if (null == deprecated) {
+            return false;
+        }
+
+        return deprecated;
+    }
+
+    public void setDeprecated(Boolean deprecated) {
+        this.deprecated = deprecated;
     }
 
     public Integer getLevel() {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/Content.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/Content.java
@@ -206,10 +206,6 @@ public class Content extends ContentBase {
     }
 
     public Boolean getDeprecated() {
-        if (null == deprecated) {
-            return false;
-        }
-
         return deprecated;
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/EmailTemplate.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/EmailTemplate.java
@@ -59,9 +59,10 @@ public class EmailTemplate extends Content {
     public EmailTemplate(final String _id, final String id, final String title, final String subtitle,
             final String type, final String author, final String encoding, final String canonicalSourceFile,
             final String layout, final List<ContentBase> children, final String value, final String attribution,
-            final List<String> relatedContent, final Boolean published, final Set<String> tags, final Integer level) {
+            final List<String> relatedContent, final Boolean published, final Boolean deprecated,
+                         final Set<String> tags, final Integer level) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
 
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/SeguePage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/SeguePage.java
@@ -40,10 +40,11 @@ public class SeguePage extends Content {
             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBase> children,
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") Boolean published,
-            @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
+            @JsonProperty("deprecated") Boolean deprecated, @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("level") Integer level) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
 
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/ContentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/ContentDTO.java
@@ -44,6 +44,7 @@ public class ContentDTO extends ContentBaseDTO {
     protected String attribution;
     protected List<ContentSummaryDTO> relatedContent;
     protected Boolean published;
+    protected Boolean deprecated;
     protected Integer level;
 
     @JsonCreator
@@ -54,8 +55,8 @@ public class ContentDTO extends ContentBaseDTO {
             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBaseDTO> children,
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
-            @JsonProperty("published") Boolean published, @JsonProperty("tags") Set<String> tags,
-            @JsonProperty("level") Integer level) {
+            @JsonProperty("published") Boolean published, @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
         this.id = id;
         this.title = title;
         this.subtitle = subtitle;
@@ -68,6 +69,7 @@ public class ContentDTO extends ContentBaseDTO {
         this.attribution = attribution;
         this.relatedContent = relatedContent;
         this.published = published;
+        this.deprecated = deprecated;
         this.children = children;
         this.tags = tags;
         this.level = level;
@@ -202,6 +204,14 @@ public class ContentDTO extends ContentBaseDTO {
      */
     public void setPublished(final Boolean published) {
         this.published = published;
+    }
+
+    public Boolean getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(Boolean deprecated) {
+        this.deprecated = deprecated;
     }
 
     public Integer getLevel() {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/EmailTemplateDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/EmailTemplateDTO.java
@@ -63,7 +63,7 @@ public class EmailTemplateDTO extends ContentDTO {
             final Set<String> tags, final Integer level) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
                 attribution, relatedContent, published, deprecated, tags, level);
-    } // TODO CP REMOVE THIS AND TEST
+    }
 
     /**
      * @param value

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/EmailTemplateDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/EmailTemplateDTO.java
@@ -52,18 +52,18 @@ public class EmailTemplateDTO extends ContentDTO {
      * @param attribution
      * @param relatedContent
      * @param published
+     * @param deprecated
      * @param tags
      * @param level
      */
     public EmailTemplateDTO(final String _id, final String id, final String title, final String subtitle,
             final String type, final String author, final String encoding, final String canonicalSourceFile,
             final String layout, final List<ContentBaseDTO> children, final String value, final String attribution,
-            final List<ContentSummaryDTO> relatedContent, final Boolean published, final Set<String> tags,
-            final Integer level) {
+            final List<ContentSummaryDTO> relatedContent, final Boolean published, final Boolean deprecated,
+            final Set<String> tags, final Integer level) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
-
-    }
+                attribution, relatedContent, published, deprecated, tags, level);
+    } // TODO CP REMOVE THIS AND TEST
 
     /**
      * @param value

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/SeguePageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/SeguePageDTO.java
@@ -37,11 +37,11 @@ public class SeguePageDTO extends ContentDTO {
             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBaseDTO> children,
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
-            @JsonProperty("published") Boolean published, @JsonProperty("tags") Set<String> tags,
-            @JsonProperty("level") Integer level) {
+            @JsonProperty("published") Boolean published, @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, tags, level);
+                attribution, relatedContent, published, deprecated, tags, level);
 
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -149,12 +149,12 @@ public class IsaacTest {
         quizSection2.setId("studentQuiz|section2");
         quizSection2.setChildren(ImmutableList.of(question2, question3));
 
-        studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, true, QuizFeedbackMode.OVERALL_MARK, null);
-        teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, false, null, null);
-        otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, null, null, true, QuizFeedbackMode.DETAILED_FEEDBACK, null);
+        studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, false, null, null, true, QuizFeedbackMode.OVERALL_MARK, null);
+        teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, false, null, null, false, null, null);
+        otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, false, null, null, true, QuizFeedbackMode.DETAILED_FEEDBACK, null);
 
         // A bit scrappy, but hopefully sufficient.
-        studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, true, null);
+        studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, false, null, null, true, null);
 
         student = new RegisteredUserDTO("Some", "Student", "test-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "");
         student.setRole(Role.STUDENT);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/dao/GitContentManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/dao/GitContentManagerTest.java
@@ -161,7 +161,7 @@ public class GitContentManagerTest {
 	private Content createEmptyContentElement(final List<ContentBase> children,
 			final String id) {
 		return new Content(id, "", "", "", "", "", "", "", children, "",
-				"", new LinkedList<String>(), false, new HashSet<String>(), 1);
+				"", new LinkedList<String>(), false, false, new HashSet<String>(), 1);
 	}
 
 	/**

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -215,7 +215,7 @@ public class ContentIndexerTest {
     private Content createEmptyContentElement(final List<ContentBase> children,
                                               final String id) {
         return new Content(id, "", "", "", "", "", "", "", children, "",
-                "", new LinkedList<>(), false, new HashSet<>(), 1);
+                "", new LinkedList<>(), false, false, new HashSet<>(), 1);
     }
 
     /**


### PR DESCRIPTION
Doing this highlighted a weird inconsistency - some places in the API map the JSON attribute `version` to the Content class attribute `published`, but it doesn't look like `version` is actually used anywhere. This probably needs some kind of clean up.