### PR TITLE
Add disregardSignificantFigures flag for numeric questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacNumericQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacNumericQuestion.java
@@ -35,6 +35,7 @@ import static uk.ac.cam.cl.dtg.isaac.api.Constants.NUMERIC_QUESTION_DEFAULT_SIGN
 @ValidatesWith(IsaacNumericValidator.class)
 public class IsaacNumericQuestion extends IsaacQuestionBase {
     private Boolean requireUnits;
+    private Boolean disregardSignificantFigures;
     private Integer significantFiguresMin;
     private Integer significantFiguresMax;
     private List<String> availableUnits;
@@ -133,5 +134,26 @@ public class IsaacNumericQuestion extends IsaacQuestionBase {
      */
     public void setDisplayUnit(String displayUnit) {
         this.displayUnit = displayUnit;
+    }
+
+    /**
+     * Set whether the question accepts values equal to the answer without considering significant figures.
+     *
+     * @param disregardSignificantFigures - whether to accept values equal to the answer without considering sig figs.
+     */
+    public final void setDisregardSignificantFigures(final boolean disregardSignificantFigures){
+        this.disregardSignificantFigures = disregardSignificantFigures;
+    }
+
+    /**
+     * Get whether the question accepts values equal to the answer without considering significant figures.
+     *
+     * @return whether to accept values equal to the answer without considering sig figs.
+     */
+    public final Boolean getDisregardSignificantFigures(){
+        if (this.disregardSignificantFigures == null) {
+            return false;
+        }
+        return this.disregardSignificantFigures;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacNumericQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacNumericQuestion.java
@@ -141,7 +141,7 @@ public class IsaacNumericQuestion extends IsaacQuestionBase {
      *
      * @param disregardSignificantFigures - whether to accept values equal to the answer without considering sig figs.
      */
-    public final void setDisregardSignificantFigures(final boolean disregardSignificantFigures){
+    public final void setDisregardSignificantFigures(final boolean disregardSignificantFigures) {
         this.disregardSignificantFigures = disregardSignificantFigures;
     }
 
@@ -150,7 +150,7 @@ public class IsaacNumericQuestion extends IsaacQuestionBase {
      *
      * @return whether to accept values equal to the answer without considering sig figs.
      */
-    public final Boolean getDisregardSignificantFigures(){
+    public final Boolean getDisregardSignificantFigures() {
         if (this.disregardSignificantFigures == null) {
             return false;
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
@@ -119,7 +119,7 @@ public class IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
      *
      * @param disregardSignificantFigures - whether to accept values equal to the answer without considering sig figs.
      */
-    public final void setDisregardSignificantFigures(final boolean disregardSignificantFigures){
+    public final void setDisregardSignificantFigures(final boolean disregardSignificantFigures) {
         this.disregardSignificantFigures = disregardSignificantFigures;
     }
 
@@ -128,7 +128,7 @@ public class IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
      *
      * @return whether to accept values equal to the answer without considering sig figs.
      */
-    public final Boolean getDisregardSignificantFigures(){
+    public final Boolean getDisregardSignificantFigures() {
         if (this.disregardSignificantFigures == null) {
             return false;
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
@@ -36,6 +36,7 @@ import static uk.ac.cam.cl.dtg.isaac.api.Constants.NUMERIC_QUESTION_DEFAULT_SIGN
 @ValidatesWith(IsaacNumericValidator.class)
 public class IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
     private Boolean requireUnits;
+    private Boolean disregardSignificantFigures;
     private List<String> availableUnits;
     private String displayUnit;
 
@@ -113,4 +114,24 @@ public class IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
         this.displayUnit = displayUnit;
     }
 
+    /**
+     * Set whether the question accepts values equal to the answer without considering significant figures.
+     *
+     * @param disregardSignificantFigures - whether to accept values equal to the answer without considering sig figs.
+     */
+    public final void setDisregardSignificantFigures(final boolean disregardSignificantFigures){
+        this.disregardSignificantFigures = disregardSignificantFigures;
+    }
+
+    /**
+     * Get whether the question accepts values equal to the answer without considering significant figures.
+     *
+     * @return whether to accept values equal to the answer without considering sig figs.
+     */
+    public final Boolean getDisregardSignificantFigures(){
+        if (this.disregardSignificantFigures == null) {
+            return false;
+        }
+        return this.disregardSignificantFigures;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -233,7 +233,7 @@ public class IsaacNumericValidator implements IValidator {
         QuantityValidationResponse bestResponse = null;
         Integer sigFigsToValidateWith = null;
 
-        if (!isaacNumericQuestion.getDisregardSignificantFigures()){
+        if (!isaacNumericQuestion.getDisregardSignificantFigures()) {
             sigFigsToValidateWith = numberOfSignificantFiguresToValidateWith(answerFromUser.getValue(),
                     isaacNumericQuestion.getSignificantFiguresMin(), isaacNumericQuestion.getSignificantFiguresMax());
         }
@@ -301,7 +301,7 @@ public class IsaacNumericValidator implements IValidator {
         QuantityValidationResponse bestResponse = null;
         Integer sigFigsToValidateWith = null;
 
-        if (!isaacNumericQuestion.getDisregardSignificantFigures()){
+        if (!isaacNumericQuestion.getDisregardSignificantFigures()) {
             sigFigsToValidateWith = numberOfSignificantFiguresToValidateWith(answerFromUser.getValue(),
                     isaacNumericQuestion.getSignificantFiguresMin(), isaacNumericQuestion.getSignificantFiguresMax());
         }
@@ -340,8 +340,8 @@ public class IsaacNumericValidator implements IValidator {
      *
      * @param trustedValue               - first number
      * @param untrustedValue             - second number
-     * @param significantFiguresRequired - the number of significant figures to perform comparisons to (can be null,
-     *                                   to skip significant figure checks)
+     * @param significantFiguresRequired - the number of significant figures to perform comparisons to (can be null, in
+     *                                   which case exact comparison is performed)
      * @return true when the numbers match
      * @throws NumberFormatException - when one of the values cannot be parsed
      */
@@ -353,11 +353,10 @@ public class IsaacNumericValidator implements IValidator {
         String untrustedParsedValue = reformatNumberForParsing(untrustedValue);
         String trustedParsedValue = reformatNumberForParsing(trustedValue);
 
-        if (significantFiguresRequired == null){
+        if (null == significantFiguresRequired) {
             trustedDouble = stringValueToDouble(trustedParsedValue);
             untrustedDouble = stringValueToDouble(untrustedParsedValue);
-        }
-        else {
+        } else {
             // Round to N s.f.
             trustedDouble = roundStringValueToSigFigs(trustedParsedValue, significantFiguresRequired);
             untrustedDouble = roundStringValueToSigFigs(untrustedParsedValue, significantFiguresRequired);
@@ -394,6 +393,8 @@ public class IsaacNumericValidator implements IValidator {
      * @return the converted number.
      */
     private double stringValueToDouble(final String value) {
+        log.debug("\t[stringValueToDouble]");
+
         return new BigDecimal(value).doubleValue();
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -808,6 +808,32 @@ public class IsaacNumericValidatorTest {
         assertFalse(response.isCorrect());
     }
 
+    /*
+    Test that the validator returns an incorrect response when a question's disregard sig figs flag is enabled, and
+    the user submitted answer is incorrect at a significant figure the correct answer is not specified to.
+    */
+    @Test
+    public final void isaacNumericValidator_DisregardSigFigsEnabledAndAnswerIncorrectAt3SF_ResponseIsIncorrect() {
+        // Arrange
+        IsaacNumericQuestion someNumericQuestion = new IsaacNumericQuestion();
+        someNumericQuestion.setDisregardSignificantFigures(true);
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity someCorrectAnswer = new Quantity("2.1", "None");
+        someCorrectAnswer.setCorrect(true);
+
+        answerList.add(someCorrectAnswer);
+        someNumericQuestion.setChoices(answerList);
+
+        // Act
+        Quantity userSubmittedAnswer = new Quantity("2.11", "None");
+        QuestionValidationResponse response = validator.validateQuestionResponse(someNumericQuestion,
+                userSubmittedAnswer);
+
+        // Assert
+        assertFalse(response.isCorrect());
+    }
+
     //  ---------- Helper methods to test internal functionality of the validator class ----------
 
     private void testSigFigRoundingWorks(String inputValue, int sigFigToRoundTo, double expectedResult) throws Exception {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -754,6 +754,60 @@ public class IsaacNumericValidatorTest {
         this.testSigFigExtractionWorks("3333000", 2, 4, 4);
     }
 
+    /*
+        Test that the validator returns a correct response when a question's disregard sig figs flag is enabled, and
+        an equivalent but excessively precise answer is provided
+    */
+    @Test
+    public final void isaacNumericValidator_DisregardSigFigsEnabledAndExactAnswerProvided_ResponseIsCorrect() {
+        // Arrange
+        IsaacNumericQuestion someNumericQuestion = new IsaacNumericQuestion();
+        someNumericQuestion.setDisregardSignificantFigures(true);
+        someNumericQuestion.setRequireUnits(false);
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity someCorrectAnswer = new Quantity("13");
+        someCorrectAnswer.setCorrect(true);
+
+        answerList.add(someCorrectAnswer);
+        someNumericQuestion.setChoices(answerList);
+
+        // Act
+        Quantity userSubmittedAnswerWithExcessivePrecision = new Quantity("13.000");
+        QuestionValidationResponse response = validator.validateQuestionResponse(someNumericQuestion,
+                userSubmittedAnswerWithExcessivePrecision);
+
+        // Assert
+        assertTrue(response.isCorrect());
+    }
+
+    /*
+        Test that the validator returns an incorrect response when a question's disregard sig figs flag is disabled, and
+        an equivalent but excessively precise answer is provided
+    */
+    @Test
+    public final void isaacNumericValidator_DisregardSigFigsDisabledAndExactAnswerProvided_ResponseIsIncorrect() {
+        // Arrange
+        IsaacNumericQuestion someNumericQuestion = new IsaacNumericQuestion();
+        someNumericQuestion.setDisregardSignificantFigures(false);
+        someNumericQuestion.setRequireUnits(false);
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity someCorrectAnswer = new Quantity("13");
+        someCorrectAnswer.setCorrect(true);
+
+        answerList.add(someCorrectAnswer);
+        someNumericQuestion.setChoices(answerList);
+
+        // Act
+        Quantity userSubmittedAnswerWithExcessivePrecision = new Quantity("13.000");
+        QuestionValidationResponse response = validator.validateQuestionResponse(someNumericQuestion,
+                userSubmittedAnswerWithExcessivePrecision);
+
+        // Assert
+        assertFalse(response.isCorrect());
+    }
+
     //  ---------- Helper methods to test internal functionality of the validator class ----------
 
     private void testSigFigRoundingWorks(String inputValue, int sigFigToRoundTo, double expectedResult) throws Exception {


### PR DESCRIPTION
This flag allows the content team to indicate that significant
figures should not be taken into account when marking a question.
If this flag is true, the validator skips significant figure
checks and marks any mathematically equal answer correct.

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change _(N/A)_
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped _(N/A)_
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted _(N/A)_
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/) 
- [ ] Security - Access Control - Check authorisation on every new endpoint _(N/A)_
- [ ] Security - New dependency - configured sensibly not relying on defaults _(N/A)_
- [ ] Security - New dependency - Searched for any know vulnerabilities _(N/A)_
- [ ] Security - New dependency - Signed up team to mailing list _(N/A)_
- [ ] Security - New dependency - Added to dependency list _(N/A)_
- [ ] DB schema changes - postgres-rutherford-create-script updated _(N/A)_
- [ ] DB schema changes - upgrade script created matching create script _(N/A)_
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions) _(N/A)_
- [ ] Peer-Reviewed
