### PR TITLE
Add name length and illegal character validation to user create/update endpoint

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -50,6 +50,7 @@ import uk.ac.cam.cl.dtg.segue.auth.exceptions.MissingRequiredFieldException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoCredentialsAvailableException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidNameException;
 import uk.ac.cam.cl.dtg.segue.comm.CommunicationException;
 import uk.ac.cam.cl.dtg.segue.comm.EmailMustBeVerifiedException;
 import uk.ac.cam.cl.dtg.segue.comm.EmailType;
@@ -857,6 +858,9 @@ public class UsersFacade extends AbstractSegueFacade {
         } catch (AuthenticationProviderMappingException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
                     "Unable to map to a known authenticator. The provider: is unknown").toResponse();
+        } catch (InvalidNameException e) {
+            log.warn("Invalid name provided during registration.");
+            return new SegueErrorResponse(Status.BAD_REQUEST, e.getMessage()).toResponse();
         }
     }
 
@@ -913,6 +917,9 @@ public class UsersFacade extends AbstractSegueFacade {
             log.warn("Someone attempted to register with an Isaac email address: " + userObjectFromClient.getEmail());
             return new SegueErrorResponse(Status.BAD_REQUEST,
                     "You cannot register with an Isaac email address.").toResponse();
+        } catch (InvalidNameException e) {
+            log.warn("Invalid name provided during registration.");
+            return new SegueErrorResponse(Status.BAD_REQUEST, e.getMessage()).toResponse();
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -859,7 +859,7 @@ public class UsersFacade extends AbstractSegueFacade {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
                     "Unable to map to a known authenticator. The provider: is unknown").toResponse();
         } catch (InvalidNameException e) {
-            log.warn("Invalid name provided during registration.");
+            log.warn("Invalid name provided during user update.");
             return new SegueErrorResponse(Status.BAD_REQUEST, e.getMessage()).toResponse();
         }
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -774,7 +774,7 @@ public class UserAccountManager implements IUserAccountManager {
         }
 
         if (!this.isUserNameValid(user.getFamilyName())) {
-            throw new InvalidNameException("The given name provided is too long or contains illegal characters.");
+            throw new InvalidNameException("The family name provided is too long or contains illegal characters.");
         }
 
         IPasswordAuthenticator authenticator = (IPasswordAuthenticator) this.registeredAuthProviders

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -770,11 +770,11 @@ public class UserAccountManager implements IUserAccountManager {
 
         // validate names
         if (!this.isUserNameValid(user.getGivenName())) {
-            throw new InvalidNameException("The given name provided is too long or contains illegal characters.");
+            throw new InvalidNameException("The given name provided is an invalid length or contains illegal characters.");
         }
 
         if (!this.isUserNameValid(user.getFamilyName())) {
-            throw new InvalidNameException("The family name provided is too long or contains illegal characters.");
+            throw new InvalidNameException("The family name provided is an invalid length or contains illegal characters.");
         }
 
         IPasswordAuthenticator authenticator = (IPasswordAuthenticator) this.registeredAuthProviders
@@ -857,11 +857,11 @@ public class UserAccountManager implements IUserAccountManager {
 
         // validate names
         if (!this.isUserNameValid(updatedUser.getGivenName())) {
-            throw new InvalidNameException("The given name provided is too long or contains illegal characters.");
+            throw new InvalidNameException("The given name provided is an invalid length or contains illegal characters.");
         }
 
         if (!this.isUserNameValid(updatedUser.getFamilyName())) {
-            throw new InvalidNameException("The family name provided is too long or contains illegal characters.");
+            throw new InvalidNameException("The family name provided is an invalid length or contains illegal characters.");
         }
 
         IPasswordAuthenticator authenticator = (IPasswordAuthenticator) this.registeredAuthProviders
@@ -1591,14 +1591,11 @@ public class UserAccountManager implements IUserAccountManager {
      * @return true if it meets the internal storage requirements, false if not.
      */
     private boolean isUserValid(final RegisteredUser userToValidate) {
-        boolean isValid = true;
-
         if (userToValidate.getEmail() == null || userToValidate.getEmail().isEmpty()
                 || !userToValidate.getEmail().matches(".*(@.+\\.[^.]+|-(facebook|google|twitter)$)")) {
-            isValid = false;
+            return false;
         }
-        
-        return isValid;
+        return true;
     }
 
     /**
@@ -1608,15 +1605,12 @@ public class UserAccountManager implements IUserAccountManager {
      *            - the name to validate.
      * @return true if the name is valid, false otherwise.
      */
-    public boolean isUserNameValid(final String name){
-        boolean isValid = true;
-
+    public final boolean isUserNameValid(final String name){
         Pattern illegalCharacters = Pattern.compile(USER_NAME_ILLEGAL_CHARS_REGEX);
-        if (name.length() > USER_NAME_MAX_LENGTH || illegalCharacters.matcher(name).find()) {
-            isValid = false;
+        if (name.length() > USER_NAME_MAX_LENGTH || illegalCharacters.matcher(name).find() || name.isEmpty()) {
+           return false;
         }
-
-        return isValid;
+        return true;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.text.WordUtils.capitalizeFully;
@@ -97,6 +98,10 @@ public class UserAccountManager implements IUserAccountManager {
     private final PropertiesLoader properties;
 
     private final ISecondFactorAuthenticator secondFactorManager;
+
+    private final int USER_NAME_MAX_LENGTH = 255;
+    private final String USER_NAME_ILLEGAL_CHARS_REGEX = "[*<>]";
+
 
     /**
      * Create an instance of the user manager class.
@@ -727,7 +732,7 @@ public class UserAccountManager implements IUserAccountManager {
             final HttpServletResponse response, final RegisteredUser user, final String newPassword,
                                                         final boolean rememberMe) throws InvalidPasswordException,
             MissingRequiredFieldException, SegueDatabaseException,
-            EmailMustBeVerifiedException, InvalidKeySpecException, NoSuchAlgorithmException {
+            EmailMustBeVerifiedException, InvalidKeySpecException, NoSuchAlgorithmException, InvalidNameException {
         Validate.isTrue(user.getId() == null,
                 "When creating a new user the user id must not be set.");
 
@@ -761,6 +766,15 @@ public class UserAccountManager implements IUserAccountManager {
         // Before save we should validate the user for mandatory fields.
         if (!this.isUserValid(userToSave)) {
             throw new MissingRequiredFieldException("The email address provided is invalid.");
+        }
+
+        // validate names
+        if (!this.isUserNameValid(user.getGivenName())) {
+            throw new InvalidNameException("The given name provided is too long or contains illegal characters.");
+        }
+
+        if (!this.isUserNameValid(user.getFamilyName())) {
+            throw new InvalidNameException("The given name provided is too long or contains illegal characters.");
         }
 
         IPasswordAuthenticator authenticator = (IPasswordAuthenticator) this.registeredAuthProviders
@@ -821,7 +835,7 @@ public class UserAccountManager implements IUserAccountManager {
      */
     public RegisteredUserDTO updateUserObject(final RegisteredUser updatedUser, final String newPassword)
             throws InvalidPasswordException, MissingRequiredFieldException, SegueDatabaseException,
-            InvalidKeySpecException, NoSuchAlgorithmException {
+            InvalidKeySpecException, NoSuchAlgorithmException, InvalidNameException {
         Validate.notNull(updatedUser.getId());
 
         // We want to map to DTO first to make sure that the user cannot
@@ -839,6 +853,15 @@ public class UserAccountManager implements IUserAccountManager {
         // Check that the user isn't trying to take an existing users e-mail.
         if (this.findUserByEmail(updatedUser.getEmail()) != null && !existingUser.getEmail().equals(updatedUser.getEmail())) {
             throw new DuplicateAccountException("An account with that e-mail address already exists.");
+        }
+
+        // validate names
+        if (!this.isUserNameValid(updatedUser.getGivenName())) {
+            throw new InvalidNameException("The given name provided is too long or contains illegal characters.");
+        }
+
+        if (!this.isUserNameValid(updatedUser.getFamilyName())) {
+            throw new InvalidNameException("The family name provided is too long or contains illegal characters.");
         }
 
         IPasswordAuthenticator authenticator = (IPasswordAuthenticator) this.registeredAuthProviders
@@ -1575,6 +1598,24 @@ public class UserAccountManager implements IUserAccountManager {
             isValid = false;
         }
         
+        return isValid;
+    }
+
+    /**
+     * This function checks that the name provided is valid.
+     *
+     * @param name
+     *            - the name to validate.
+     * @return true if the name is valid, false otherwise.
+     */
+    public boolean isUserNameValid(final String name){
+        boolean isValid = true;
+
+        Pattern illegalCharacters = Pattern.compile(USER_NAME_ILLEGAL_CHARS_REGEX);
+        if (name.length() > USER_NAME_MAX_LENGTH || illegalCharacters.matcher(name).find()) {
+            isValid = false;
+        }
+
         return isValid;
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidNameException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidNameException.java
@@ -1,0 +1,19 @@
+package uk.ac.cam.cl.dtg.segue.auth.exceptions;
+
+/**
+ * An exception which indicates the name provided by the user is not valid.
+ *
+ */
+public class InvalidNameException extends Exception {
+
+    /**
+     * An exception which indicates the name provided by the user is not valid.
+     *
+     * @param message
+     *            - message to add
+     */
+
+    public InvalidNameException(final String message) {
+        super(message);
+    }
+}

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import ma.glasnost.orika.MapperFacade;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +37,7 @@ import uk.ac.cam.cl.dtg.segue.auth.ISecondFactorAuthenticator;
 import uk.ac.cam.cl.dtg.segue.auth.SegueLocalAuthenticator;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticationProviderMappingException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.CrossSiteRequestForgeryException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidNameException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
@@ -671,6 +673,57 @@ public class UserManagerTest {
         // Assert
         verify(dummyQuestionDatabase, dummySession, request);
         assertTrue(!valid);
+    }
+
+    /**
+     * Ensure isUserNameValid returns false when an excessively long name is provided.
+     *
+     */
+    @Test
+    public final void isUserNameValid_longNameProvided_returnsFalse()  {
+        // Arrange
+        UserAccountManager userManager = buildTestUserManager();
+        String name = StringUtils.repeat("a", 256);
+
+        // Act
+        boolean valid = userManager.isUserNameValid(name);
+
+        // Assert
+        assertFalse(valid);
+    }
+
+    /**
+     * Ensure isUserNameValid returns true when a name of acceptable length and no illegal characters is provided.
+     *
+     */
+    @Test
+    public final void isUserNameValid_acceptableNameProvided_returnsTrue()  {
+        // Arrange
+        UserAccountManager userManager = buildTestUserManager();
+        String name = StringUtils.repeat("a", 255);
+
+        // Act
+        boolean valid = userManager.isUserNameValid(name);
+
+        // Assert
+        assertTrue(valid);
+    }
+
+    /**
+     * Ensure isUserNameValid returns false when a name with illegal characters is provided.
+     *
+     */
+    @Test
+    public final void isUserNameValid_nameWithIllegalCharactersProvided_returnsFalse()  {
+        // Arrange
+        UserAccountManager userManager = buildTestUserManager();
+        String name = "Matthew*";
+
+        // Act
+        boolean valid = userManager.isUserNameValid(name);
+
+        // Assert
+        assertFalse(valid);
     }
 
     /**

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -727,6 +727,23 @@ public class UserManagerTest {
     }
 
     /**
+     * Ensure isUserNameValid returns false when an empty name is provided.
+     *
+     */
+    @Test
+    public final void isUserNameValid_emptyNameProvided_returnsFalse()  {
+        // Arrange
+        UserAccountManager userManager = buildTestUserManager();
+        String name = "";
+
+        // Act
+        boolean valid = userManager.isUserNameValid(name);
+
+        // Assert
+        assertFalse(valid);
+    }
+
+    /**
      * Helper method to construct a UserManager with the default TEST provider.
      * 
      * @return A new UserManager instance


### PR DESCRIPTION
---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped _(Not applicable)_
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint _(Not applicable)_
- [ ] Security - New dependency - configured sensibly not relying on defaults _(Not applicable)_
- [ ] Security - New dependency - Searched for any know vulnerabilities _(Not applicable)_
- [ ] Security - New dependency - Signed up team to mailing list _(Not applicable)_
- [ ] Security - New dependency - Added to dependency list _(Not applicable)_
- [ ] DB schema changes - postgres-rutherford-create-script updated _(Not applicable)_
- [ ] DB schema changes - upgrade script created matching create script _(Not applicable)_
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions) _(Not applicable)_
- [ ] Peer-Reviewed
