### PR TITLE
Mark correct numeric units as correct even for a known incorrect choice

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -251,10 +251,11 @@ public class IsaacNumericValidator implements IValidator {
 
                 // What sort of match do we have:
                 if (numericValuesMatched && unitsFromUser.equals(unitsFromChoice)) {
-                    // Exact match: nothing else can do better.
+                    // Exact match: nothing else can do better, but previous match may tell us if units are also correct:
+                    Boolean unitsCorrect = (null != bestResponse && bestResponse.getCorrectUnits()) || quantityFromQuestion.isCorrect();
                     bestResponse = new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser,
                             quantityFromQuestion.isCorrect(), (Content) quantityFromQuestion.getExplanation(),
-                            quantityFromQuestion.isCorrect(), quantityFromQuestion.isCorrect(), new Date());
+                            quantityFromQuestion.isCorrect(), unitsCorrect, new Date());
                     break;
                 } else if (numericValuesMatched && !unitsFromUser.equals(unitsFromChoice) && quantityFromQuestion.isCorrect()) {
                     // Matches value but not units of a correct choice.

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -478,6 +478,41 @@ public class IsaacNumericValidatorTest {
         assertEquals(response.getExplanation(), defaultFeedback);
     }
 
+    /*
+        Test that correct units are noted even when matching a known incorrect choice.
+
+        (There is no way to record that only the value is wrong, but we can use other choices
+         to decide if the units are correct or not).
+    */
+    @Test
+    public final void isaacNumericValidator_CheckCorrectUnitsIncorrectChoiceMatch_CorrectUnitsResponseShouldHappen() {
+        // Set up the question object:
+        IsaacNumericQuestion someNumericQuestion = new IsaacNumericQuestion();
+        someNumericQuestion.setRequireUnits(true);
+        someNumericQuestion.setSignificantFiguresMin(2);
+        someNumericQuestion.setSignificantFiguresMax(3);
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity someCorrectAnswer = new Quantity("31.4", "m");
+        someCorrectAnswer.setCorrect(true);
+        answerList.add(someCorrectAnswer);
+        Quantity someIncorrectAnswer = new Quantity("20.0", "m");
+        someIncorrectAnswer.setCorrect(false);
+        answerList.add(someIncorrectAnswer);
+
+        someNumericQuestion.setChoices(answerList);
+
+        // Set up user answer:
+        Quantity q = new Quantity("20", "m");
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someNumericQuestion, q);
+        QuantityValidationResponse quantityValidationResponse = (QuantityValidationResponse) response;
+
+        assertFalse(response.isCorrect());
+        assertTrue(quantityValidationResponse.getCorrectUnits());
+    }
+
     //  ---------- Tests from here test invalid questions themselves ----------
 
     /*


### PR DESCRIPTION
This will only work in some circumstances:
 - the units provided match a known correct answer.
 - the value and units both match a known incorrect answer.

Then, and only then, can we safely mark the units as correct and the value as incorrect. Limited in usefulness, but addresses a noticed issue in the content without (I hope!) any side effects.
Also add a test for the noticed case for future reference.