### PR TITLE
Quiz group CSV: Sort by surname and fix date-ification of mark fractions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1065,10 +1065,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             IsaacQuizDTO quiz = quizManager.findQuiz(assignment.getQuizId());
 
-            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group).stream()
-                    .sorted(Comparator.comparing(RegisteredUserDTO::getGivenName, String.CASE_INSENSITIVE_ORDER))
-                    .sorted(Comparator.comparing(RegisteredUserDTO::getFamilyName, String.CASE_INSENSITIVE_ORDER))
-                    .collect(Collectors.toList());
+            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroupSortedByName(group);
 
             Map<RegisteredUserDTO, QuizFeedbackDTO> feedbackMap = quizQuestionManager.getAssignmentTeacherFeedback(quiz, assignment, groupMembers);
 
@@ -1138,10 +1135,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             }
 
             IsaacQuizDTO quiz = quizManager.findQuiz(assignment.getQuizId());
-            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group).stream()
-                    .sorted(Comparator.comparing(RegisteredUserDTO::getGivenName))
-                    .sorted(Comparator.comparing(RegisteredUserDTO::getFamilyName))
-                    .collect(Collectors.toList());
+            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroupSortedByName(group);
 
             List<String[]> rows = Lists.newArrayList();
             StringWriter stringWriter = new StringWriter();
@@ -1251,10 +1245,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             UserGroupDTO group = this.groupManager.getGroupById(groupId);
 
-            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group).stream()
-                    .sorted(Comparator.comparing(RegisteredUserDTO::getGivenName))
-                    .sorted(Comparator.comparing(RegisteredUserDTO::getFamilyName))
-                    .collect(Collectors.toList());
+            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroupSortedByName(group);
 
             if (!canManageGroup(user, group)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1065,7 +1065,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             IsaacQuizDTO quiz = quizManager.findQuiz(assignment.getQuizId());
 
-            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroupSortedByName(group);
+            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group);
 
             Map<RegisteredUserDTO, QuizFeedbackDTO> feedbackMap = quizQuestionManager.getAssignmentTeacherFeedback(quiz, assignment, groupMembers);
 
@@ -1135,7 +1135,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             }
 
             IsaacQuizDTO quiz = quizManager.findQuiz(assignment.getQuizId());
-            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroupSortedByName(group);
+            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group);
 
             List<String[]> rows = Lists.newArrayList();
             StringWriter stringWriter = new StringWriter();
@@ -1245,7 +1245,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             UserGroupDTO group = this.groupManager.getGroupById(groupId);
 
