### PR TITLE
Fix site-wide search doc type validation

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -16,6 +16,7 @@
 package uk.ac.cam.cl.dtg.isaac.api;
 
 import uk.ac.cam.cl.dtg.segue.api.Constants.LogType;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -49,6 +50,9 @@ public final class Constants {
     public static final String SEARCHABLE_TAG = "search_result";
     public static final String HIDE_FROM_FILTER_TAG = "nofilter";
     public static final String RELATED_CONTENT_FIELDNAME = "relatedContent";
+
+    public static final Set<String> SITE_WIDE_SEARCH_VALID_DOC_TYPES = ImmutableSet.of(
+            QUESTION_TYPE, CONCEPT_TYPE, TOPIC_SUMMARY_PAGE_TYPE, PAGE_TYPE, EVENT_TYPE);
 
     public static final int NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES = 2;
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -205,6 +205,11 @@ public class IsaacController extends AbstractIsaacFacade {
                 showHiddenContent = isUserStaff(userManager, (RegisteredUserDTO) currentUser);
             }
             List<String> documentTypes = !types.isEmpty() ? Arrays.asList(types.split(",")) : null;
+            // Return an error if any of the proposed document types are invalid
+            if (documentTypes != null && !SITE_WIDE_SEARCH_VALID_DOC_TYPES.containsAll(documentTypes)) {
+                return new SegueErrorResponse(Status.BAD_REQUEST, "Invalid document types.").toResponse();
+            }
+
             ResultsWrapper<ContentDTO> searchResults = this.contentManager.siteWideSearch(
                     this.contentIndex, searchString, documentTypes, showHiddenContent, startIndex, limit);
 


### PR DESCRIPTION
This PR fixes the validation of document types sent to site-wide search.

The facade method returns a bad request if any of the document types are invalid.
The manager filters any invalid document types. If the list of valid document types are then empty (or the more common case of the user not specifying document types) then we search for all valid document types.

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- ~Added enough Logging to monitor expected behaviour change~
_We do not tend to log bad requests_
- [ ] Peer-Reviewed
