### PR TITLE
Allow localhost:3001 to talk to the API

### DIFF
--- a/override-api-web.xml
+++ b/override-api-web.xml
@@ -11,7 +11,7 @@
         </init-param>
         <init-param>
             <param-name>allowedOrigins</param-name>
-            <param-value>(https://*.isaac(physics|computerscience).org|http://localhost:(800[01234]|8421))</param-value>
+            <param-value>(https://*.isaac(physics|computerscience).org|http://localhost:(800[01234]|8421|3001))</param-value>
         </init-param>
         <init-param>
             <param-name>exposedHeaders</param-name>


### PR DESCRIPTION
This is needed so that the renderer and API can talk locally (the renderer now needs to talk to an API since it needed to render glossary terms)