### PR TITLE
Better Caching Headers

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -521,7 +521,7 @@ public class IsaacController extends AbstractIsaacFacade {
                 this.getLogManager().logEvent(user, request, IsaacServerLogType.VIEW_USER_PROGRESS,
                         ImmutableMap.of(USER_ID_FKEY_FIELDNAME, userOfInterestFull.getId()));
 
-                return Response.ok(userProgressInformation).build();
+                return Response.ok(userProgressInformation).cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
             } else {
                 return new SegueErrorResponse(Status.FORBIDDEN, "You do not have permission to view this users data.")
                         .toResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
@@ -168,6 +168,8 @@ public abstract class AbstractSegueFacade {
         // assume if null or false that the data is private
         if (isPublicData != null && isPublicData) {
             cc.getCacheExtension().put("public", "");
+        } else {
+            cc.setPrivate(true);
         }
         
         return cc;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -1279,7 +1279,7 @@ public class AdminFacade extends AbstractSegueFacade {
     /**
      *  Manually trigger a sync for testing or debugging purposes. Minimal success or failure reporting.
      */
-    @GET
+    @POST
     @Path("/sync_external_accounts")
     @ApiOperation(value = "Trigger an update for external providers where account details have changed.")
     public Response syncExternalAccounts(@Context final HttpServletRequest httpServletRequest) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -988,7 +988,8 @@ public class AdminFacade extends AbstractSegueFacade {
             log.info(String.format("%s user (%s) did a user id lookup based on user id {%s}", currentUser.getRole(),
                     currentUser.getEmail(), userId));
 
-            return Response.ok(this.userManager.getUserDTOById(userId)).build();
+            return Response.ok(this.userManager.getUserDTOById(userId))
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (SegueDatabaseException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
                     "Database error while looking up user information.").toResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
@@ -147,11 +147,15 @@ public class AuthenticationFacade extends AbstractSegueFacade {
                         .toResponse();
             }
 
+            RegisteredUserDTO userToLookup;
             if (currentRegisteredUser.getId().equals(userId)) {
-                return Response.ok(this.userManager.getUsersAuthenticationSettings(currentRegisteredUser)).build();
+                userToLookup = currentRegisteredUser;
             } else {
-                return Response.ok(this.userManager.getUsersAuthenticationSettings(this.userManager.getUserDTOById(userId))).build();
+                userToLookup = this.userManager.getUserDTOById(userId);
             }
+
+            return Response.ok(this.userManager.getUsersAuthenticationSettings(userToLookup))
+                    .cacheControl(getCacheControl(Constants.NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (SegueDatabaseException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
@@ -43,10 +43,7 @@ import javax.ws.rs.core.Response.Status;
 import java.util.Collections;
 import java.util.List;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.BooleanOperator;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.DEFAULT_RESULTS_LIMIT;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * Glossary Facade
@@ -121,7 +118,7 @@ public class GlossaryFacade extends AbstractSegueFacade {
         // Calculate the ETag on last modified date of tags list
         // NOTE: Assumes that the latest version of the content is being used.
         EntityTag etag = new EntityTag(this.contentManager.getCurrentContentSHA().hashCode() + "");
-        return Response.ok(c).tag(etag).build();
+        return Response.ok(c).tag(etag).cacheControl(getCacheControl(NUMBER_SECONDS_IN_TEN_MINUTES, true)).build();
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
@@ -219,7 +219,7 @@ public class GroupsFacade extends AbstractSegueFacade {
                 results.add(map);
             }
 
-            return Response.ok(results).build();
+            return Response.ok(results).cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (SegueDatabaseException e) {
@@ -770,7 +770,7 @@ public class GroupsFacade extends AbstractSegueFacade {
                 s.setUser(associationManager.enforceAuthorisationPrivacy(currentUser, s.getUser()));
             }
 
-            return Response.ok(groupProgressSummary).build();
+            return Response.ok(groupProgressSummary).cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (SegueDatabaseException e) {
             log.error("Database error while trying to get group progress for a group. ", e);
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Database error", e).toResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
@@ -71,9 +71,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.HOST_NAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.SegueServerLogType;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager.extractPageIdFromQuestionId;
 
 /**
@@ -214,7 +212,8 @@ public class QuestionFacade extends AbstractSegueFacade {
                 fromDateObject = userOfInterest.getRegistrationDate();
             }
 
-            return Response.ok(this.questionManager.getUsersQuestionAttemptCountsByDate(userOfInterest, fromDateObject, new Date(toDate), perDay)).build();
+            return Response.ok(this.questionManager.getUsersQuestionAttemptCountsByDate(userOfInterest, fromDateObject, new Date(toDate), perDay))
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (NoUserException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -521,7 +521,8 @@ public class UsersFacade extends AbstractSegueFacade {
         try {
             RegisteredUserDTO user = this.userManager.getCurrentRegisteredUser(request);
 
-            return Response.ok(this.userManager.getNewSharedSecret(user)).build();
+            return Response.ok(this.userManager.getNewSharedSecret(user))
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
 
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
@@ -542,7 +543,8 @@ public class UsersFacade extends AbstractSegueFacade {
         try {
             RegisteredUserDTO user = this.userManager.getCurrentRegisteredUser(request);
 
-            return Response.ok(ImmutableMap.of("mfaStatus", this.userManager.has2FAConfigured(user))).build();
+            return Response.ok(ImmutableMap.of("mfaStatus", this.userManager.has2FAConfigured(user)))
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (SegueDatabaseException e) {


### PR DESCRIPTION
If a response is explicitly marked as not-public, or has a cache header added but is not designated public; mark it as private. This should help cases where man-in-the-middle monitoring software acts as a HTTP cache and introduces security issues.

Technically this change may prevent the altered endpoints that may otherwise have been cached from being cached (due to
the max-age=0 bit), but this is fine for these cases.