### PR TITLE
Prevent deleted groups from breaking event leader tools

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -241,6 +241,8 @@ public class EventBookingManager {
                 }
             } catch (InvalidUserAssociationTokenException e) {
                 log.error("Event {} has an invalid user association token - ignoring", event.getId());
+            } catch (ResourceNotFoundException ignored) {
+                // The group for this event has been deleted or does not exist. Since deletion is common, fail silently.
             }
         }
         return false;


### PR DESCRIPTION
A log here to catch the (unlikely) event that a group code is incorrect would be swamped by the (guaranteed, since this has happened) case that an event references a now-deleted group.