### PR TITLE
Page fragment updates

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -29,6 +29,7 @@ import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.URIManager;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacTopicSummaryPage;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacPageFragmentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuestionPageDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacTopicSummaryPageDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
@@ -657,12 +658,13 @@ public class PagesFacade extends AbstractIsaacFacade {
 
             Response result = this.findSingleResult(fieldsToMatch);
 
-            getLogManager().logEvent(userManager.getCurrentUser(httpServletRequest), httpServletRequest,
-                    IsaacServerLogType.VIEW_PAGE_FRAGMENT, ImmutableMap.of(
-                            FRAGMENT_ID_LOG_FIELDNAME, fragmentId,
-                            CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA()
-                    ));
-
+            if (result.getEntity() instanceof IsaacPageFragmentDTO) {
+                getLogManager().logEvent(userManager.getCurrentUser(httpServletRequest), httpServletRequest,
+                        IsaacServerLogType.VIEW_PAGE_FRAGMENT, ImmutableMap.of(
+                                FRAGMENT_ID_LOG_FIELDNAME, fragmentId,
+                                CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA()
+                        ));
+            }
             return Response.status(result.getStatus()).entity(result.getEntity())
                     .cacheControl(getCacheControl(NUMBER_SECONDS_IN_ONE_HOUR, true)).tag(etag).build();
         } catch (SegueDatabaseException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPageFragment.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPageFragment.java
@@ -23,4 +23,24 @@ import uk.ac.cam.cl.dtg.segue.dos.content.JsonContentType;
 @DTOMapping(IsaacPageFragmentDTO.class)
 @JsonContentType("isaacPageFragment")
 public class IsaacPageFragment extends Content {
+    private String summary;
+
+    /**
+     * Gets the summary.
+     *
+     * @return the summary
+     */
+    public final String getSummary() {
+        return summary;
+    }
+
+    /**
+     * Sets the summary.
+     *
+     * @param summary
+     *            the summary to set
+     */
+    public final void setSummary(final String summary) {
+        this.summary = summary;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPageFragmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPageFragmentDTO.java
@@ -21,6 +21,7 @@ import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
 
 @JsonContentType("isaacPageFragment")
 public class IsaacPageFragmentDTO extends ContentDTO {
+    private String summary;
 
     @Override
     @JsonIgnore(false) // Override the parent class decorator!
@@ -28,4 +29,22 @@ public class IsaacPageFragmentDTO extends ContentDTO {
         return this.canonicalSourceFile;
     }
 
+    /**
+     * Gets the summary.
+     *
+     * @return the summary
+     */
+    public final String getSummary() {
+        return summary;
+    }
+
+    /**
+     * Sets the summary.
+     *
+     * @param summary
+     *            the summary to set
+     */
+    public final void setSummary(final String summary) {
+        this.summary = summary;
+    }
 }


### PR DESCRIPTION
This is a prerequisite for adding meta descriptions for book pages, since they are solely fragment based. I also fixed a logging issue where fragments that did not exist and were not found were logged equivalently to valid ones.