### PR TITLE
Fix HTML validation for email parameter replacement

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -118,15 +118,14 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
     }
 
     /**
-     * Escape any HTML present in the email before sending
+     * Escape any HTML present in the email before sending.
      *
      * @param emailParameters - the parameters to be inserted into the email
      */
     public static void sanitizeEmailParameters(final Map<Object, Object> emailParameters) {
-        List<String> allowedHtmlKeys = ImmutableList.of("assignmentsInfo", "studentsList");
         for (Map.Entry<Object, Object> entry : emailParameters.entrySet()) {
             String key = entry.getKey().toString();
-            if (!(key.startsWith("event.") || key.endsWith("URL") || allowedHtmlKeys.contains(key))) {
+            if (!(key.startsWith("event.") || key.endsWith("URL") || key.endsWith("_HTML"))) {
                 emailParameters.put(entry.getKey(), StringEscapeUtils.escapeHtml4(entry.getValue().toString()));
             }
         }


### PR DESCRIPTION
We don't use the original key names, we use a special suffix "_HTML" for parameters with both an HTML and plain text version. I missed this when I changed this method because I didn't test it thoroughly enough!