### PR TITLE
Cloze question subset matching of item choices

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
@@ -139,7 +139,7 @@ public class IsaacClozeValidator implements IValidator {
                 Set<String> choiceItemIdSet = new HashSet<>(choiceItemIds);
                 /* If the intersection of the submitted and choice ids is equal to the choice ones, then
                    this means that:
-                    - choiceItemIds.size() <= submittedItemIds.size()
+                    - choiceItemIdSet.size() <= submittedItemIds.size()
                     - All choice ids are within the set of submitted ids
                  */
                 if (allowSubsetMatch && Sets.intersection(submittedItemIdSet, choiceItemIdSet).equals(choiceItemIdSet)) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.isaac.quiz;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -164,45 +163,7 @@ public class IsaacClozeValidator implements IValidator {
 
     @Override
     public List<Choice> getOrderedChoices(final List<Choice> choices) {
-        List<Choice> orderedChoices = Lists.newArrayList(choices);
-
-        /* First sort by whether subset matching is allowed or not - 'strict' match
-           item choices will appear before subset match ones.
-           Any Choices that are not ItemChoices will be ordered after 'strict' match
-           item choices.
-           Choices without a null value for allowSubsetMatch are considered 'strict'
-           for the ordering.
-         */
-        orderedChoices.sort((o1, o2) -> {
-            int o1Val = 1;
-            int o2Val = 1;
-            Boolean subsetMatch;
-            if (o1 instanceof ItemChoice) {
-                subsetMatch = ((ItemChoice) o1).isAllowSubsetMatch();
-                o1Val = (null != subsetMatch && subsetMatch) ? 1 : 0;
-            }
-            if (o2 instanceof ItemChoice) {
-                subsetMatch = ((ItemChoice) o2).isAllowSubsetMatch();
-                o2Val = (null != subsetMatch && subsetMatch) ? 1 : 0;
-            }
-            return o1Val - o2Val;
-        });
-
-        // Then sort in order of correctness
-        orderedChoices.sort((o1, o2) -> {
-            int o1Val = o1.isCorrect() ? 0 : 1;
-            int o2Val = o2.isCorrect() ? 0 : 1;
-            return o1Val - o2Val;
-        });
-
-        /* This should leave us with the following ordering:
-            0 Correct strict
-            1 Incorrect strict
-            2 Correct subset match
-            3 Incorrect subset match
-         */
-
-        return orderedChoices;
+        return IsaacItemQuestionValidator.getOrderedChoicesWithSubsets(choices);
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
@@ -15,6 +15,8 @@
  */
 package uk.ac.cam.cl.dtg.isaac.quiz;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 
 /**
@@ -130,9 +133,20 @@ public class IsaacClozeValidator implements IValidator {
                     choiceItemIds.add(item.getId());
                 }
 
-                // TODO match on positions and enable subset matching - this requires a ClozeItem with a position attribute
-                //  describing which drop-zone it is in/intended for
-                if (choiceItemIds.equals(submittedItemIds)) {
+                // Do not allow subset matching by default
+                boolean allowSubsetMatch = (null != itemChoice.isAllowSubsetMatch() && itemChoice.isAllowSubsetMatch());
+
+                Set<String> choiceItemIdSet = new HashSet<>(choiceItemIds);
+                /* If the intersection of the submitted and choice ids is equal to the choice ones, then
+                   this means that:
+                    - choiceItemIds.size() <= submittedItemIds.size()
+                    - All choice ids are within the set of submitted ids
+                 */
+                if (allowSubsetMatch && Sets.intersection(submittedItemIdSet, choiceItemIdSet).equals(choiceItemIdSet)) {
+                    responseCorrect = itemChoice.isCorrect();
+                    feedback = (Content) itemChoice.getExplanation();
+                    break;
+                } else if (choiceItemIds.equals(submittedItemIds)) {
                     responseCorrect = itemChoice.isCorrect();
                     feedback = (Content) itemChoice.getExplanation();
                     break;
@@ -146,6 +160,49 @@ public class IsaacClozeValidator implements IValidator {
         }
 
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
+    }
+
+    @Override
+    public List<Choice> getOrderedChoices(final List<Choice> choices) {
+        List<Choice> orderedChoices = Lists.newArrayList(choices);
+
+        /* First sort by whether subset matching is allowed or not - 'strict' match
+           item choices will appear before subset match ones.
+           Any Choices that are not ItemChoices will be ordered after 'strict' match
+           item choices.
+           Choices without a null value for allowSubsetMatch are considered 'strict'
+           for the ordering.
+         */
+        orderedChoices.sort((o1, o2) -> {
+            int o1Val = 1;
+            int o2Val = 1;
+            Boolean subsetMatch;
+            if (o1 instanceof ItemChoice) {
+                subsetMatch = ((ItemChoice) o1).isAllowSubsetMatch();
+                o1Val = (null != subsetMatch && subsetMatch) ? 1 : 0;
+            }
+            if (o2 instanceof ItemChoice) {
+                subsetMatch = ((ItemChoice) o2).isAllowSubsetMatch();
+                o2Val = (null != subsetMatch && subsetMatch) ? 1 : 0;
+            }
+            return o1Val - o2Val;
+        });
+
+        // Then sort in order of correctness
+        orderedChoices.sort((o1, o2) -> {
+            int o1Val = o1.isCorrect() ? 0 : 1;
+            int o2Val = o2.isCorrect() ? 0 : 1;
+            return o1Val - o2Val;
+        });
+
+        /* This should leave us with the following ordering:
+            0 Correct strict
+            1 Incorrect strict
+            2 Correct subset match
+            3 Incorrect subset match
+         */
+
+        return orderedChoices;
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
@@ -133,8 +133,8 @@ public class IsaacClozeValidator implements IValidator {
                     choiceItemIds.add(item.getId());
                 }
 
-                // Do not allow subset matching by default
-                boolean allowSubsetMatch = (null != itemChoice.isAllowSubsetMatch() && itemChoice.isAllowSubsetMatch());
+                // Do not allow subset matching by default, and only allow if the cloze question does not have replacement/item duplication enabled
+                boolean allowSubsetMatch = (null != itemChoice.isAllowSubsetMatch() && itemChoice.isAllowSubsetMatch()) && (null != clozeQuestion.getWithReplacement() && !clozeQuestion.getWithReplacement());
 
                 Set<String> choiceItemIdSet = new HashSet<>(choiceItemIds);
                 /* If the intersection of the submitted and choice ids is equal to the choice ones, then

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
@@ -157,6 +157,10 @@ public class IsaacItemQuestionValidator implements IValidator {
 
     @Override
     public List<Choice> getOrderedChoices(final List<Choice> choices) {
+        return getOrderedChoicesWithSubsets(choices);
+    }
+
+    public static List<Choice> getOrderedChoicesWithSubsets(final List<Choice> choices) {
         List<Choice> orderedChoices = Lists.newArrayList(choices);
 
         /* First sort by whether subset matching is allowed or not - 'strict' match
@@ -197,5 +201,4 @@ public class IsaacItemQuestionValidator implements IValidator {
 
         return orderedChoices;
     }
-
 }


### PR DESCRIPTION
This enables subset matching for cloze questions - if the question **doesn't have `withReplacement` enabled**, then it is possible to match a subset of an item choice.

This is useful for when a content creator wants to give feedback for an incorrect answer that contains a particular item. 
You could imagine one of the items being a completely made up word, and if the user's answer includes that word, the specific feedback might sarcastically ask the user to go and find a definition of it (might not be a practical example, but it's an example).