### PR TITLE
Expose content manager cache stats to Prometheus

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -117,7 +117,7 @@ public class GitContentManager implements IContentManager {
         }
 
         this.cache = CacheBuilder.newBuilder().recordStats().softValues().expireAfterAccess(1, TimeUnit.DAYS).build();
-        CACHE_METRICS_COLLECTOR.addCache("GitContentManagerCache", cache);
+        CACHE_METRICS_COLLECTOR.addCache("git_content_manager_cache", cache);
 
         this.contentShaCache = CacheBuilder.newBuilder().softValues().expireAfterWrite(5, TimeUnit.SECONDS).build();
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -69,6 +69,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics.CACHE_METRICS_COLLECTOR;
 
 /**
  * Implementation that specifically works with Content objects.
@@ -115,7 +116,9 @@ public class GitContentManager implements IContentManager {
             log.info("API Configured to only allow published content to be returned.");
         }
 
-        this.cache = CacheBuilder.newBuilder().softValues().expireAfterAccess(1, TimeUnit.DAYS).build();
+        this.cache = CacheBuilder.newBuilder().recordStats().softValues().expireAfterAccess(1, TimeUnit.DAYS).build();
+        CACHE_METRICS_COLLECTOR.addCache("GitContentManagerCache", cache);
+
         this.contentShaCache = CacheBuilder.newBuilder().softValues().expireAfterWrite(5, TimeUnit.SECONDS).build();
     }
 


### PR DESCRIPTION
---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional) - _N/A_
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs - _N/A_
- [ ] Added enough Logging to monitor expected behaviour change - _N/A_
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped - _N/A_
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted - _N/A_
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint - _N/A_
- [ ] Security - New dependency - configured sensibly not relying on defaults - _N/A_
- [ ] Security - New dependency - Searched for any know vulnerabilities - _N/A_
- [ ] Security - New dependency - Signed up team to mailing list - _N/A_
- [ ] Security - New dependency - Added to dependency list - _N/A_
- [ ] DB schema changes - postgres-rutherford-create-script updated - _N/A_
- [ ] DB schema changes - upgrade script created matching create script - _N/A_
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions) - _N/A_
- [ ] Peer-Reviewed
