### PR TITLE
Add stage and difficulty stats to getUserQuestionInformation

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -37,8 +37,11 @@ import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
 import uk.ac.cam.cl.dtg.segue.dao.schools.SchoolListReader;
 import uk.ac.cam.cl.dtg.segue.dao.schools.UnableToIndexSchoolsException;
+import uk.ac.cam.cl.dtg.segue.dos.AudienceContext;
+import uk.ac.cam.cl.dtg.segue.dos.Difficulty;
 import uk.ac.cam.cl.dtg.segue.dos.IUserStreaksManager;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
+import uk.ac.cam.cl.dtg.segue.dos.Stage;
 import uk.ac.cam.cl.dtg.segue.dos.users.Role;
 import uk.ac.cam.cl.dtg.segue.dos.users.School;
 import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
@@ -62,6 +65,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -412,6 +416,8 @@ public class StatisticsManager implements IStatisticsManager {
         int attemptedQuestionPartsThisAcademicYear = 0;
         Map<String, Integer> questionAttemptsByTagStats = Maps.newHashMap();
         Map<String, Integer> questionsCorrectByTagStats = Maps.newHashMap();
+        Map<Stage, Map<Difficulty, Integer>> questionAttemptsByStageAndDifficultyStats = Maps.newHashMap();
+        Map<Stage, Map<Difficulty, Integer>> questionsCorrectByStageAndDifficultyStats = Maps.newHashMap();
         Map<String, Integer> questionAttemptsByLevelStats = Maps.newHashMap();
         Map<String, Integer> questionsCorrectByLevelStats = Maps.newHashMap();
         Map<String, Integer> questionAttemptsByTypeStats = Maps.newHashMap();
@@ -523,6 +529,52 @@ public class StatisticsManager implements IStatisticsManager {
                 }
             }
 
+            // Stage and difficulty Stats
+            // This is hideous, sorry
+            if (questionContentDTO.getAudience() != null) {
+                for (AudienceContext audience : questionContentDTO.getAudience()) {
+                    // Check the question has both a stage and a difficulty
+                    if (audience.getStage() != null && audience.getDifficulty() != null) {
+                        // Count the attempt at the question
+                        if (questionAttemptsByStageAndDifficultyStats.containsKey(audience.getStage().get(0))) {
+                            if (questionAttemptsByStageAndDifficultyStats.get(audience.getStage().get(0)).containsKey(audience.getDifficulty().get(0))) {
+                                questionAttemptsByStageAndDifficultyStats.get(
+                                        audience.getStage().get(0)).put(
+                                                audience.getDifficulty().get(0),
+                                                questionAttemptsByStageAndDifficultyStats.get(
+                                                        audience.getStage().get(0)).get(
+                                                                audience.getDifficulty().get(0)) + 1);
+                            } else {
+                                questionAttemptsByStageAndDifficultyStats.get(audience.getStage().get(0)).put(audience.getDifficulty().get(0), 1);
+                            }
+                        } else {
+                            questionAttemptsByStageAndDifficultyStats.put(audience.getStage().get(0), new HashMap() {{
+                                put(audience.getDifficulty().get(0), 1);
+                            }});
+                        }
+
+                        // If correct, count this too:
+                        if (questionIsCorrect) {
+                            if (questionsCorrectByStageAndDifficultyStats.containsKey(audience.getStage().get(0))) {
+                                if (questionsCorrectByStageAndDifficultyStats.get(audience.getStage().get(0)).containsKey(audience.getDifficulty().get(0))) {
+                                    questionsCorrectByStageAndDifficultyStats.get(
+                                            audience.getStage().get(0)).put(
+                                                    audience.getDifficulty().get(0),
+                                                    questionsCorrectByStageAndDifficultyStats.get(
+                                                            audience.getStage().get(0)).get(audience.getDifficulty().get(0)) + 1);
+                                } else {
+                                    questionsCorrectByStageAndDifficultyStats.get(audience.getStage().get(0)).put(audience.getDifficulty().get(0), 1);
+                                }
+                            } else {
+                                questionsCorrectByStageAndDifficultyStats.put(audience.getStage().get(0), new HashMap() {{
+                                    put(audience.getDifficulty().get(0), 1);
+                                }});
+                            }
+                        }
+                    }
+                }
+            }
+
             // Level Stats:
             Integer questionLevelInteger = questionContentDTO.getLevel();
             String questionLevel;
