### PR TITLE
Initialise Isaac on Jetty start not first HTTP request

### DIFF
--- a/override-api-web.xml
+++ b/override-api-web.xml
@@ -34,6 +34,7 @@
             <param-name>resteasy.servlet.mapping.prefix</param-name>
             <param-value>/api</param-value>
         </init-param>
+        <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet-mapping>
         <servlet-name>Isaac</servlet-name>


### PR DESCRIPTION
Turns out that it had always been this simple and for years we could have fixed this issue with so little effort :upside_down_face:

This change means that the Isaac Application initialises its classes on Jetty startup and does not wait for the first matching HTTP request to do so. This means the API will (finally) start by itself without needing to be poked or prompted.