### PR TITLE
PDF download endpoint

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -119,6 +119,7 @@ public final class Constants {
     public static final String CONCEPT_ID_LOG_FIELDNAME = "conceptId";
     public static final String PAGE_ID_LOG_FIELDNAME = "pageId";
     public static final String FRAGMENT_ID_LOG_FIELDNAME = "pageFragmentId";
+    public static final String DOCUMENT_PATH_LOG_FIELDNAME = "path";
 
     /**
      * Class to represent Isaac log types.
@@ -131,6 +132,7 @@ public final class Constants {
         DELETE_BOARD_FROM_PROFILE,
         DOWNLOAD_ASSIGNMENT_PROGRESS_CSV,
         DOWNLOAD_GROUP_PROGRESS_CSV,
+        DOWNLOAD_FILE,
         GLOBAL_SITE_SEARCH,
         SET_NEW_ASSIGNMENT,
         SET_NEW_QUIZ_ASSIGNMENT,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -27,7 +27,6 @@ import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.api.services.ContentSummarizerService;
-import uk.ac.cam.cl.dtg.segue.api.SegueContentFacade;
 import uk.ac.cam.cl.dtg.segue.api.managers.IStatisticsManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
@@ -85,7 +84,6 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 public class IsaacController extends AbstractIsaacFacade {
     private static final Logger log = LoggerFactory.getLogger(IsaacController.class);
 
-    private final SegueContentFacade api;
     private final IStatisticsManager statsManager;
     private final UserAccountManager userManager;
     private final UserAssociationManager associationManager;
@@ -121,8 +119,6 @@ public class IsaacController extends AbstractIsaacFacade {
     /**
      * Creates an instance of the isaac controller which provides the REST endpoints for the isaac api.
      * 
-     * @param api
-     *            - Instance of segue Api
      * @param propertiesLoader
      *            - Instance of properties Loader
      * @param logManager
@@ -139,7 +135,7 @@ public class IsaacController extends AbstractIsaacFacade {
      *            - So we can summarize search results
      */
     @Inject
-    public IsaacController(final SegueContentFacade api, final PropertiesLoader propertiesLoader,
+    public IsaacController(final PropertiesLoader propertiesLoader,
                            final ILogManager logManager, final IStatisticsManager statsManager,
                            final UserAccountManager userManager, final IContentManager contentManager,
                            final UserAssociationManager associationManager,
@@ -148,7 +144,6 @@ public class IsaacController extends AbstractIsaacFacade {
                            final UserBadgeManager userBadgeManager,
                            final ContentSummarizerService contentSummarizerService) {
         super(propertiesLoader, logManager);
-        this.api = api;
         this.statsManager = statsManager;
         this.userManager = userManager;
         this.associationManager = associationManager;
@@ -245,6 +240,8 @@ public class IsaacController extends AbstractIsaacFacade {
      *
      * @param request
      *            - used for intelligent cache responses.
+     * @param httpServletRequest
+     *            - used for the Referer header for helpful error messages.
      * @param path
      *            of image in the database
      * @return a Response containing the image file contents or containing a SegueErrorResponse.
@@ -254,7 +251,7 @@ public class IsaacController extends AbstractIsaacFacade {
     @Path("images/{path:.*}")
     @GZIP
     @ApiOperation(value = "Get a binary object from the current content version.",
-            notes = "This can only be used to get images from the content database.")
+                  notes = "This can only be used to get images from the content database.")
     public final Response getImageByPath(@Context final Request request, @Context final HttpServletRequest httpServletRequest,
                                          @PathParam("path") final String path) {
         if (null == path || Files.getFileExtension(path).isEmpty()) {
@@ -271,8 +268,8 @@ public class IsaacController extends AbstractIsaacFacade {
             return cachedResponse;
         }
 
-        ByteArrayOutputStream fileContent = null;
-        String mimeType = MediaType.WILDCARD;
+        ByteArrayOutputStream fileContent;
+        String mimeType;
 
         switch (Files.getFileExtension(path).toLowerCase()) {
             case "svg":
@@ -341,7 +338,7 @@ public class IsaacController extends AbstractIsaacFacade {
     @Path("documents/{path:.*}")
     @GZIP
     @ApiOperation(value = "Get a binary object from the current content version.",
-            notes = "This can only be used to get PDF documents from the content database.")
+                  notes = "This can only be used to get PDF documents from the content database.")
     public final Response getDocumentByPath(@Context final Request request, @Context final HttpServletRequest httpServletRequest,
                                          @PathParam("path") final String path) {
         if (null == path || Files.getFileExtension(path).isEmpty()) {
@@ -433,7 +430,7 @@ public class IsaacController extends AbstractIsaacFacade {
     }
 
     /**
-     * Get snapshot for the current user
+     * Get snapshot for the current user.
      *
      * @param request
      *            - so we can find the current user.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -242,7 +242,7 @@ public class IsaacController extends AbstractIsaacFacade {
 
     /**
      * Rest end point to allow images to be requested from the database.
-     * 
+     *
      * @param request
      *            - used for intelligent cache responses.
      * @param path
@@ -254,23 +254,16 @@ public class IsaacController extends AbstractIsaacFacade {
     @Path("images/{path:.*}")
     @GZIP
     @ApiOperation(value = "Get a binary object from the current content version.",
-                  notes = "This can only be used to get images from the content database.")
+            notes = "This can only be used to get images from the content database.")
     public final Response getImageByPath(@Context final Request request, @Context final HttpServletRequest httpServletRequest,
                                          @PathParam("path") final String path) {
-        // entity tags etc are already added by segue
-
-        // This comes from SegueContentFacade::getImageFileContent -- no other method was calling it, so moving it here.
-        if (null == this.contentIndex || null == path || Files.getFileExtension(path).isEmpty()) {
-            SegueErrorResponse error = new SegueErrorResponse(Status.BAD_REQUEST,
-                    "Bad input to api call. Required parameter not provided.");
-            log.debug(error.getErrorMessage());
+        if (null == path || Files.getFileExtension(path).isEmpty()) {
+            SegueErrorResponse error = new SegueErrorResponse(Status.BAD_REQUEST, "Invalid file path or filename.");
             return error.toResponse();
         }
-        // 'version' now points to an ElasticSearch index name (live or latest, probably)
-        // Go there and look up the git sha.
-        String sha = this.contentManager.getCurrentContentSHA();
 
         // determine if we can use the cache if so return cached response.
+        String sha = this.contentManager.getCurrentContentSHA();
         EntityTag etag = new EntityTag(sha.hashCode() + path.hashCode() + "");
         Response cachedResponse = generateCachedResponse(request, etag, NUMBER_SECONDS_IN_ONE_DAY);
 


### PR DESCRIPTION
Currently blanket-limited to teacher accounts and above, with a new log type `DOWNLOAD_FILE` recording what path was downloaded.
Left the switch statement in, in case we add more supported types.

I am unsure how we make this more general; perhaps some files will want students to be able to download them too? But for now it will work.