### PR TITLE
Add ETL timing logs and extra bulk indexing

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -102,33 +102,30 @@ public class ContentIndexer {
 
             long totalStartTime, startTime, endTime;
 
-            log.debug("Beginning to populate the Git content cache");
-
             totalStartTime = System.nanoTime();
             buildGitContentIndex(version, true, contentCache, tagsList, allUnits, publishedUnits, indexProblemCache);
             endTime = System.nanoTime();
 
-            log.debug("Finished populating Git content cache, took: " + ((endTime - totalStartTime) / 1000000) + " milliseconds");
-            log.debug("Beginning to record content errors");
+            log.info("Finished populating Git content cache, took: " + ((endTime - totalStartTime) / 1000000) + "ms");
+            log.info("Beginning to record content errors");
 
             startTime = System.nanoTime();
             recordContentErrors(version, contentCache, indexProblemCache);
             endTime = System.nanoTime();
 
-            log.debug("Finished recording content errors, took: " + ((endTime - startTime) / 1000000) + " milliseconds");
-            log.debug("Beginning to build elasticsearch index from Git content cache");
+            log.info("Finished recording content errors, took: " + ((endTime - startTime) / 1000000) + "ms");
 
             startTime = System.nanoTime();
             buildElasticSearchIndex(version, contentCache, tagsList, allUnits, publishedUnits, indexProblemCache);
             endTime = System.nanoTime();
-            log.debug("Finished indexing git content cache, took: " + ((endTime - startTime) / 1000000) + " milliseconds");
+            log.info("Finished indexing git content cache, took: " + ((endTime - startTime) / 1000000) + "ms");
 
             // Verify the version requested is now available
             if (!es.hasIndex(version, CONTENT_INDEX_TYPE.CONTENT.toString())) {
                 throw new Exception(String.format("Failed to index version %s. Don't know why.", version));
             }
 
-            log.info("Finished indexing version " + version + ", took: " + ((endTime - totalStartTime) / 1000000) + " milliseconds");
+            log.info("Finished indexing version " + version + ", took: " + ((endTime - totalStartTime) / 1000000) + "ms");
 
         } finally {
             versionLocks.remove(version);
@@ -679,7 +676,7 @@ public class ContentIndexer {
                 }
             }).filter(Objects::nonNull).collect(Collectors.toList()));
             endTime = System.nanoTime();
-            log.debug("Bulk unit indexing took: " + ((endTime - startTime) / 1000000) + " milliseconds");
+            log.info("Bulk unit indexing took: " + ((endTime - startTime) / 1000000) + "ms");
 
             startTime = System.nanoTime();
             es.bulkIndex(sha, CONTENT_INDEX_TYPE.CONTENT_ERROR.toString(), indexProblemCache.entrySet().stream().map(e -> {
@@ -696,9 +693,8 @@ public class ContentIndexer {
                     return null;
                 }
             }).filter(Objects::nonNull).collect(Collectors.toList()));
-
             endTime = System.nanoTime();
