### PR TITLE
Add hiddenFromRoles property to quizzes to allow more flexible filtering

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
@@ -77,15 +77,12 @@ public class QuizManager {
      *            - so we can summarize content with links
      * @param mapper
      *            - so we can convert cached content DOs to DTOs.
-     * @param contentIndex
-     *            - the current version of content to use.
      */
     @Inject
     public QuizManager(final PropertiesLoader properties, final ContentService contentService,
                        final IContentManager contentManager,
                        final ContentSummarizerService contentSummarizerService,
-                       final ContentMapper mapper,
-                       @Named(CONTENT_INDEX) final String contentIndex) {
+                       final ContentMapper mapper) {
         this.properties = properties;
         this.contentService = contentService;
         this.contentManager = contentManager;
@@ -93,15 +90,20 @@ public class QuizManager {
         this.mapper = mapper;
     }
 
-    public ResultsWrapper<ContentSummaryDTO> getAvailableQuizzes(boolean onlyVisibleToStudents, @Nullable Integer startIndex, @Nullable Integer limit) throws ContentManagerException {
+    public ResultsWrapper<ContentSummaryDTO> getAvailableQuizzes(boolean onlyVisibleToStudents, String visibleToRole, @Nullable Integer startIndex, @Nullable Integer limit) throws ContentManagerException {
 
         List<IContentManager.BooleanSearchClause> fieldsToMatch = Lists.newArrayList();
         fieldsToMatch.add(new IContentManager.BooleanSearchClause(
                 TYPE_FIELDNAME, Constants.BooleanOperator.AND, Collections.singletonList(QUIZ_TYPE)));
 
+        // TODO: remove deprecated onlyVisibleToStudents check and argument!
         if (onlyVisibleToStudents) {
             fieldsToMatch.add(new IContentManager.BooleanSearchClause(
                     VISIBLE_TO_STUDENTS_FIELDNAME, Constants.BooleanOperator.AND, Collections.singletonList(Boolean.toString(true))));
+        }
+        if (null != visibleToRole) {
+            fieldsToMatch.add(new IContentManager.BooleanSearchClause(HIDDEN_FROM_ROLES_FIELDNAME,
+                    BooleanOperator.NOT, Collections.singletonList(visibleToRole)));
         }
 
         ResultsWrapper<ContentDTO> content = this.contentService.findMatchingContent(null, fieldsToMatch, startIndex, limit);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Raspberry Pi Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,8 +34,9 @@ import java.util.Set;
 @DTOMapping(IsaacQuizDTO.class)
 @JsonContentType("isaacQuiz")
 public class IsaacQuiz extends SeguePage {
-
+    @Deprecated
     private boolean visibleToStudents;
+    private List<String> hiddenFromRoles;
     private Content rubric;
 
     @JsonCreator
@@ -56,12 +57,14 @@ public class IsaacQuiz extends SeguePage {
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
             @JsonProperty("visibleToStudents") boolean visibleToStudents,
+            @JsonProperty("hiddenFromRoles") List<String> hiddenFromRoles,
             @JsonProperty("rubric") Content rubric){
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
                 relatedContent, published, deprecated, tags, level);
 
         this.visibleToStudents = visibleToStudents;
+        this.hiddenFromRoles = hiddenFromRoles;
         this.rubric = rubric;
     }
 
@@ -72,10 +75,12 @@ public class IsaacQuiz extends SeguePage {
 
     }
 
+    @Deprecated
     public boolean getVisibleToStudents() {
         return visibleToStudents;
     }
 
+    @Deprecated
     public void setVisibleToStudents(boolean visibleToStudents) {
         this.visibleToStudents = visibleToStudents;
     }
@@ -86,5 +91,13 @@ public class IsaacQuiz extends SeguePage {
 
     public void setRubric(Content rubric){
         this.rubric = rubric;
+    }
+
+    public List<String> getHiddenFromRoles() {
+        return hiddenFromRoles;
+    }
+
+    public void setHiddenFromRoles(List<String> hiddenFromRoles) {
+        this.hiddenFromRoles = hiddenFromRoles;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Raspberry Pi Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,9 @@ import java.util.Set;
  */
 @JsonContentType("isaacQuiz")
 public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleOrId {
+    @Deprecated
     private boolean visibleToStudents;
+    private List<String> hiddenFromRoles;
     private QuizFeedbackMode defaultFeedbackMode;
     private ContentDTO rubric;
 
@@ -65,6 +67,7 @@ public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleO
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
             @JsonProperty("visibleToStudents") boolean visibleToStudents,
+            @JsonProperty("hiddenFromRoles") List<String> hiddenFromRoles,
             @JsonProperty("defaultFeedbackMode") QuizFeedbackMode defaultFeedbackMode,
             @JsonProperty("rubric") ContentDTO rubric) {
         super(id, title, subtitle, type, author, encoding,
@@ -72,6 +75,7 @@ public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleO
                 relatedContent, published, deprecated, tags, level);
 
         this.visibleToStudents = visibleToStudents;
+        this.hiddenFromRoles = hiddenFromRoles;
         this.defaultFeedbackMode = defaultFeedbackMode;
         this.rubric = rubric;
     }
@@ -83,12 +87,22 @@ public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleO
 
     }
 
+    @Deprecated
     public boolean getVisibleToStudents() {
         return visibleToStudents;
     }
 
+    @Deprecated
     public void setVisibleToStudents(boolean visibleToStudents) {
         this.visibleToStudents = visibleToStudents;
+    }
+
+    public List<String> getHiddenFromRoles() {
+        return hiddenFromRoles;
+    }
+
+    public void setHiddenFromRoles(List<String> hiddenFromRoles) {
+        this.hiddenFromRoles = hiddenFromRoles;
     }
 
     @Nullable

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -414,6 +414,7 @@ public final class Constants {
     public static final String[] ADDRESS_FIELDNAMES = {"addressLine1", "addressLine2", "town", "county", "postalCode"};
     public static final String SEARCHABLE_CONTENT_FIELDNAME = "searchableContent";
     public static final String VISIBLE_TO_STUDENTS_FIELDNAME = "visibleToStudents";
+    public static final String HIDDEN_FROM_ROLES_FIELDNAME = "hiddenFromRoles";
 
     public static final String STAGE_FIELDNAME = "audience.stage";
     public static final String DIFFICULTY_FIELDNAME = "audience.difficulty";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuizSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/QuizSummaryDTO.java
@@ -1,7 +1,10 @@
 package uk.ac.cam.cl.dtg.segue.dto.content;
 
+import java.util.List;
+
 public class QuizSummaryDTO extends ContentSummaryDTO {
     private boolean visibleToStudents;
+    private List<String> hiddenFromRoles;
 
     public QuizSummaryDTO() {
 
@@ -13,5 +16,13 @@ public class QuizSummaryDTO extends ContentSummaryDTO {
 
     public void setVisibleToStudents(final boolean visibleToStudents) {
         this.visibleToStudents = visibleToStudents;
+    }
+
+    public List<String> getHiddenFromRoles() {
+        return hiddenFromRoles;
+    }
+
+    public void setHiddenFromRoles(List<String> hiddenFromRoles) {
+        this.hiddenFromRoles = hiddenFromRoles;
     }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -149,12 +149,12 @@ public class IsaacTest {
         quizSection2.setId("studentQuiz|section2");
         quizSection2.setChildren(ImmutableList.of(question2, question3));
 
-        studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, false, null, null, true, QuizFeedbackMode.OVERALL_MARK, null);
-        teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, false, null, null, false, null, null);
-        otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, false, null, null, true, QuizFeedbackMode.DETAILED_FEEDBACK, null);
+        studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
+        teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, false, ImmutableList.of("STUDENT"), null, null);
+        otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.DETAILED_FEEDBACK, null);
 
         // A bit scrappy, but hopefully sufficient.
-        studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, false, null, null, true, null);
+        studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, true, null, null);
 
         student = new RegisteredUserDTO("Some", "Student", "test-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "");
         student.setRole(Role.STUDENT);
@@ -234,8 +234,8 @@ public class IsaacTest {
         quizManager = createMock(QuizManager.class);
 
         registerDefaultsFor(quizManager, m -> {
-            expect(m.getAvailableQuizzes(true, 0, 9000)).andStubReturn(wrap(studentQuizSummary));
-            expect(m.getAvailableQuizzes(false, 0, 9000)).andStubReturn(wrap(studentQuizSummary, teacherQuizSummary));
+            expect(m.getAvailableQuizzes(true,"STUDENT", 0, 9000)).andStubReturn(wrap(studentQuizSummary));
+            expect(m.getAvailableQuizzes(false,"TEACHER", 0, 9000)).andStubReturn(wrap(studentQuizSummary, teacherQuizSummary));
             expect(m.findQuiz(studentQuiz.getId())).andStubReturn(studentQuiz);
             expect(m.findQuiz(teacherQuiz.getId())).andStubReturn(teacherQuiz);
             expect(m.findQuiz(otherQuiz.getId())).andStubReturn(otherQuiz);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManagerTest.java
@@ -36,8 +36,7 @@ public class QuizManagerTest extends AbstractManagerTest {
         IContentManager contentManager = createMock(IContentManager.class);
         ContentSummarizerService contentSummarizerService = createMock(ContentSummarizerService.class);
         ContentMapper mapper = createMock(ContentMapper.class);
-        String contentIndex = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-        quizManager = new QuizManager(properties, contentService, contentManager, contentSummarizerService, mapper, contentIndex);
+        quizManager = new QuizManager(properties, contentService, contentManager, contentSummarizerService, mapper);
 
         brokenQuiz = new IsaacQuizDTO();
         brokenQuiz.setChildren(ImmutableList.of(quizSection1, new ContentDTO(), quizSection2));


### PR DESCRIPTION
Currently there is only "visibleToStudents", this is the first step to deprecating that property. The changes attempt to be backwards compatible; if the content does not have the new property but only the old one (as it must for one release cycle) then the old behaviour should be unchanged.
We will then need to remove the old property from the content and then from the DOs and DTOs.

The new property is a list of roles (in all-caps as in our enums: `["STUDENT", "TEACHER"]`) who cannot see the quiz to attempt it freely, but only see it if assigned. There is currently no clever checking of roles, so it is possible to make a quiz that nobody can view or assign (by limiting all roles except students, say). Perhaps this may want to be a content error eventually, but for now it is okay.
The frontend and editor will need updating to use this new property. For the editor, I wonder if a radio button choice between "anyone" which leaves the property as `null` (i.e. anyone can see it), "only teacher assigned" which is `["STUDENT"]` (i.e. the current visibleToStudents=true), and "only staff" which is `["STUDENT", "TEACHER"]`. 
CS may eventually want to worry about EVENT_LEADERS who are TEACHERS but with some extra permissions, so maybe a multi-select will be necessary.