### PR TITLE
Replace outdated JSch for etl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+            <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
             <version>5.13.0.202109080827-r</version>
         </dependency>
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/database/ETLInMemorySshConfigStore.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/database/ETLInMemorySshConfigStore.java
@@ -1,0 +1,77 @@
+package uk.ac.cam.cl.dtg.segue.database;
+
+import org.eclipse.jgit.transport.SshConfigStore;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+public class ETLInMemorySshConfigStore implements SshConfigStore {
+
+    private final InMemoryHostConfig inMemoryHostConfig;
+
+    /**
+     * @param config - A Map of config keys to config values (of the sort ordinarily found in ~/.ssh/config),
+     *               which will apply to all sessions using this store regardless of the target host, port or user.
+     */
+    public ETLInMemorySshConfigStore(final Map<String, List<String>> config) {
+        inMemoryHostConfig = new InMemoryHostConfig(config);
+    }
+
+    /**
+     * @param hostName - ignored, as we will use the same configuration regardless.
+     * @param port - ignored, as we will use the same configuration regardless.
+     * @param userName - ignored, as we will use the same configuration regardless.
+     * @return A new InMemoryHostConfig holding the provided configuration options.
+     */
+    @Override
+    public HostConfig lookup(final String hostName, final int port, final String userName) {
+        return inMemoryHostConfig;
+    }
+
+    /**
+     * A HostConfig that ignores config options on disk, instead using those passed in via the constructor.
+     */
+    public static class InMemoryHostConfig implements HostConfig {
+
+        private final Map<String, List<String>> config;
+
+        /**
+         * @param config - A Map of config keys to config values (of the sort ordinarily found in ~/.ssh/config).
+         */
+        public InMemoryHostConfig(final Map<String, List<String>> config) {
+            this.config = config;
+        }
+
+        @Override
+        public String getValue(final String key) {
+            List<String> value = config.get(key);
+            if (null == value || value.size() == 0) {
+                return  null;
+            }
+            return value.get(0);
+        }
+
+        @Override
+        public List<String> getValues(final String key) {
+            return config.get(key);
+        }
+
+        @Override
+        public Map<String, String> getOptions() {
+            return config.entrySet()
+                    .stream()
+                    .filter(e -> null != e.getValue() && e.getValue().size() == 1)
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get(0)));
+        }
+
+        @Override
+        public Map<String, List<String>> getMultiValuedOptions() {
+            return config.entrySet()
+                    .stream()
+                    .filter(e -> null != e.getValue() && e.getValue().size() > 1)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ETLInMemorySshConfigStore.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ETLInMemorySshConfigStore.java
@@ -1,4 +1,4 @@
-package uk.ac.cam.cl.dtg.segue.database;
+package uk.ac.cam.cl.dtg.segue.etl;
 
 import org.eclipse.jgit.transport.SshConfigStore;
 


### PR DESCRIPTION
JSch doesn't like ECDSA keys so we are replacing it with something that does like them.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