-            log.debug("Bulk content error indexing took: " + ((endTime - startTime) / 1000000) + " milliseconds");
+            log.info("Bulk content error indexing took: " + ((endTime - startTime) / 1000000) + "ms");
         } catch (JsonProcessingException e) {
             log.error("Unable to serialise sha or tags");
         } catch (SegueSearchException e) {
@@ -710,7 +706,7 @@ public class ContentIndexer {
             startTime = System.nanoTime();
             es.bulkIndex(sha, CONTENT_INDEX_TYPE.CONTENT.toString(), contentToIndex);
             endTime = System.nanoTime();
-            log.debug("Bulk indexing content indexing took: " + ((endTime - startTime) / 1000000) + " milliseconds");
+            log.info("Bulk indexing content indexing took: " + ((endTime - startTime) / 1000000) + "ms");
             log.info("Search index request sent for: " + sha);
         } catch (SegueSearchException e) {
             log.error("Error whilst trying to perform bulk index operation.", e);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -648,7 +648,7 @@ public class ContentIndexer {
             startTime = System.nanoTime();
             es.bulkIndex(sha, CONTENT_INDEX_TYPE.UNIT.toString(), allUnits.entrySet().stream().map(entry -> {
                 try {
-                    return immutableEntry((String) null, objectMapper.writeValueAsString(ImmutableMap.of("cleanKey", entry.getKey(), "unit", entry.getValue())));
+                    return objectMapper.writeValueAsString(ImmutableMap.of("cleanKey", entry.getKey(), "unit", entry.getValue()));
                 } catch (JsonProcessingException jsonProcessingException) {
                     log.error("Unable to serialise unit entry for unit: " + entry.getValue());
                     return null;
@@ -656,7 +656,7 @@ public class ContentIndexer {
             }).filter(Objects::nonNull).collect(Collectors.toList()));
             es.bulkIndex(sha, CONTENT_INDEX_TYPE.PUBLISHED_UNIT.toString(), publishedUnits.entrySet().stream().map(entry -> {
                 try {
-                    return immutableEntry((String) null, objectMapper.writeValueAsString(ImmutableMap.of("cleanKey", entry.getKey(), "unit", entry.getValue())));
+                    return objectMapper.writeValueAsString(ImmutableMap.of("cleanKey", entry.getKey(), "unit", entry.getValue()));
                 } catch (JsonProcessingException jsonProcessingException) {
                     log.error("Unable to serialise published unit entry for unit: " + entry.getValue());
                     return null;
@@ -668,13 +668,13 @@ public class ContentIndexer {
             startTime = System.nanoTime();
             es.bulkIndex(sha, CONTENT_INDEX_TYPE.CONTENT_ERROR.toString(), indexProblemCache.entrySet().stream().map(e -> {
                 try {
-                    return immutableEntry((String) null, objectMapper.writeValueAsString(ImmutableMap.of(
+                    return objectMapper.writeValueAsString(ImmutableMap.of(
                             "canonicalSourceFile", e.getKey().getCanonicalSourceFile(),
                             "id", e.getKey().getId() == null ? "" : e.getKey().getId(),
                             "title", e.getKey().getTitle() == null ? "" : e.getKey().getTitle(),
                             // "tags", c.getTags(), // TODO: Add tags
                             "published", e.getKey().getPublished() == null ? "" : e.getKey().getPublished(),
-                            "errors", e.getValue().toArray())));
+                            "errors", e.getValue().toArray()));
                 } catch (JsonProcessingException jsonProcessingException) {
                     log.error("Unable to serialise content error entry from file: " + e.getKey().getCanonicalSourceFile());
                     return null;
@@ -691,7 +691,7 @@ public class ContentIndexer {
 
         try {
             startTime = System.nanoTime();
-            es.bulkIndex(sha, CONTENT_INDEX_TYPE.CONTENT.toString(), contentToIndex);
+            es.bulkIndexWithIDs(sha, CONTENT_INDEX_TYPE.CONTENT.toString(), contentToIndex);
             endTime = System.nanoTime();
             log.info("Bulk indexing content took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
             log.info("Search index request sent for: " + sha);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -133,20 +133,6 @@ public class ContentIndexer {
 
     }
 
-
-            // Verify the version requested is now available
-            if (!es.hasIndex(version, CONTENT_INDEX_TYPE.CONTENT.toString())) {
-                throw new Exception(String.format("Failed to index version %s. Don't know why.", version));
-            }
-
-            log.info("Finished indexing version " + version);
-
-        } finally {
-            versionLocks.remove(version);
-        }
-
-    }
-
     void setNamedVersion(String alias, String version) {
         List<String> allContentTypes = Arrays.stream(CONTENT_INDEX_TYPE.values())
                 .map((contentIndexType) -> contentIndexType.toString()).collect(Collectors.toList());
@@ -706,7 +692,7 @@ public class ContentIndexer {
             startTime = System.nanoTime();
             es.bulkIndex(sha, CONTENT_INDEX_TYPE.CONTENT.toString(), contentToIndex);
             endTime = System.nanoTime();
-            log.info("Bulk indexing content indexing took: " + ((endTime - startTime) / 1000000) + "ms");
+            log.info("Bulk indexing content took: " + ((endTime - startTime) / 1000000) + "ms");
             log.info("Search index request sent for: " + sha);
         } catch (SegueSearchException e) {
             log.error("Error whilst trying to perform bulk index operation.", e);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -57,6 +57,7 @@ public class ContentIndexer {
     private ContentMapper mapper;
 
     private static final int MEDIA_FILE_SIZE_LIMIT = 300 * 1024; // Bytes
+    private static final int NANOSECONDS_IN_A_MILLISECOND = 1000000;
 
     @Inject
     public ContentIndexer(GitDb database, ElasticSearchIndexer es, ContentMapper mapper) {
@@ -106,26 +107,26 @@ public class ContentIndexer {
             buildGitContentIndex(version, true, contentCache, tagsList, allUnits, publishedUnits, indexProblemCache);
             endTime = System.nanoTime();
 
-            log.info("Finished populating Git content cache, took: " + ((endTime - totalStartTime) / 1000000) + "ms");
+            log.info("Finished populating Git content cache, took: " + ((endTime - totalStartTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
             log.info("Beginning to record content errors");
 
             startTime = System.nanoTime();
             recordContentErrors(version, contentCache, indexProblemCache);
             endTime = System.nanoTime();
 
-            log.info("Finished recording content errors, took: " + ((endTime - startTime) / 1000000) + "ms");
+            log.info("Finished recording content errors, took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
 
             startTime = System.nanoTime();
             buildElasticSearchIndex(version, contentCache, tagsList, allUnits, publishedUnits, indexProblemCache);
             endTime = System.nanoTime();
-            log.info("Finished indexing git content cache, took: " + ((endTime - startTime) / 1000000) + "ms");
+            log.info("Finished indexing git content cache, took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
 
             // Verify the version requested is now available
             if (!es.hasIndex(version, CONTENT_INDEX_TYPE.CONTENT.toString())) {
                 throw new Exception(String.format("Failed to index version %s. Don't know why.", version));
             }
 
-            log.info("Finished indexing version " + version + ", took: " + ((endTime - totalStartTime) / 1000000) + "ms");
+            log.info("Finished indexing version " + version + ", took: " + ((endTime - totalStartTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
 
         } finally {
             versionLocks.remove(version);
@@ -662,7 +663,7 @@ public class ContentIndexer {
                 }
             }).filter(Objects::nonNull).collect(Collectors.toList()));
             endTime = System.nanoTime();
-            log.info("Bulk unit indexing took: " + ((endTime - startTime) / 1000000) + "ms");
+            log.info("Bulk unit indexing took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
 
             startTime = System.nanoTime();
             es.bulkIndex(sha, CONTENT_INDEX_TYPE.CONTENT_ERROR.toString(), indexProblemCache.entrySet().stream().map(e -> {
@@ -680,7 +681,7 @@ public class ContentIndexer {
                 }
             }).filter(Objects::nonNull).collect(Collectors.toList()));
             endTime = System.nanoTime();
-            log.info("Bulk content error indexing took: " + ((endTime - startTime) / 1000000) + "ms");
+            log.info("Bulk content error indexing took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
         } catch (JsonProcessingException e) {
             log.error("Unable to serialise sha or tags");
         } catch (SegueSearchException e) {
@@ -692,7 +693,7 @@ public class ContentIndexer {
             startTime = System.nanoTime();
             es.bulkIndex(sha, CONTENT_INDEX_TYPE.CONTENT.toString(), contentToIndex);
             endTime = System.nanoTime();
-            log.info("Bulk indexing content took: " + ((endTime - startTime) / 1000000) + "ms");
+            log.info("Bulk indexing content took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
             log.info("Search index request sent for: " + sha);
         } catch (SegueSearchException e) {
             log.error("Error whilst trying to perform bulk index operation.", e);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SchoolIndexer.java
@@ -79,7 +79,7 @@ class SchoolIndexer {
         }
 
         try {
-            es.bulkIndex(SCHOOLS_INDEX_BASE, SCHOOLS_INDEX_TYPE.SCHOOL_SEARCH.toString(), indexList);
+            es.bulkIndexWithIDs(SCHOOLS_INDEX_BASE, SCHOOLS_INDEX_TYPE.SCHOOL_SEARCH.toString(), indexList);
             log.info("School list index request complete.");
         } catch (SegueSearchException e) {
             log.error("Unable to complete bulk index operation for schools list.", e);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -134,9 +134,13 @@ public class ContentIndexerTest {
 
         // Ensure units are indexed
         searchProvider.bulkIndex(eq(INITIAL_VERSION), eq(Constants.CONTENT_INDEX_TYPE.UNIT.toString()), anyObject());
-        expectLastCall().atLeastOnce();
+        expectLastCall().once();
         searchProvider.bulkIndex(eq(INITIAL_VERSION), eq(Constants.CONTENT_INDEX_TYPE.PUBLISHED_UNIT.toString()), anyObject());
-        expectLastCall().atLeastOnce();
+        expectLastCall().once();
+
+        // Ensure content errors are indexed
+        searchProvider.bulkIndex(eq(INITIAL_VERSION), eq(Constants.CONTENT_INDEX_TYPE.CONTENT_ERROR.toString()), anyObject());
+        expectLastCall().once();
 
         // Ensure at least one bulk index for general content is requested
         searchProvider.bulkIndex(eq(INITIAL_VERSION), eq(Constants.CONTENT_INDEX_TYPE.CONTENT.toString()), anyObject());

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -143,7 +143,7 @@ public class ContentIndexerTest {
         expectLastCall().once();
 
         // Ensure at least one bulk index for general content is requested
-        searchProvider.bulkIndex(eq(INITIAL_VERSION), eq(Constants.CONTENT_INDEX_TYPE.CONTENT.toString()), anyObject());
+        searchProvider.bulkIndexWithIDs(eq(INITIAL_VERSION), eq(Constants.CONTENT_INDEX_TYPE.CONTENT.toString()), anyObject());
 		expectLastCall().once();
 
 		replay(searchProvider, contentMapper, objectMapper);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -133,9 +133,9 @@ public class ContentIndexerTest {
         expectLastCall().atLeastOnce();
 
         // Ensure units are indexed
-        searchProvider.indexObject(eq(INITIAL_VERSION), eq("unit"), eq(someUnitsMap.toString()));
+        searchProvider.bulkIndex(eq(INITIAL_VERSION), eq(Constants.CONTENT_INDEX_TYPE.UNIT.toString()), anyObject());
         expectLastCall().atLeastOnce();
-        searchProvider.indexObject(eq(INITIAL_VERSION), eq("publishedUnit"), eq(publishedUnitsMap.toString()));
+        searchProvider.bulkIndex(eq(INITIAL_VERSION), eq(Constants.CONTENT_INDEX_TYPE.PUBLISHED_UNIT.toString()), anyObject());
         expectLastCall().atLeastOnce();
 
         // Ensure at least one bulk index for general content is requested


### PR DESCRIPTION
The branch name is a bit ominous, but this PR just adds bulk indexing for units, published units and content errors (which speeds up ETL phy locally by about 8 seconds). 

Importantly, some logging is added that times various parts of the indexing process. This will be helpful in diagnosing what exactly is taking ages on the live server.