@@ -576,6 +628,8 @@ public class StatisticsManager implements IStatisticsManager {
         questionInfo.put("totalQuestionPartsAttemptedThisAcademicYear", attemptedQuestionPartsThisAcademicYear);
         questionInfo.put("attemptsByTag", questionAttemptsByTagStats);
         questionInfo.put("correctByTag", questionsCorrectByTagStats);
+        questionInfo.put("attemptsByStageAndDifficulty", questionAttemptsByStageAndDifficultyStats);
+        questionInfo.put("correctByStageAndDifficulty", questionsCorrectByStageAndDifficultyStats);
         questionInfo.put("attemptsByLevel", questionAttemptsByLevelStats);
         questionInfo.put("correctByLevel", questionsCorrectByLevelStats);
         questionInfo.put("attemptsByType", questionAttemptsByTypeStats);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -535,39 +535,41 @@ public class StatisticsManager implements IStatisticsManager {
                 for (AudienceContext audience : questionContentDTO.getAudience()) {
                     // Check the question has both a stage and a difficulty
                     if (audience.getStage() != null && audience.getDifficulty() != null) {
+                        Stage currentStage = audience.getStage().get(0);
+                        Difficulty currentDifficulty = audience.getDifficulty().get(0);
                         // Count the attempt at the question
-                        if (questionAttemptsByStageAndDifficultyStats.containsKey(audience.getStage().get(0))) {
-                            if (questionAttemptsByStageAndDifficultyStats.get(audience.getStage().get(0)).containsKey(audience.getDifficulty().get(0))) {
+                        if (questionAttemptsByStageAndDifficultyStats.containsKey(currentStage)) {
+                            if (questionAttemptsByStageAndDifficultyStats.get(currentStage).containsKey(currentDifficulty)) {
                                 questionAttemptsByStageAndDifficultyStats.get(
-                                        audience.getStage().get(0)).put(
-                                                audience.getDifficulty().get(0),
+                                        currentStage).put(
+                                        currentDifficulty,
                                                 questionAttemptsByStageAndDifficultyStats.get(
-                                                        audience.getStage().get(0)).get(
-                                                                audience.getDifficulty().get(0)) + 1);
+                                                        currentStage).get(
+                                                        currentDifficulty) + 1);
                             } else {
-                                questionAttemptsByStageAndDifficultyStats.get(audience.getStage().get(0)).put(audience.getDifficulty().get(0), 1);
+                                questionAttemptsByStageAndDifficultyStats.get(currentStage).put(currentDifficulty, 1);
                             }
                         } else {
-                            questionAttemptsByStageAndDifficultyStats.put(audience.getStage().get(0), new HashMap() {{
-                                put(audience.getDifficulty().get(0), 1);
+                            questionAttemptsByStageAndDifficultyStats.put(currentStage, new HashMap() {{
+                                put(currentDifficulty, 1);
                             }});
                         }
 
                         // If correct, count this too:
                         if (questionIsCorrect) {
-                            if (questionsCorrectByStageAndDifficultyStats.containsKey(audience.getStage().get(0))) {
-                                if (questionsCorrectByStageAndDifficultyStats.get(audience.getStage().get(0)).containsKey(audience.getDifficulty().get(0))) {
+                            if (questionsCorrectByStageAndDifficultyStats.containsKey(currentStage)) {
+                                if (questionsCorrectByStageAndDifficultyStats.get(currentStage).containsKey(currentDifficulty)) {
                                     questionsCorrectByStageAndDifficultyStats.get(
-                                            audience.getStage().get(0)).put(
-                                                    audience.getDifficulty().get(0),
+                                            currentStage).put(
+                                            currentDifficulty,
                                                     questionsCorrectByStageAndDifficultyStats.get(
-                                                            audience.getStage().get(0)).get(audience.getDifficulty().get(0)) + 1);
+                                                            currentStage).get(currentDifficulty) + 1);
                                 } else {
-                                    questionsCorrectByStageAndDifficultyStats.get(audience.getStage().get(0)).put(audience.getDifficulty().get(0), 1);
+                                    questionsCorrectByStageAndDifficultyStats.get(currentStage).put(currentDifficulty, 1);
                                 }
                             } else {
-                                questionsCorrectByStageAndDifficultyStats.put(audience.getStage().get(0), new HashMap() {{
-                                    put(audience.getDifficulty().get(0), 1);
+                                questionsCorrectByStageAndDifficultyStats.put(currentStage, new HashMap() {{
+                                    put(currentDifficulty, 1);
                                 }});
                             }
                         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -546,9 +546,9 @@ public class StatisticsManager implements IStatisticsManager {
                                 questionAttemptsByStageAndDifficultyStats.get(currentStage).put(currentDifficulty, 1);
                             }
                         } else {
-                            questionAttemptsByStageAndDifficultyStats.put(currentStage, new HashMap() {{
-                                put(currentDifficulty, 1);
-                            }});
+                            Map<Difficulty, Integer> newDifficultyMap = Maps.newHashMap();
+                            newDifficultyMap.put(currentDifficulty, 1);
+                            questionAttemptsByStageAndDifficultyStats.put(currentStage, newDifficultyMap);
                         }
 
                         // If correct, count this too:
@@ -561,9 +561,9 @@ public class StatisticsManager implements IStatisticsManager {
                                     questionsCorrectByStageAndDifficultyStats.get(currentStage).put(currentDifficulty, 1);
                                 }
                             } else {
-                                questionsCorrectByStageAndDifficultyStats.put(currentStage, new HashMap() {{
-                                    put(currentDifficulty, 1);
-                                }});
+                                Map<Difficulty, Integer> newDifficultyMap = Maps.newHashMap();
+                                newDifficultyMap.put(currentDifficulty, 1);
+                                questionsCorrectByStageAndDifficultyStats.put(currentStage, newDifficultyMap);
                             }
                         }
                     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -540,12 +540,8 @@ public class StatisticsManager implements IStatisticsManager {
                         // Count the attempt at the question
                         if (questionAttemptsByStageAndDifficultyStats.containsKey(currentStage)) {
                             if (questionAttemptsByStageAndDifficultyStats.get(currentStage).containsKey(currentDifficulty)) {
-                                questionAttemptsByStageAndDifficultyStats.get(
-                                        currentStage).put(
-                                        currentDifficulty,
-                                                questionAttemptsByStageAndDifficultyStats.get(
-                                                        currentStage).get(
-                                                        currentDifficulty) + 1);
+                                questionAttemptsByStageAndDifficultyStats.get(currentStage)
+                                .put(currentDifficulty, questionAttemptsByStageAndDifficultyStats.get(currentStage).get(currentDifficulty) + 1);
                             } else {
                                 questionAttemptsByStageAndDifficultyStats.get(currentStage).put(currentDifficulty, 1);
                             }
@@ -559,11 +555,8 @@ public class StatisticsManager implements IStatisticsManager {
                         if (questionIsCorrect) {
                             if (questionsCorrectByStageAndDifficultyStats.containsKey(currentStage)) {
                                 if (questionsCorrectByStageAndDifficultyStats.get(currentStage).containsKey(currentDifficulty)) {
-                                    questionsCorrectByStageAndDifficultyStats.get(
-                                            currentStage).put(
-                                            currentDifficulty,
-                                                    questionsCorrectByStageAndDifficultyStats.get(
-                                                            currentStage).get(currentDifficulty) + 1);
+                                    questionsCorrectByStageAndDifficultyStats.get(currentStage)
+                                    .put(currentDifficulty, questionsCorrectByStageAndDifficultyStats.get(currentStage).get(currentDifficulty) + 1);
                                 } else {
                                     questionsCorrectByStageAndDifficultyStats.get(currentStage).put(currentDifficulty, 1);
                                 }


### PR DESCRIPTION
Adds stage and difficulty question information to user attempts in the StatisticsManager. It builds it in the same way as tags but because it's a nested map it's not the easiest to follow. If there's a simpler approach that is staring me in the face please let me know! At the moment the information is returned as a `Map<Stage, Map<Difficulty, Integer>>`

---
**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
