### PR TITLE
Replace misleading error message for free attempt on previously assig…

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -452,7 +452,9 @@ public class QuizFacade extends AbstractIsaacFacade {
             List<QuizAssignmentDTO> activeQuizAssignments = this.quizAssignmentManager.getActiveQuizAssignments(quiz, user);
 
             if (!activeQuizAssignments.isEmpty()) {
-                return new SegueErrorResponse(Status.FORBIDDEN, "This test is currently assigned to you. You must complete your assignment before you can attempt this test freely.").toResponse();
+                return new SegueErrorResponse(Status.FORBIDDEN, "This test has been assigned to you by a teacher. "
+                        + "You can not attempt this test freely. If you have already done the test for your teacher, "
+                        + "and want to do it again, ask your teacher to allow you another attempt.").toResponse();
             }
 
             // Create a quiz attempt


### PR DESCRIPTION
Replaces misleading error message for free attempt on previously assigned test.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional) _(Not applicable)_
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs _(Not applicable)_
- [ ] Added enough Logging to monitor expected behaviour change _(Not applicable)_
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped _(Not applicable)_
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted _(Not applicable)_
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint _(Not applicable)_
- [ ] Security - New dependency - configured sensibly not relying on defaults _(Not applicable)_
- [ ] Security - New dependency - Searched for any know vulnerabilities _(Not applicable)_
- [ ] Security - New dependency - Signed up team to mailing list _(Not applicable)_
- [ ] Security - New dependency - Added to dependency list _(Not applicable)_
- [ ] DB schema changes - postgres-rutherford-create-script updated _(Not applicable)_
- [ ] DB schema changes - upgrade script created matching create script _(Not applicable)_
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions) _(Not applicable)_
- [ ] Peer-Reviewed
