### PR TITLE
Conditional Quartz startup

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -1304,7 +1304,7 @@ public class AdminFacade extends AbstractSegueFacade {
     @Path("/start_quartz")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Start the Quartz Job Scheduler service if not already started.")
-    public Response resetMisuseMonitor(@Context final HttpServletRequest request) {
+    public Response startQuartzJobService(@Context final HttpServletRequest request) {
         try {
             RegisteredUserDTO user = userManager.getCurrentRegisteredUser(request);
             if (!isUserAnAdmin(userManager, user)) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/InfoFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/InfoFacade.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.segue.configuration.SegueGuiceConfigurationModule;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
+import uk.ac.cam.cl.dtg.segue.scheduler.SegueJobService;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import javax.ws.rs.GET;
@@ -58,7 +59,7 @@ public class InfoFacade extends AbstractSegueFacade {
     private static final Logger log = LoggerFactory.getLogger(InfoFacade.class);
 
     private final IContentManager contentManager;
-    private final String contentIndex;
+    private final SegueJobService segueJobService;
 
     /**
      * @param properties
@@ -69,11 +70,12 @@ public class InfoFacade extends AbstractSegueFacade {
      *            - for logging events using the logging api.
      */
     @Inject
-    public InfoFacade(final PropertiesLoader properties, final IContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex,
+    public InfoFacade(final PropertiesLoader properties, final IContentManager contentManager,
+                      final SegueJobService segueJobService,
                       final ILogManager logManager) {
         super(properties, logManager);
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
+        this.segueJobService = segueJobService;
     }
 
     /**
@@ -270,5 +272,22 @@ public class InfoFacade extends AbstractSegueFacade {
             return Response.ok(ImmutableMap.of("success", false)).build();
         }
 
+    }
+
+    /**
+     * This method checks the status of the Quartz job service.
+     *
+     * @return json success true or false
+     */
+    @GET
+    @Path("quartz/ping")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Check whether Quartz job scheduler is running.")
+    public Response pingQuartzScheduler() {
+        if (segueJobService.isStarted()) {
+            return Response.ok(ImmutableMap.of("success", true)).build();
+        } else {
+            return Response.ok(ImmutableMap.of("success", false)).build();
+        }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -925,7 +925,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
                     "Sync users to mailjet",
                     "0 0 0/4 ? * * *");
 
-            List<SegueScheduledJob> configuredScheduledJobs = new ArrayList<>(Arrays.asList(PIISQLJob, cleanUpOldAnonymousUsers, cleanUpExpiredReservations));
+            List<SegueScheduledJob> configuredScheduledJobs = Arrays.asList(PIISQLJob, cleanUpOldAnonymousUsers, cleanUpExpiredReservations);
 
             if (mailjetKey != null && mailjetSecret != null) {
                 configuredScheduledJobs.add(syncMailjetUsers);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -143,6 +143,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -924,18 +925,17 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
                     "Sync users to mailjet",
                     "0 0 0/4 ? * * *");
 
-            Collection<SegueScheduledJob> configuredScheduledJobs = new ArrayList<>(Arrays.asList(PIISQLJob, cleanUpOldAnonymousUsers, cleanUpExpiredReservations));
+            List<SegueScheduledJob> configuredScheduledJobs = new ArrayList<>(Arrays.asList(PIISQLJob, cleanUpOldAnonymousUsers, cleanUpExpiredReservations));
 
             if (mailjetKey != null && mailjetSecret != null) {
                 configuredScheduledJobs.add(syncMailjetUsers);
             }
 
-            segueJobService = new SegueJobService(configuredScheduledJobs);
+            segueJobService = new SegueJobService(configuredScheduledJobs, database);
 
             if (mailjetKey == null && mailjetSecret == null) {
                 segueJobService.removeScheduleJob(syncMailjetUsers);
             }
-            log.info("Created Segue Job Manager for scheduled jobs");
         }
 
         return segueJobService;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/database/PostgresSqlDb.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/database/PostgresSqlDb.java
@@ -91,15 +91,13 @@ public class PostgresSqlDb implements Closeable {
      * Check whether the database is a read only replica or not.
      * @return whether the database is read only.
      */
-    public boolean isReadOnlyReplica() {
+    public boolean isReadOnlyReplica() throws SQLException {
         try (Connection conn = getDatabaseConnection()) {
             PreparedStatement pst;
             pst = conn.prepareStatement("SELECT pg_is_in_recovery()");
             ResultSet results = pst.executeQuery();
             results.next();
             return results.getBoolean(1);
-        } catch (SQLException e) {
-            return true;
         }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/database/PostgresSqlDb.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/database/PostgresSqlDb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,14 +15,14 @@
  */
 package uk.ac.cam.cl.dtg.segue.database;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-
+import com.google.inject.Inject;
 import org.apache.commons.dbcp2.BasicDataSource;
 
-import com.google.inject.Inject;
+import java.io.Closeable;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * PostgresSqlDb adapter.
@@ -85,5 +85,21 @@ public class PostgresSqlDb implements Closeable {
             e.printStackTrace();
         }
 
+    }
+
+    /**
+     * Check whether the database is a read only replica or not.
+     * @return whether the database is read only.
+     */
+    public boolean isReadOnlyReplica() {
+        try (Connection conn = getDatabaseConnection()) {
+            PreparedStatement pst;
+            pst = conn.prepareStatement("SELECT pg_is_in_recovery()");
+            ResultSet results = pst.executeQuery();
+            results.next();
+            return results.getBoolean(1);
+        } catch (SQLException e) {
+            return true;
+        }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/database/PostgresSqlDb.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/database/PostgresSqlDb.java
@@ -92,10 +92,10 @@ public class PostgresSqlDb implements Closeable {
      * @return whether the database is read only.
      */
     public boolean isReadOnlyReplica() throws SQLException {
-        try (Connection conn = getDatabaseConnection()) {
-            PreparedStatement pst;
-            pst = conn.prepareStatement("SELECT pg_is_in_recovery()");
-            ResultSet results = pst.executeQuery();
+        try (Connection conn = getDatabaseConnection();
+             PreparedStatement pst = conn.prepareStatement("SELECT pg_is_in_recovery()");
+             ResultSet results = pst.executeQuery();
+        ) {
             results.next();
             return results.getBoolean(1);
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SchedulerClusterDataSource.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SchedulerClusterDataSource.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.segue.scheduler;
 
-import com.google.inject.Injector;
 import org.quartz.utils.ConnectionProvider;
 import uk.ac.cam.cl.dtg.segue.configuration.SegueGuiceConfigurationModule;
 import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
@@ -29,13 +28,11 @@ import java.sql.SQLException;
  */
 public class SchedulerClusterDataSource implements ConnectionProvider {
 
-    private static Injector injector;
     private static PostgresSqlDb ds;
 
     public SchedulerClusterDataSource() {
         // horrible dependency injection hack because quartz insists on initialising its own db connection class.
-        injector = SegueGuiceConfigurationModule.getGuiceInjector();
-        ds = injector.getInstance(PostgresSqlDb.class);
+        ds = SegueGuiceConfigurationModule.getGuiceInjector().getInstance(PostgresSqlDb.class);
     }
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
@@ -135,7 +135,7 @@ public class SegueJobService implements ServletContextListener {
     /**
      *  Attempt to register all known jobs and start the scheduler service.
      */
-    public void initialiseService() throws SchedulerException {
+    public synchronized void initialiseService() throws SchedulerException {
         if (!isStarted()) {
             this.registerScheduledJobs(allKnownJobs);
             scheduler.start();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
@@ -30,6 +30,7 @@ import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -62,7 +63,7 @@ public class SegueJobService implements ServletContextListener {
             } else {
                 log.warn("Segue Job Service: Not starting due to readonly database.");
             }
-        } catch (SchedulerException e) {
+        } catch (SchedulerException | SQLException e) {
             throw new RuntimeException("Segue Job Service: Failed to schedule quartz jobs or start scheduler! Aborting!", e);
         }
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
@@ -20,13 +20,13 @@ import org.quartz.CronTrigger;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
-import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.TriggerBuilder;
 import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
@@ -40,34 +40,30 @@ public class SegueJobService implements ServletContextListener {
 
     private final Scheduler scheduler;
 
+    private final List<SegueScheduledJob> allKnownJobs;
     private final List<SegueScheduledJob> localRegisteredJobs;
 
     private static final Logger log = LoggerFactory.getLogger(SegueJobService.class);
 
     /**
      * A job manager that can execute jobs on a schedule or by trigger.
-     * @param staticallyConfiguredScheduledJobs Collection of statically configured jobs
+     * @param allKnownJobs Collection of jobs to register
      */
     @Inject
-    public SegueJobService(Collection<SegueScheduledJob> staticallyConfiguredScheduledJobs) {
+    public SegueJobService(List<SegueScheduledJob> allKnownJobs, PostgresSqlDb database) {
+        this.allKnownJobs = allKnownJobs;
         this.localRegisteredJobs = new ArrayList<>();
         StdSchedulerFactory stdSchedulerFactory = new StdSchedulerFactory();
 
         try {
             scheduler = stdSchedulerFactory.getScheduler();
-
+            if (!database.isReadOnlyReplica()) {
+                initialiseService();
+            } else {
+                log.warn("Segue Job Service: Not starting due to readonly database.");
+            }
         } catch (SchedulerException e) {
-            throw new RuntimeException("Unable to initialise the scheduler", e);
-        }
-
-        // try to schedule / reschedule jobs
-        try {
-            // register statically configured jobs
-            this.registerScheduledJobs(staticallyConfiguredScheduledJobs);
-
-            scheduler.start();
-        } catch (SchedulerException e) {
-            log.error("Scheduler ERROR - Unable to to schedule quartz jobs or start scheduler on this API instance. Aborting...", e);
+            throw new RuntimeException("Segue Job Service: Failed to schedule quartz jobs or start scheduler! Aborting!", e);
         }
     }
 
@@ -127,15 +123,33 @@ public class SegueJobService implements ServletContextListener {
         localRegisteredJobs.add(jobToRegister);
     }
 
+    public boolean isStarted() {
+        try {
+            return scheduler.isStarted();
+        } catch (SchedulerException e) {
+            return false;
+        }
+    }
+
+    /**
+     *  Attempt to register all known jobs and start the scheduler service.
+     */
+    public void initialiseService() throws SchedulerException {
+        if (!isStarted()) {
+            this.registerScheduledJobs(allKnownJobs);
+            scheduler.start();
+            log.info("Segue Job Service started.");
+        }
+    }
+
     @Override
     public void contextInitialized(ServletContextEvent servletContextEvent) {
-        log.info("Segue Job Service Initialised");
     }
 
     @Override
     public void contextDestroyed(ServletContextEvent servletContextEvent) {
         try {
-            log.info("Shutting down segue scheduler");
+            log.info("Shutting down Segue Job Service");
             this.scheduler.shutdown(true);
         } catch (SchedulerException e) {
             log.error("Error while attempting to shutdown Segue Scheduler.", e);


### PR DESCRIPTION
I had intended to prevent Quartz from attempting to start on the standby (and then failing, because of the read-only database) by using a configuration flag. But it occurred to me it would be more sensible to just find out directly if the database is readonly and not start if so. That avoids the risk of the config getting out of sync, and means it fails-safe if we forget about it; Quartz will start if it would be able to run successfully.

Obviously if it doesn't start at API startup, we then need some way of starting it later, hence an admin endpoint to do so. Note that that endpoint does not check the database status and just attempts to initialise Quartz regardless.
To ensure we cannot forget to start Quartz, or leave it not running for extended periods, also add an info endpoint that can be used to monitor the status of Quartz on the live server.