### PR TITLE
Do not make additional status code checks on MailJet requests

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/util/email/MailJetApiClientWrapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/email/MailJetApiClientWrapper.java
@@ -78,11 +78,6 @@ public class MailJetApiClientWrapper {
         }
         MailjetRequest request = new MailjetRequest(Contact.resource, mailjetIdOrEmail);
         MailjetResponse response = mailjetClient.get(request);
-        int responseStatus = response.getStatus();
-        if (responseStatus != Response.Status.OK.getStatusCode()) {
-            log.error("Failed to talk to MailJet!");
-            throw new MailjetException(String.format("Failed to successfully get user, status code: %s", responseStatus));
-        }
         JSONArray responseData = response.getData();
         if (response.getTotal() == 1) {
             return responseData.getJSONObject(0);
@@ -99,12 +94,7 @@ public class MailJetApiClientWrapper {
     public void permanentlyDeleteAccountById(final String mailjetId) throws MailjetException {
         Validate.notNull(mailjetId);
         MailjetRequest request = new MailjetRequest(Contacts.resource, mailjetId);
-        MailjetResponse response = mailjetClient.delete(request);
-        int responseStatus = response.getStatus();
-        if (!(responseStatus == Response.Status.OK.getStatusCode())) {
-            // TODO: Do we want to get any of the data from this request?
-            throw new MailjetException("Failed to delete user!");
-        }
+        mailjetClient.delete(request);
     }
 
     /**
@@ -123,11 +113,6 @@ public class MailJetApiClientWrapper {
         try {
             MailjetRequest request = new MailjetRequest(Contact.resource).property(Contact.EMAIL, email);
             MailjetResponse response = mailjetClient.post(request);
-            int responseStatus = response.getStatus();
-            if (responseStatus != Response.Status.OK.getStatusCode()) {
-                log.error("Failed to talk to MailJet!");
-                throw new MailjetException(String.format("Failed to successfully get user, status code: %s", responseStatus));
-            }
             // Get MailJet ID out:
             JSONObject responseData = response.getData().getJSONObject(0);
             return Integer.toString(responseData.getInt("ID"));
@@ -162,11 +147,6 @@ public class MailJetApiClientWrapper {
                         .put(new JSONObject().put("Name", "verification_status").put("value", email_verification_status))
                 );
         MailjetResponse response = mailjetClient.put(request);
-        int responseStatus = response.getStatus();
-        if (responseStatus != Response.Status.OK.getStatusCode()) {
-            log.error("Failed to talk to MailJet!");
-            throw new MailjetException(String.format("Failed to successfully get user, status code: %s", responseStatus));
-        }
         if (response.getTotal() != 1) {
             // TODO: Do we want to get any of the data from this request?
             throw new MailjetException("Failed to update user!" + response.getTotal());
@@ -192,11 +172,6 @@ public class MailJetApiClientWrapper {
                                 .put(ContactslistImportList.ACTION, eventsEmails.value))
                 );
         MailjetResponse response = mailjetClient.post(request);
-        int responseStatus = response.getStatus();
-        if (responseStatus != Response.Status.OK.getStatusCode()) {
-            log.error("Failed to talk to MailJet!");
-            throw new MailjetException(String.format("Failed to successfully get user, status code: %s", responseStatus));
-        }
         if (response.getTotal() != 1) {
             // TODO: Do we want to get any of the data from this request?
             throw new MailjetException("Failed to update user subscriptions!" + response.getTotal());


### PR DESCRIPTION
MailJet's API actually already does this under the hood in [`MailjetResponseUtil::validateMailjetResponse`](https://github.com/mailjet/mailjet-apiv3-java/blob/mailjet-client-5.2.0/src/main/java/com/mailjet/client/MailjetResponseUtil.java#L28-L40) and we're blocking the 202 and 201 status codes they sometimes use with the old implementation we had!

This was my mistake, I asked Ben to add this and I shouldn't have.