-            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroupSortedByName(group);
+            List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group);
 
             if (!canManageGroup(user, group)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1252,8 +1252,8 @@ public class QuizFacade extends AbstractIsaacFacade {
             UserGroupDTO group = this.groupManager.getGroupById(groupId);
 
             List<RegisteredUserDTO> groupMembers = this.groupManager.getUsersInGroup(group).stream()
-                    .sorted(Comparator.comparing(RegisteredUserDTO::getFamilyName))
                     .sorted(Comparator.comparing(RegisteredUserDTO::getGivenName))
+                    .sorted(Comparator.comparing(RegisteredUserDTO::getFamilyName))
                     .collect(Collectors.toList());
 
             if (!canManageGroup(user, group)) {
@@ -1314,7 +1314,9 @@ public class QuizFacade extends AbstractIsaacFacade {
                         if (feedback != null) {
                             QuizFeedbackDTO.Mark overallMark = feedback.getOverallMark();
                             if (overallMark != null) {
-                                quizTotals.add(String.format("%d/%d", overallMark.correct, overallMark.correct + overallMark.incorrect + overallMark.notAttempted));
+                                // Add an apostrophe to the beginning of the score, so that the fraction isn't
+                                // interpreted as a date in excel
+                                quizTotals.add(String.format("'%d/%d", overallMark.correct, overallMark.correct + overallMark.incorrect + overallMark.notAttempted));
                             } else {
                                 quizTotals.add("");
                             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -58,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Comparator;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * GroupManager. Responsible for managing group related logic.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -155,7 +155,7 @@ public class GroupManager {
      * 
      * @param group
      *            to find
-     * @return list of users who are members of the group
+     * @return list of users who are members of the group, sorted by given name, then family name (case insensitive)
      * @throws SegueDatabaseException
      *             - If an error occurred while interacting with the database.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Comparator;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * GroupManager. Responsible for managing group related logic.
@@ -169,6 +170,21 @@ public class GroupManager {
         List<RegisteredUserDTO> users = userManager.findUsers(groupMemberIds);
         this.orderUsersByName(users);
         return users;
+    }
+
+    /**
+     * getUsersInGroupSortedByName. Case insensitive
+     *
+     * @param group to find
+     * @return list of users who are members of the group, sorted by name (family name first, then given name)
+     * @throws SegueDatabaseException
+     *             - If an error occurred while interacting with the database.
+     */
+    public List<RegisteredUserDTO> getUsersInGroupSortedByName(final UserGroupDTO group) throws SegueDatabaseException {
+        return getUsersInGroup(group).stream()
+                .sorted(Comparator.comparing(RegisteredUserDTO::getGivenName, String.CASE_INSENSITIVE_ORDER))
+                .sorted(Comparator.comparing(RegisteredUserDTO::getFamilyName, String.CASE_INSENSITIVE_ORDER))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -173,21 +173,6 @@ public class GroupManager {
     }
 
     /**
-     * getUsersInGroupSortedByName. Case insensitive
-     *
-     * @param group to find
-     * @return list of users who are members of the group, sorted by name (family name first, then given name)
-     * @throws SegueDatabaseException
-     *             - If an error occurred while interacting with the database.
-     */
-    public List<RegisteredUserDTO> getUsersInGroupSortedByName(final UserGroupDTO group) throws SegueDatabaseException {
-        return getUsersInGroup(group).stream()
-                .sorted(Comparator.comparing(RegisteredUserDTO::getGivenName, String.CASE_INSENSITIVE_ORDER))
-                .sorted(Comparator.comparing(RegisteredUserDTO::getFamilyName, String.CASE_INSENSITIVE_ORDER))
-                .collect(Collectors.toList());
-    }
-
-    /**
      * Get a map representing the current membership of a given group.
      * @param groupId - group of interest
      * @return map of user id to membership record.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -198,14 +198,14 @@ public class GroupManager {
     }
 
     /**
-     * Helper method to consistently sort users by family name then given name in a case-insensitive order.
+     * Helper method to consistently sort users by given name then family name in a case-insensitive order.
      * @param users
      *            - list of users.
      */
     private void orderUsersByName(final List<RegisteredUserDTO> users) {
         users.sort((userA, userB) -> ComparisonChain.start().
-                compare(userA.getFamilyName(), userB.getFamilyName(), Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)).
                 compare(userA.getGivenName(), userB.getGivenName(), Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)).
+                compare(userA.getFamilyName(), userB.getFamilyName(), Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)).
                 result());
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -150,11 +150,11 @@ public class GroupManager {
     }
 
     /**
-     * getUsersInGroup.
+     * getUsersInGroup. This sorts the users by given name, then family name (case-insensitive)
      * 
      * @param group
      *            to find
-     * @return list of users who are members of the group, sorted by given name, then family name (case insensitive)
+     * @return list of users who are members of the group, sorted by given name, then family name (case-insensitive)
      * @throws SegueDatabaseException
      *             - If an error occurred while interacting with the database.
      */
@@ -167,6 +167,7 @@ public class GroupManager {
         }
 
         List<RegisteredUserDTO> users = userManager.findUsers(groupMemberIds);
+        // Sort the users by name
         this.orderUsersByName(users);
         return users;
     }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -226,8 +226,8 @@ public class QuizFacadeTest extends AbstractFacadeTest {
             requiresLogin(),
             as(studentsTeachersOrAdmin(),
                 prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignment)).andReturn(studentGroup)),
-                prepare(quizQuestionManager, m -> expect(m.getAssignmentTeacherFeedback(studentQuiz, studentAssignment, ImmutableList.of(secondStudent, student)))
-                    .andReturn(ImmutableMap.of(secondStudent, otherStudentFeedback, student, studentFeedback))),
+                prepare(quizQuestionManager, m -> expect(m.getAssignmentTeacherFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
+                    .andReturn(ImmutableMap.of(student, studentFeedback, secondStudent, otherStudentFeedback))),
                 prepare(associationManager, m -> {
                     expect(m.enforceAuthorisationPrivacy(currentUser(), getUserSummaryFor(secondStudent))).andAnswer(grantAccess(true));
                     expect(m.enforceAuthorisationPrivacy(currentUser(), getUserSummaryFor(student))).andAnswer(grantAccess(true));
@@ -241,8 +241,8 @@ public class QuizFacadeTest extends AbstractFacadeTest {
             forbiddenForEveryoneElse(),
             as(studentsTeachersOrAdmin(),
                 prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignment)).andReturn(studentGroup)),
-                prepare(quizQuestionManager, m -> expect(m.getAssignmentTeacherFeedback(studentQuiz, studentAssignment, ImmutableList.of(secondStudent, student)))
-                    .andReturn(ImmutableMap.of(secondStudent, otherStudentFeedback, student, studentFeedback))),
+                prepare(quizQuestionManager, m -> expect(m.getAssignmentTeacherFeedback(studentQuiz, studentAssignment, ImmutableList.of(student, secondStudent)))
+                    .andReturn(ImmutableMap.of(student, studentFeedback, secondStudent, otherStudentFeedback))),
                 prepare(associationManager, m -> {
                     expect(m.enforceAuthorisationPrivacy(currentUser(), getUserSummaryFor(secondStudent))).andAnswer(grantAccess(false));
                     expect(m.enforceAuthorisationPrivacy(currentUser(), getUserSummaryFor(student))).andAnswer(grantAccess(true));


### PR DESCRIPTION
The sorts weren't needed in the first place, since the users are already sorted by name when got from a group. However, this sorting was incorrect, so I changed its order.
With the marks, it's probably better for users to see an extra apostrophe than for excel to interpret the fractions as dates IMO

The issues this fixes can be seen in this screencap from [this ticket](https://tickets.isaacphysics.org/scp/tickets.php?id=29023)