### PR TITLE
Make the PgEventBooking a POJO and remove update logic

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -3,15 +3,12 @@ package uk.ac.cam.cl.dtg.isaac.dao;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.util.Lists;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
-import ma.glasnost.orika.MapperFacade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
 import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.BookingStatus;
 import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.EventBooking;
 import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.EventBookings;
-import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.PgEventBooking;
 import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.PgEventBookings;
 import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
@@ -30,8 +27,6 @@ import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * EventBookingPersistenceManager.
@@ -96,7 +91,7 @@ public class EventBookingPersistenceManager {
      *             - if an error occurs.
      */
     public EventBookingDTO getBookingById(final Long bookingId) throws SegueDatabaseException {
-        return this.convertToDTO(new PgEventBooking(database, bookingId));
+        return this.convertToDTO(dao.findBookingById(bookingId));
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBooking.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBooking.java
@@ -76,6 +76,4 @@ public interface EventBooking {
     Date getCreationDate();
 
     Map<String, String> getAdditionalInformation();
-
-    void setAdditionalInformation(Map<String, String> additionalInformation);
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -16,8 +16,8 @@
 package uk.ac.cam.cl.dtg.isaac.dos.eventbookings;
 
 import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -179,6 +179,15 @@ public interface EventBookings {
      *             - if an error occurs.
      */
     EventBooking findBookingByEventAndUser(String eventId, Long userId) throws SegueDatabaseException;
+
+    /**
+     * Find an event booking by id.
+     *
+     * @param bookingId - the event ID of interest.
+     * @return the booking or an error.
+     * @throws SegueDatabaseException - if an error occurs.
+     */
+    EventBooking findBookingById(Long bookingId) throws SegueDatabaseException;
 
     /**
      * Expunge the additional information field for all bookings for a given user id.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBooking.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBooking.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,57 +15,31 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dos.eventbookings;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import uk.ac.cam.cl.dtg.segue.dao.ResourceNotFoundException;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 
 /**
  * Postgres specific implementation for event booking.
  *
  */
 public class PgEventBooking implements EventBooking {
-    private PostgresSqlDb ds;
-
-    private Long bookingId;
-    private Long userId;
-    private Long reservedById;
-    private String eventId;
-    private BookingStatus bookingStatus;
-    private Date created;
-    private Date updated;
-    private Map<String, String> additionalInformation;
-
-    /**
-     * Partial Constructor - the remaining fields will be populated.
-     * 
-     * @param ds
-     *            - connection to the database.
-     * @param bookingId
-     *            - unique identifier for this booking
-     * @throws SegueDatabaseException
-     *             - if we cannot complete the operation.
-     */
-    public PgEventBooking(final PostgresSqlDb ds, final Long bookingId) throws SegueDatabaseException {
-        this.ds = ds;
-        this.bookingId = bookingId;
-        this.populateBookingDetails();
-    }
+    private final Long bookingId;
+    private final Long userId;
+    private final Long reservedById;
+    private final String eventId;
+    private final BookingStatus bookingStatus;
+    private final Date created;
+    private final Date updated;
+    private final Map<String, String> additionalInformation;
 
     /**
      * Full constructor will not populate the fields.
-     * 
-     * @param ds
-     *            - connection to the database.
+     *
      * @param bookingId
      *            - unique identifier for this booking
      * @param userId
@@ -75,9 +49,8 @@ public class PgEventBooking implements EventBooking {
      * @param created
      *            - the date the booking was made.
      */
-    public PgEventBooking(final PostgresSqlDb ds, final Long bookingId, final Long userId, final Long reservedById, final String eventId,
+    public PgEventBooking(final Long bookingId, final Long userId, final Long reservedById, final String eventId,
             final BookingStatus bookingStatus, final Date created, final Date updated, final Object additionalInformation) throws SegueDatabaseException {
-        this.ds = ds;
         this.bookingId = bookingId;
         this.userId = userId;
         this.reservedById = reservedById;
@@ -91,6 +64,8 @@ public class PgEventBooking implements EventBooking {
             } catch (IOException e) {
                 throw new SegueDatabaseException("Unable to convert object additionalInformation to Map.", e);
             }
+        } else {
+            this.additionalInformation = null;
         }
 
     }
@@ -131,84 +106,6 @@ public class PgEventBooking implements EventBooking {
     @Override
     public Map<String, String> getAdditionalInformation() {
         return additionalInformation;
-    }
-
-    @Override
-    public void setAdditionalInformation(Map<String, String> additionalInformation) {
-        this.additionalInformation = additionalInformation;
-    }
-
-    /**
-     * populateBookingDetails - will attempt to populate missing details.
-     * 
-     * @throws SegueDatabaseException
-     *             - if we cannot complete the operation.
-     */
-    private void populateBookingDetails() throws SegueDatabaseException {
-        if (isPopulated()) {
-            // do not augment.
-            return;
-        }
-
-        // FIXME: try-with-resources!
-        try (Connection conn = ds.getDatabaseConnection()) {
-            PreparedStatement pst;
-            if (bookingId != null) {
-                pst = conn.prepareStatement("SELECT * FROM event_bookings WHERE id = ?");
-                pst.setLong(1, bookingId);
-            } else if (userId != null && eventId != null) {
-                pst = conn.prepareStatement("SELECT * FROM event_bookings WHERE user_id = ? AND event_id = ?");
-                pst.setLong(1, userId);
-                pst.setString(2, eventId);
-            } else {
-                throw new IllegalArgumentException(
-                        "You must provide an object with either a userId and eventId or a booking id.");
-            }
-
-            ResultSet results = pst.executeQuery();
-            int count = 0;
-            while (results.next()) {
-                if (count > 1) {
-                    throw new IllegalArgumentException("More than one result detected.");
-                }
-                count++;
-
-                this.bookingId = results.getLong("id");
-                this.eventId = results.getString("event_id");
-                this.userId = results.getLong("user_id");
-                this.reservedById = results.getLong("reserved_by");
-                if (results.wasNull()) {
-                    this.reservedById = null;
-                }
-                this.bookingStatus = BookingStatus.valueOf(results.getString("booking_status"));
-                this.created = results.getDate("created");
-                this.updated = results.getDate("updated");
-
-                Map<String, String> additionalInfoObject = this.convertFromJsonbToMap(results.getObject("additionalEventInformation"));
-
-                this.additionalInformation = additionalInfoObject;
-            }
-
-            if (count == 0) {
-                throw new ResourceNotFoundException("Unable to locate the Event booking you requested");
-            }
-
-        } catch (SQLException | IOException e) {
-            throw new SegueDatabaseException("Unable to fully populate the Booking Details object.", e);
-        }
-    }
-
-    /**
-     * Check if the event booking has been populated.
-     * 
-     * @return true if the fields are not null, false if one or more are null.
-     */
-    private boolean isPopulated() {
-        if (bookingId != null && userId != null && eventId != null && created != null) {
-            // do not augment.
-            return true;
-        }
-        return false;
     }
 
     private Map<String, String> convertFromJsonbToMap(Object objectToConvert) throws IOException {


### PR DESCRIPTION
The object should just be a store of data, not something that holds a database connection and can update itself. This removes a (non-functional! the column names are all wrong!) method for the object to update itself, and adds instead a new manager method to get a booking by ID.
