### PR TITLE
Event booking transactions and locking

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -773,6 +773,7 @@ public class EventBookingManager {
             userDTO, final boolean attended)
             throws SegueDatabaseException, EventBookingUpdateException {
 
+        DetailedEventBookingDTO updatedBooking;
         try (ITransaction transaction = transactionManager.getTransaction()) {
             this.bookingPersistenceManager.lockEventUntilTransactionComplete(transaction, event.getId());
 
@@ -787,9 +788,12 @@ public class EventBookingManager {
                 throw new EventBookingUpdateException("Booking attendance is already registered.");
             }
 
-            return this.bookingPersistenceManager.updateBookingStatus(transaction, eventBooking.getEventId(),
+            updatedBooking = this.bookingPersistenceManager.updateBookingStatus(transaction, eventBooking.getEventId(),
                     userDTO.getId(), attendanceStatus, eventBooking.getAdditionalInformation());
+
+            transaction.commit();
         }
+        return updatedBooking;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -491,8 +491,7 @@ public class EventBookingManager {
         }
 
         List<EventBookingDTO> reservations = new ArrayList<>();
-        // Wrap this into a database transaction
-        // FIXME: None of the booking code uses this transaction in any way!
+        // Wrap this into a database transaction:
         try (ITransaction transaction = transactionManager.getTransaction()) {
             try {
                 // Obtain an exclusive database lock for the event:

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -1056,6 +1056,7 @@ public class EventBookingManager {
 
             this.bookingPersistenceManager.deleteBooking(transaction, event.getId(), user.getId());
             this.removeUserFromEventGroup(event, user);
+            transaction.commit();
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -118,16 +118,18 @@ public class EventBookingPersistenceManager {
 	/**
      * Modify an existing event booking's status
      *
+     * @param transaction - the database transaction to use
      * @param eventId - the id of the event
      * @param userId = the user who is registered against the event
      * @param reservingUserId - the user who is updating this booking to be a reservation
      * @param bookingStatus - the new booking status for this booking.
+     * @param additionalEventInformation - additional information required for the event.
      * @return The newly updated event booking
      * @throws SegueDatabaseException
      *             - if an error occurs.
      */
-    public DetailedEventBookingDTO updateBookingStatus(final String eventId, final Long userId, final Long reservingUserId, final BookingStatus bookingStatus, final Map additionalEventInformation) throws SegueDatabaseException {
-        dao.updateStatus(eventId, userId, reservingUserId, bookingStatus, additionalEventInformation);
+    public DetailedEventBookingDTO updateBookingStatus(final ITransaction transaction, final String eventId, final Long userId, final Long reservingUserId, final BookingStatus bookingStatus, final Map<String, String> additionalEventInformation) throws SegueDatabaseException {
+        dao.updateStatus(transaction, eventId, userId, reservingUserId, bookingStatus, additionalEventInformation);
         return this.getBookingByEventIdAndUserId(eventId, userId);
     }
 
@@ -141,8 +143,8 @@ public class EventBookingPersistenceManager {
      * @throws SegueDatabaseException
      *             - if an error occurs.
      */
-    public DetailedEventBookingDTO updateBookingStatus(final String eventId, final Long userId, final BookingStatus bookingStatus, final Map additionalEventInformation) throws SegueDatabaseException {
-        return updateBookingStatus(eventId, userId, null, bookingStatus, additionalEventInformation);
+    public DetailedEventBookingDTO updateBookingStatus(final ITransaction transaction, final String eventId, final Long userId, final BookingStatus bookingStatus, final Map additionalEventInformation) throws SegueDatabaseException {
+        return updateBookingStatus(transaction, eventId, userId, null, bookingStatus, additionalEventInformation);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -273,6 +273,8 @@ public class EventBookingPersistenceManager {
     }
 
     /**
+     * @param transaction
+     *            - the database transaction to use
      * @param eventId
      *            - event id
      * @param userId
@@ -280,8 +282,8 @@ public class EventBookingPersistenceManager {
      * @throws SegueDatabaseException
      *             - if an error occurs.
      */
-    public void deleteBooking(final String eventId, final Long userId) throws SegueDatabaseException {
-        dao.delete(eventId, userId);
+    public void deleteBooking(final ITransaction transaction, final String eventId, final Long userId) throws SegueDatabaseException {
+        dao.delete(transaction, eventId, userId);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -298,30 +298,6 @@ public class EventBookingPersistenceManager {
     }
 
     /**
-     * Acquire a globally unique database lock.
-     *
-     * This lock must be released manually.
-     *
-     * @param resourceId - the unique id for the object to be locked.
-     * @throws SegueDatabaseException if there is a problem acquiring the lock
-     */
-    @Deprecated
-    public void acquireDistributedLock(final String resourceId) throws SegueDatabaseException {
-        dao.acquireDistributedLock(resourceId);
-    }
-
-    /**
-     * Release a globally unique database lock.
-     * This lock must be released manually.
-     * @param resourceId - the unique id for the object to be locked.
-     * @throws SegueDatabaseException if there is a problem releasing the lock
-     */
-    @Deprecated
-    public void releaseDistributedLock(final String resourceId) throws SegueDatabaseException {
-        dao.releaseDistributedLock(resourceId);
-    }
-
-    /**
      * Acquire a globally unique lock on an event for the duration of a transaction.
      *
      * This lock will interact as expected with acquireDistributedLock for the same resource ID.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -223,35 +223,32 @@ public class EventBookingPersistenceManager {
     }
 
     /**
-     * @param eventId
-     *            - of interest
-     * @param userId
-     *            - user to book on to the event.
-     * @param reservingId
-     *            - user making the reservation
-     * @param status
-     *            - The status of the booking to create.
+     * @param transaction - the database transaction to use
+     * @param eventId - of interest
+     * @param userId - user to book on to the event.
+     * @param reservingId - user making the reservation
+     * @param status - The status of the booking to create.
+     * @param additionalInformation - additional information required for the event.
      * @return the newly created booking.
-     * @throws SegueDatabaseException
-     *             - if an error occurs.
+     * @throws SegueDatabaseException - if an error occurs.
      */
-    public EventBookingDTO createBooking(final String eventId, final Long userId, final Long reservingId, final BookingStatus status, final Map<String,String> additionalInformation) throws SegueDatabaseException {
-        return this.convertToDTO(dao.add(eventId, userId, reservingId, status, additionalInformation));
+    public EventBookingDTO createBooking(final ITransaction transaction, final String eventId, final Long userId, final Long reservingId, final BookingStatus status,
+                                         final Map<String, String> additionalInformation) throws SegueDatabaseException {
+        return this.convertToDTO(dao.add(transaction, eventId, userId, reservingId, status, additionalInformation));
     }
 
     /**
-     * @param eventId
-     *            - of interest
-     * @param userId
-     *            - user to book on to the event.
-     * @param status
-     *            - The status of the booking to create.
+     * @param transaction - the database transaction to use
+     * @param eventId - of interest
+     * @param userId - user to book on to the event.
+     * @param status - The status of the booking to create.
+     * @param additionalInformation - additional information required for the event.
      * @return the newly created booking.
-     * @throws SegueDatabaseException
-     *             - if an error occurs.
+     * @throws SegueDatabaseException - if an error occurs.
      */
-    public EventBookingDTO createBooking(final String eventId, final Long userId, final BookingStatus status, final Map<String,String> additionalInformation) throws SegueDatabaseException {
-        return this.convertToDTO(dao.add(eventId, userId, status, additionalInformation));
+    public EventBookingDTO createBooking(final ITransaction transaction, final String eventId, final Long userId, final BookingStatus status,
+                                         final Map<String, String> additionalInformation) throws SegueDatabaseException {
+        return this.convertToDTO(dao.add(transaction, eventId, userId, status, additionalInformation));
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import com.google.api.client.util.Lists;
 import com.google.inject.Inject;
 
+import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
 import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.*;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.eventbookings.DetailedEventBookingDTO;
@@ -301,6 +302,7 @@ public class EventBookingPersistenceManager {
      * @param resourceId - the unique id for the object to be locked.
      * @throws SegueDatabaseException if there is a problem acquiring the lock
      */
+    @Deprecated
     public void acquireDistributedLock(final String resourceId) throws SegueDatabaseException {
         dao.acquireDistributedLock(resourceId);
     }
@@ -311,8 +313,21 @@ public class EventBookingPersistenceManager {
      * @param resourceId - the unique id for the object to be locked.
      * @throws SegueDatabaseException if there is a problem releasing the lock
      */
+    @Deprecated
     public void releaseDistributedLock(final String resourceId) throws SegueDatabaseException {
         dao.releaseDistributedLock(resourceId);
+    }
+
+    /**
+     * Acquire a globally unique lock on an event for the duration of a transaction.
+     *
+     * This lock will interact as expected with acquireDistributedLock for the same resource ID.
+     *
+     * @param transaction - the database transaction to acquire the lock in.
+     * @param resourceId - the ID of the event to be locked.
+     */
+    public void lockEventUntilTransactionComplete(final ITransaction transaction, final String resourceId) throws SegueDatabaseException {
+        dao.lockEventUntilTransactionComplete(transaction, resourceId);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -300,8 +300,6 @@ public class EventBookingPersistenceManager {
     /**
      * Acquire a globally unique lock on an event for the duration of a transaction.
      *
-     * This lock will interact as expected with acquireDistributedLock for the same resource ID.
-     *
      * @param transaction - the database transaction to acquire the lock in.
      * @param resourceId - the ID of the event to be locked.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ITransaction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ITransaction.java
@@ -3,11 +3,31 @@ package uk.ac.cam.cl.dtg.isaac.dos;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 
 /**
- * Created by du220 on 04/06/2018.
+ *  Interface to abstract database transaction connection management.
+ *
+ *  Use an ITransaction to provide a Connection object to be used instead of
+ *  getting separate Connections from the thread pool for linked queries.
+ *  Statements executed using that object will be batched and not committed until
+ *  commit() is called.
+ *
+ *  Use in a try-with-resources block, but you MUST either commit or rollback
+ *  explicitly since behaviour is undefined on closing without doing so!
+ *  e.g.
+ *  <pre>
+ *  try (ITransaction transaction = transactionManager.getTransaction()) {
+ *      Connection conn = transaction.getConnection();
+ *      doSomethingInATransaction(conn);
+ *      doMoreInATransaction(conn);
+ *      transaction.commit();
+ *  }
+ *  </pre>
+ *
  */
-public interface ITransaction {
+public interface ITransaction extends AutoCloseable {
 
     Object getConnection();
     void commit() throws SegueDatabaseException;
     void rollback() throws SegueDatabaseException;
+    @Override
+    void close() throws SegueDatabaseException;
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgTransaction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgTransaction.java
@@ -7,7 +7,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 
 /**
- * Created by du220 on 04/06/2018.
+ *  @see ITransaction
  */
 public class PgTransaction implements ITransaction {
 
@@ -30,11 +30,7 @@ public class PgTransaction implements ITransaction {
     @Override
     public void commit() throws SegueDatabaseException {
         try {
-            try {
-                conn.commit();
-            } finally {
-                conn.close();
-            }
+            conn.commit();
         } catch (SQLException e) {
             throw new SegueDatabaseException("Transaction Commit Failure!", e);
         }
@@ -43,11 +39,16 @@ public class PgTransaction implements ITransaction {
     @Override
     public void rollback() throws SegueDatabaseException {
         try {
-            try {
-                conn.rollback();
-            } finally {
-                conn.close();
-            }
+            conn.rollback();
+        } catch (SQLException e) {
+            throw new SegueDatabaseException("Transaction Rollback Failure!", e);
+        }
+    }
+
+    @Override
+    public void close() throws SegueDatabaseException {
+        try {
+            conn.close();
         } catch (SQLException e) {
             throw new SegueDatabaseException("Transaction Rollback Failure!", e);
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgTransaction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgTransaction.java
@@ -11,7 +11,7 @@ import java.sql.SQLException;
  */
 public class PgTransaction implements ITransaction {
 
-    private Connection conn;
+    private final Connection conn;
 
     public PgTransaction(final PostgresSqlDb postgresSqlDb) throws SegueDatabaseException {
         try {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgTransaction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgTransaction.java
@@ -50,7 +50,7 @@ public class PgTransaction implements ITransaction {
         try {
             conn.close();
         } catch (SQLException e) {
-            throw new SegueDatabaseException("Transaction Rollback Failure!", e);
+            throw new SegueDatabaseException("Transaction Close Failure!", e);
         }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -34,36 +34,33 @@ public interface EventBookings {
     /**
      * Add booking to the database.
      *
-     * @param eventId
-     *            - the event id
-     * @param userId
-     *            - the user id
-     * @param reservedById
-     *            - the user id of who made the reservation (can be null)
-     * @param status
-     *            - the initial status of the booking.
+     * @param transaction - the database transaction to use
+     * @param eventId - the event id
+     * @param userId - the user id
+     * @param reservedById - the user id of who made the reservation (can be null)
+     * @param status - the initial status of the booking.
      * @param additionalInformation - additional information required for the event.
      * @return the newly created booking
      * @throws SegueDatabaseException
      *             - if an error occurs.
      */
-    EventBooking add(final String eventId, final Long userId, final Long reservedById, final BookingStatus status, final Map<String,String> additionalInformation) throws SegueDatabaseException;
+    EventBooking add(ITransaction transaction, String eventId, Long userId, Long reservedById, BookingStatus status,
+                     Map<String, String> additionalInformation) throws SegueDatabaseException;
 
     /**
      * Add booking to the database.
-     * 
-     * @param eventId
-     *            - the event id
-     * @param userId
-     *            - the user id
-     * @param status
-     *            - the initial status of the booking.
+     *
+     * @param transaction - the database transaction to use
+     * @param eventId - the event id
+     * @param userId - the user id
+     * @param status - the initial status of the booking.
      * @param additionalInformation - additional information required for the event.
      * @return the newly created booking
      * @throws SegueDatabaseException
      *             - if an error occurs.
      */
-    EventBooking add(final String eventId, final Long userId, final BookingStatus status, final Map<String,String> additionalInformation) throws SegueDatabaseException;
+    EventBooking add(ITransaction transaction, String eventId, Long userId, BookingStatus status,
+                     Map<String, String> additionalInformation) throws SegueDatabaseException;
 
 	/**
      * updateStatus.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -91,23 +91,6 @@ public interface EventBookings {
     void delete(ITransaction transaction, String eventId, Long userId) throws SegueDatabaseException;
 
     /**
-     * Acquire a globally unique database lock.
-     * This lock must be released manually.
-     * @param resourceId - the unique id for the object to be locked.
-     */
-    @Deprecated
-    void acquireDistributedLock(String resourceId) throws SegueDatabaseException;
-
-    /**
-     * Release a globally unique database lock.
-     * This method will release a previously acquired lock.
-     *
-     * @param resourceId - the unique id for the object to be locked.
-     */
-    @Deprecated
-    void releaseDistributedLock(String resourceId) throws SegueDatabaseException;
-
-    /**
      * Acquire a globally unique lock on an event for the duration of a transaction.
      *
      * This lock will interact as expected with acquireDistributedLock for the same resource ID.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -68,14 +68,15 @@ public interface EventBookings {
 	/**
      * updateStatus.
      *
+     * @param transaction - the database transaction to use
      * @param eventId - the id of the event
      * @param userId - the id of the user booked on to the event
+     * @param reservingUserId - the id of the user making the reservation
      * @param status - the new status to change the booking to
      * @param additionalEventInformation - additional information required for the event if null it will be unmodified.
-     * @return the newly updated event booking.
      * @throws SegueDatabaseException - if the database goes wrong.
      */
-    void updateStatus(final String eventId, final Long userId, final Long reservingUserId, final BookingStatus status, Map<String, String> additionalEventInformation) throws SegueDatabaseException;
+    void updateStatus(ITransaction transaction, String eventId, Long userId, Long reservingUserId, BookingStatus status, Map<String, String> additionalEventInformation) throws SegueDatabaseException;
 
     /**
      * Remove booking from the database.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -15,6 +15,7 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dos.eventbookings;
 
+import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
 
@@ -78,7 +79,7 @@ public interface EventBookings {
 
     /**
      * Remove booking from the database.
-     * 
+     *
      * @param eventId
      *            - the event id
      * @param userId
@@ -93,6 +94,7 @@ public interface EventBookings {
      * This lock must be released manually.
      * @param resourceId - the unique id for the object to be locked.
      */
+    @Deprecated
     void acquireDistributedLock(String resourceId) throws SegueDatabaseException;
 
     /**
@@ -101,7 +103,18 @@ public interface EventBookings {
      *
      * @param resourceId - the unique id for the object to be locked.
      */
+    @Deprecated
     void releaseDistributedLock(String resourceId) throws SegueDatabaseException;
+
+    /**
+     * Acquire a globally unique lock on an event for the duration of a transaction.
+     *
+     * This lock will interact as expected with acquireDistributedLock for the same resource ID.
+     *
+     * @param transaction - the database transaction to acquire the lock in.
+     * @param resourceId - the ID of the event to be locked.
+     */
+    void lockEventUntilTransactionComplete(ITransaction transaction, String resourceId) throws SegueDatabaseException;
 
     /**
      * Find all bookings for a given event.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -93,8 +93,6 @@ public interface EventBookings {
     /**
      * Acquire a globally unique lock on an event for the duration of a transaction.
      *
-     * This lock will interact as expected with acquireDistributedLock for the same resource ID.
-     *
      * @param transaction - the database transaction to acquire the lock in.
      * @param resourceId - the ID of the event to be locked.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,7 +76,8 @@ public interface EventBookings {
      * @param additionalEventInformation - additional information required for the event if null it will be unmodified.
      * @throws SegueDatabaseException - if the database goes wrong.
      */
-    void updateStatus(ITransaction transaction, String eventId, Long userId, Long reservingUserId, BookingStatus status, Map<String, String> additionalEventInformation) throws SegueDatabaseException;
+    void updateStatus(ITransaction transaction, String eventId, Long userId, Long reservingUserId, BookingStatus status,
+                      Map<String, String> additionalEventInformation) throws SegueDatabaseException;
 
     /**
      * Remove booking from the database.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -80,6 +80,8 @@ public interface EventBookings {
     /**
      * Remove booking from the database.
      *
+     * @param transaction
+     *            - the database transaction to use
      * @param eventId
      *            - the event id
      * @param userId
@@ -87,7 +89,7 @@ public interface EventBookings {
      * @throws SegueDatabaseException
      *             - if an error occurs.
      */
-    void delete(final String eventId, final Long userId) throws SegueDatabaseException;
+    void delete(ITransaction transaction, String eventId, Long userId) throws SegueDatabaseException;
 
     /**
      * Acquire a globally unique database lock.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -176,11 +176,14 @@ public class PgEventBookings implements EventBookings {
     }
 
     @Override
-    public void delete(final String eventId, final Long userId) throws SegueDatabaseException {
+    public void delete(final ITransaction transaction, final String eventId, final Long userId) throws SegueDatabaseException {
+        if (!(transaction instanceof PgTransaction)) {
+            throw new SegueDatabaseException("Incorrect database transaction class type!");
+        }
+
         String query = "DELETE FROM event_bookings WHERE event_id = ? AND user_id = ?";
-        try (Connection conn = ds.getDatabaseConnection();
-            PreparedStatement pst = conn.prepareStatement(query);
-        ) {
+        Connection conn = ((PgTransaction) transaction).getConnection();
+        try (PreparedStatement pst = conn.prepareStatement(query)) {
             pst.setString(1, eventId);
             pst.setLong(2, userId);
             int executeUpdate = pst.executeUpdate();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -322,8 +322,6 @@ public class PgEventBookings implements EventBookings {
     /**
      * Acquire a globally unique lock on an event for the duration of a transaction.
      *
-     * This lock will interact as expected with acquireDistributedLock for the same resource ID.
-     *
      * @param transaction - the database transaction to acquire the lock in.
      * @param resourceId - the ID of the event to be locked.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -341,6 +341,7 @@ public class PgEventBookings implements EventBookings {
         try (PreparedStatement pst = conn.prepareStatement("SELECT pg_advisory_xact_lock(?)")) {
             pst.setLong(1, crc.getValue());
             log.debug(String.format("Attempting to acquire advisory transaction lock on %s (%s)", TABLE_NAME + resourceId, crc.getValue()));
+            pst.executeQuery();
         } catch (SQLException e) {
             String msg = String.format("Unable to acquire lock for event (%s).", resourceId);
             log.error(msg);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -369,7 +369,7 @@ public class PgEventBookings implements EventBookings {
         Connection conn = ((PgTransaction) transaction).getConnection();
         try (PreparedStatement pst = conn.prepareStatement("SELECT pg_advisory_xact_lock(?)")) {
             pst.setLong(1, crc.getValue());
-            log.debug(String.format("Acquiring advisory transaction lock on %s (%s)", TABLE_NAME + resourceId, crc.getValue()));
+            log.debug(String.format("Attempting to acquire advisory transaction lock on %s (%s)", TABLE_NAME + resourceId, crc.getValue()));
         } catch (SQLException e) {
             String msg = String.format("Unable to acquire lock for event (%s).", resourceId);
             log.error(msg);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/PgTransactionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/PgTransactionManager.java
@@ -10,10 +10,10 @@ import uk.ac.cam.cl.dtg.isaac.dos.PgTransaction;
  */
 public class PgTransactionManager implements ITransactionManager {
 
-    private PostgresSqlDb postgresSqlDb;
+    private final PostgresSqlDb postgresSqlDb;
 
     @Inject
-    public PgTransactionManager(PostgresSqlDb postgresSqlDb) {
+    public PgTransactionManager(final PostgresSqlDb postgresSqlDb) {
         this.postgresSqlDb = postgresSqlDb;
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
@@ -872,12 +872,13 @@ public class EventBookingManagerTest {
                 .updateBookingStatus(eq(testCase.event.getId()), eq(testCase.student2.getId()), eq(testCase.teacher.getId()), eq(BookingStatus.RESERVED), anyObject()))
                 .andReturn(testCase.student2Booking).once();
 
-        dummyTransaction.commit();
-        expectLastCall().once();
-
         dummyEventBookingPersistenceManager.releaseDistributedLock(testCase.event.getId());
         expectLastCall().once();
 
+        dummyTransaction.commit();
+        expectLastCall().once();
+        dummyTransaction.close();
+        expectLastCall().once();
 
         // Send Emails
         expect(dummyEmailManager.getEmailTemplateDTO(("email-event-reservation-requested"))).andReturn(testCase.reservationEmail).atLeastOnce();
@@ -1016,10 +1017,12 @@ public class EventBookingManagerTest {
                 .createBooking(eq(testCase.event.getId()), eq(testCase.student1.getId()), eq(testCase.teacher.getId()), eq(BookingStatus.RESERVED), anyObject()))
                 .andReturn(testCase.student1Booking).once();
 
-        dummyTransaction.commit();
+        dummyEventBookingPersistenceManager.releaseDistributedLock(testCase.event.getId());
         expectLastCall().once();
 
-        dummyEventBookingPersistenceManager.releaseDistributedLock(testCase.event.getId());
+        dummyTransaction.commit();
+        expectLastCall().once();
+        dummyTransaction.close();
         expectLastCall().once();
 
         // Send Emails

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
@@ -848,7 +848,7 @@ public class EventBookingManagerTest {
         }};
 
         // Define expected external calls
-        dummyEventBookingPersistenceManager.acquireDistributedLock(testCase.event.getId());
+        dummyEventBookingPersistenceManager.lockEventUntilTransactionComplete(dummyTransaction, testCase.event.getId());
         expectLastCall().once();
 
         // Check existing bookings
@@ -871,9 +871,6 @@ public class EventBookingManagerTest {
         expect(dummyEventBookingPersistenceManager
                 .updateBookingStatus(eq(testCase.event.getId()), eq(testCase.student2.getId()), eq(testCase.teacher.getId()), eq(BookingStatus.RESERVED), anyObject()))
                 .andReturn(testCase.student2Booking).once();
-
-        dummyEventBookingPersistenceManager.releaseDistributedLock(testCase.event.getId());
-        expectLastCall().once();
 
         dummyTransaction.commit();
         expectLastCall().once();
@@ -916,15 +913,15 @@ public class EventBookingManagerTest {
         List<RegisteredUserDTO> studentsToReserve = ImmutableList.of(testCase.student1, testCase.student2);
 
         // Define expected external calls
-        dummyEventBookingPersistenceManager.acquireDistributedLock(testCase.event.getId());
+        expect(dummyTransactionManager.getTransaction()).andReturn(dummyTransaction).once();
+        dummyEventBookingPersistenceManager.lockEventUntilTransactionComplete(dummyTransaction, testCase.event.getId());
         expectLastCall().atLeastOnce();
 
         expect(dummyEventBookingPersistenceManager.getEventBookingStatusCounts(testCase.event.getId(), false))
                 .andReturn(Maps.newHashMap()).once();
-        dummyEventBookingPersistenceManager.releaseDistributedLock(testCase.event.getId());
-        expectLastCall().atLeastOnce();
 
         replay(dummyEventBookingPersistenceManager);
+        replay(dummyTransactionManager);
         try {
             eventBookingManager.requestReservations(testCase.event, studentsToReserve, testCase.teacher);
             fail("Expected to fail from trying to reserve 2 students onto an event with only one space.");
@@ -955,7 +952,8 @@ public class EventBookingManagerTest {
         }};
 
         // Define expected external calls
-        dummyEventBookingPersistenceManager.acquireDistributedLock(testCase.event.getId());
+        expect(dummyTransactionManager.getTransaction()).andReturn(dummyTransaction).once();
+        dummyEventBookingPersistenceManager.lockEventUntilTransactionComplete(dummyTransaction, testCase.event.getId());
         expectLastCall().atLeastOnce();
         expect(dummyEventBookingPersistenceManager
                 .getEventBookingStatusCounts(testCase.event.getId(), false))
@@ -963,10 +961,9 @@ public class EventBookingManagerTest {
         expect(dummyEventBookingPersistenceManager
                 .getBookingsByEventId(testCase.event.getId()))
                 .andReturn(ImmutableList.of(existingEventBooking));
-        dummyEventBookingPersistenceManager.releaseDistributedLock(testCase.event.getId());
-        expectLastCall().atLeastOnce();
 
         replay(dummyEventBookingPersistenceManager);
+        replay(dummyTransactionManager);
         try {
             eventBookingManager.requestReservations(testCase.event, studentsToReserve, testCase.teacher);
             fail("Expected to fail from trying to reserve 2 students onto an event with only one space.");
@@ -997,7 +994,7 @@ public class EventBookingManagerTest {
         previousBookingCounts.put(BookingStatus.CANCELLED, ImmutableMap.of(Role.STUDENT, 1L));
 
         // Define expected external calls
-        dummyEventBookingPersistenceManager.acquireDistributedLock(testCase.event.getId());
+        dummyEventBookingPersistenceManager.lockEventUntilTransactionComplete(dummyTransaction, testCase.event.getId());
         expectLastCall().once();
 
         // Check existing bookings
@@ -1016,9 +1013,6 @@ public class EventBookingManagerTest {
         expect(dummyEventBookingPersistenceManager
                 .createBooking(eq(testCase.event.getId()), eq(testCase.student1.getId()), eq(testCase.teacher.getId()), eq(BookingStatus.RESERVED), anyObject()))
                 .andReturn(testCase.student1Booking).once();
-
-        dummyEventBookingPersistenceManager.releaseDistributedLock(testCase.event.getId());
-        expectLastCall().once();
 
         dummyTransaction.commit();
         expectLastCall().once();

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
@@ -131,7 +131,7 @@ public class EventBookingManagerTest {
         dummyTransaction.close();
         expectLastCall().once();
 
-        expect(dummyEventBookingPersistenceManager.createBooking(testEvent.getId(), someUser.getId(), BookingStatus
+        expect(dummyEventBookingPersistenceManager.createBooking(dummyTransaction, testEvent.getId(), someUser.getId(), BookingStatus
 				.CONFIRMED, someAdditionalInformation)).andReturn(firstBooking).atLeastOnce();
 
         expect(dummyEmailManager.getEmailTemplateDTO("email-event-booking-confirmed")).andReturn(new EmailTemplateDTO()).atLeastOnce();
@@ -379,7 +379,7 @@ public class EventBookingManagerTest {
         dummyTransaction.close();
         expectLastCall().once();
 
-        expect(dummyEventBookingPersistenceManager.createBooking(testEvent.getId(), someUser.getId(),
+        expect(dummyEventBookingPersistenceManager.createBooking(dummyTransaction, testEvent.getId(), someUser.getId(),
                 BookingStatus.CONFIRMED, someAdditionalInformation)).andReturn(secondBooking).atLeastOnce();
 
         expect(dummyEmailManager.getEmailTemplateDTO("email-event-booking-confirmed")).andReturn(new EmailTemplateDTO()).atLeastOnce();
@@ -445,7 +445,7 @@ public class EventBookingManagerTest {
         dummyTransaction.close();
         expectLastCall().once();
 
-        expect(dummyEventBookingPersistenceManager.createBooking(testEvent.getId(), firstUserFull.getId(),
+        expect(dummyEventBookingPersistenceManager.createBooking(dummyTransaction, testEvent.getId(), firstUserFull.getId(),
 				BookingStatus.CONFIRMED, someAdditionalInformation)).andReturn(secondBooking).atLeastOnce();
 
         dummyEmailManager.sendTemplatedEmailToUser(anyObject(), anyObject(), anyObject(), anyObject(), anyObject());
@@ -880,7 +880,7 @@ public class EventBookingManagerTest {
                 .getBookingByEventIdAndUserId(testCase.event.getId(), testCase.student1.getId()))
                 .andReturn(null).once();
         expect(dummyEventBookingPersistenceManager
-                .createBooking(eq(testCase.event.getId()), eq(testCase.student1.getId()), eq(testCase.teacher.getId()), eq(BookingStatus.RESERVED), anyObject()))
+                .createBooking(eq(dummyTransaction), eq(testCase.event.getId()), eq(testCase.student1.getId()), eq(testCase.teacher.getId()), eq(BookingStatus.RESERVED), anyObject()))
                 .andReturn(testCase.student1Booking).once();
 
         expect(dummyEventBookingPersistenceManager
@@ -1030,7 +1030,7 @@ public class EventBookingManagerTest {
                 .getBookingByEventIdAndUserId(testCase.event.getId(), testCase.student1.getId()))
                 .andReturn(null).once();
         expect(dummyEventBookingPersistenceManager
-                .createBooking(eq(testCase.event.getId()), eq(testCase.student1.getId()), eq(testCase.teacher.getId()), eq(BookingStatus.RESERVED), anyObject()))
+                .createBooking(eq(dummyTransaction), eq(testCase.event.getId()), eq(testCase.student1.getId()), eq(testCase.teacher.getId()), eq(BookingStatus.RESERVED), anyObject()))
                 .andReturn(testCase.student1Booking).once();
 
         dummyTransaction.commit();


### PR DESCRIPTION
This PR moves to using transaction-based locking for event bookings, and requires all state-changing booking actions to use transactions.


Make sure to [review ignoring whitespace changes](https://github.com/isaacphysics/isaac-api/pull/439/files?w=1).


---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped