### PR TITLE
Clone IsaacEventPageDTO objects to avoid cache poisoning

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -1721,12 +1721,10 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             try {
                 RegisteredUserDTO user = userManager.getCurrentRegisteredUser(request);
-                page.setUserBooked(this.bookingManager.isUserBooked(page.getId(), user.getId()));
-                page.setUserOnWaitList(this.bookingManager.hasBookingWithStatus(page.getId(), user.getId(), BookingStatus.WAITING_LIST));
                 page.setUserBookingStatus(this.bookingManager.getBookingStatus(page.getId(), user.getId()));
             } catch (NoUserLoggedInException e) {
                 // no action as we don't require the user to be logged in.
-                page.setUserBooked(null);
+                page.setUserBookingStatus(null);
             }
 
             page.setPlacesAvailable(this.bookingManager.getPlacesAvailable(page));

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -1681,7 +1681,10 @@ public class EventsFacade extends AbstractIsaacFacade {
         }
 
         if (possibleEvent instanceof IsaacEventPageDTO) {
-            return (IsaacEventPageDTO) possibleEvent;
+            // The Events Facade *mutates* the EventDTO returned by this method; we must return a copy of
+            // the original object else we will poison the contentManager's cache!
+            // TODO: might it be better to get the DO from the cache and map it to DTO here to reduce overhead?
+            return mapper.map(possibleEvent, IsaacEventPageDTO.class);
         }
         return null;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -65,8 +65,6 @@ public class IsaacEventPageDTO extends ContentDTO {
 
     private String isaacGroupToken;
 
-    private Boolean isUserBooked;
-    private Boolean isUserOnWaitList;
     private BookingStatus userBookingStatus;
 
     private Long placesAvailable;
@@ -436,22 +434,6 @@ public class IsaacEventPageDTO extends ContentDTO {
     }
 
 	/**
-     * Gets whether the currently logged in user is booked onto this event or not.
-     * @return true is yes, false is no, null is not logged in
-     */
-    public Boolean isUserBooked() {
-        return isUserBooked;
-    }
-
-	/**
-     * Sets whether or not the current user is booked on an event.
-     * @param loggedInUserBooked - true is yes, false is no, null is not logged in
-     */
-    public void setUserBooked(final Boolean loggedInUserBooked) {
-        isUserBooked = loggedInUserBooked;
-    }
-
-	/**
 	 * getPlacesAvailable based on current bookings..
      * @return the get the places available.
      */
@@ -465,14 +447,6 @@ public class IsaacEventPageDTO extends ContentDTO {
      */
     public void setPlacesAvailable(final Long placesAvailable) {
         this.placesAvailable = placesAvailable;
-    }
-
-    public Boolean isUserOnWaitList() {
-        return isUserOnWaitList;
-    }
-
-    public void setUserOnWaitList(Boolean userOnWaitList) {
-        isUserOnWaitList = userOnWaitList;
     }
 
     /**


### PR DESCRIPTION
We mutate the object returned from this method to add booking information; but since all that is returned is a reference to the DTO in the ContentManager cache, we thus mutate the cached object too! When we the use this cached object for subsequent requests, we risk returning outdated data.
Instead, use the mapper to deep-copy the DTO.
