### PR TITLE
Add status code to request duration metrics

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PerformanceMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PerformanceMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,6 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.ext.Provider;
-import java.io.IOException;
 
 import static uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics.REQUEST_LATENCY_HISTOGRAM;
 
@@ -90,8 +89,11 @@ public class PerformanceMonitor implements ContainerRequestFilter, ContainerResp
 
         // Record for metrics
         REQUEST_LATENCY_HISTOGRAM
-                .labels(requestContext.getMethod(), monitorService.getPathWithoutPathParamValues(request.getUri()))
-                .observe((double)timeInMs / NUMBER_OF_MILLISECONDS_IN_A_SECOND);
+                .labels(
+                        requestContext.getMethod(),
+                        monitorService.getPathWithoutPathParamValues(request.getUri()),
+                        String.valueOf(responseContext.getStatus())
+                ).observe((double)timeInMs / NUMBER_OF_MILLISECONDS_IN_A_SECOND);
     }
 
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
@@ -30,7 +30,7 @@ public final class SegueMetrics {
     // Request Response Time Metrics
     public static final Histogram REQUEST_LATENCY_HISTOGRAM = Histogram.build()
             .name("isaac_api_requests")
-            .labelNames("method", "path")
+            .labelNames("method", "path", "status")
             .help("Request latency in seconds.").register();
 
     // WebSocket Response Time Metrics


### PR DESCRIPTION
I am unsure whether this is best, or whether a new metric with the path and the status code (without the timing information) might be better.

@mlt47 - opinions? If you think a new metric is better, please do close this. I don't want to make an enormous expansion in the number of tracked things by adding a third dimension if that's not wise!