### PR TITLE
Prefer topic results when searching site

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -337,7 +337,7 @@ public class GitContentManager implements IContentManager {
             contentQuery.setMinimumShouldMatch(numberOfExpectedShouldMatches);
 
             if (importantDocumentTypes.contains(documentType)) {
-                contentQuery.setBoost(10f);
+                contentQuery.setBoost(5f);
             }
 
             matchQuery.should(contentQuery);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -280,6 +280,8 @@ public class GitContentManager implements IContentManager {
     ) throws  ContentManagerException {
         String nestedFieldConnector = searchProvider.getNestedFieldConnector();
 
+        List<String> importantDocumentTypes = ImmutableList.of(TOPIC_SUMMARY_PAGE_TYPE);
+
         List<String> importantFields = ImmutableList.of(
                 Constants.TITLE_FIELDNAME, Constants.ID_FIELDNAME, Constants.SUMMARY_FIELDNAME, Constants.TAGS_FIELDNAME
         );
@@ -333,6 +335,11 @@ public class GitContentManager implements IContentManager {
             }
 
             contentQuery.setMinimumShouldMatch(numberOfExpectedShouldMatches);
+
+            if (importantDocumentTypes.contains(documentType)) {
+                contentQuery.setBoost(10f);
+            }
+
             matchQuery.should(contentQuery);
         }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/BooleanMatchInstruction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/BooleanMatchInstruction.java
@@ -9,6 +9,7 @@ public class BooleanMatchInstruction extends AbstractMatchInstruction {
     private List<AbstractMatchInstruction> shoulds = Lists.newArrayList();
     private List<AbstractMatchInstruction> mustNots = Lists.newArrayList();
     private int minimumShouldMatch = 0;
+    private Float boost;
 
     public List<AbstractMatchInstruction> getMusts() {
         return musts;
@@ -36,5 +37,12 @@ public class BooleanMatchInstruction extends AbstractMatchInstruction {
     }
     public void setMinimumShouldMatch(int minimumShouldMatch) {
         this.minimumShouldMatch = minimumShouldMatch;
+    }
+
+    public void setBoost(final Float boostValue) {
+        this.boost = boostValue;
+    }
+    public Float getBoost() {
+        return this.boost;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
@@ -617,6 +617,9 @@ public class ElasticSearchProvider implements ISearchProvider {
                 query.mustNot(processMatchInstructions(mustNot));
             }
             query.minimumShouldMatch(booleanMatch.getMinimumShouldMatch());
+            if (booleanMatch.getBoost() != null) {
+                query.boost(booleanMatch.getBoost());
+            }
             return query;
         }
 


### PR DESCRIPTION
CS have requested that we rank topic summary pages higher.
From trial and error, boosting their match results by 10 seems to produce a subjectively better set of results.
This will not alter Physics' results as they do not have pages of this type.

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- ~Added enough Logging to monitor expected behaviour change~
- ~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~
- [ ] Peer-Reviewed
