### PR TITLE
Expunge all indices for version if only partially successful ETL run

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ElasticSearchIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ElasticSearchIndexer.java
@@ -128,7 +128,8 @@ class ElasticSearchIndexer extends ElasticSearchProvider {
             log.info("Sending delete request to ElasticSearch for search index: " + typedIndex);
             client.admin().indices().delete(new DeleteIndexRequest(typedIndex)).actionGet();
         } catch (ElasticsearchException e) {
-            log.error("ElasticSearch exception while trying to delete index " + typedIndex, e);
+            log.error("ElasticSearch exception while trying to delete index " + typedIndex +
+                    ", it might not have existed.", e);
             return false;
         }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -99,10 +99,13 @@ public class ContentIndexerTest {
 
         Map<Content, List<String>> someContentProblemsMap = Maps.newHashMap();
 
+        // assume in this case that there are no pre-existing indexes for this version
+        for (Constants.CONTENT_INDEX_TYPE contentIndexType : Constants.CONTENT_INDEX_TYPE.values()) {
+            expect(searchProvider.hasIndex(INITIAL_VERSION, contentIndexType.toString())).andReturn(false).once();
+        }
+
         // prepare pre-canned responses for the object mapper
 		ObjectMapper objectMapper = createMock(ObjectMapper.class);
-		expect(searchProvider.hasIndex(INITIAL_VERSION, Constants.CONTENT_INDEX_TYPE.CONTENT.toString())).andReturn(false)
-				.once();
 		expect(contentMapper.generateNewPreconfiguredContentMapper()).andReturn(objectMapper)
 				.once();
 		expect(objectMapper.writeValueAsString(content)).andReturn(


### PR DESCRIPTION
During the ETL process for a new version of the content, we create one elasticsearch index for each of the `CONTENT_INDEX_TYPE`s.
When checking whether an ETL process had completed successfuly we used to only check whether the main `CONTENT_INDEX_TYPE.CONTENT` index had been created which left the possibility, although rare, for a partially completed indexing of content for a particular version.
This PR makes sure that we check that all of the expected content type indices have been created for a version and cleans up any indices related to a version if any of the expected content type indices failed or are missing.

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- ~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~
- [ ] Peer-Reviewed
