### PR TITLE
Add SCrypt as new default password hashing algorithm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.70</version>
+        </dependency>
+
         <!-- These two don't need to be included in the war package so their scope is "provided" which means we
              promise to make them available in the deployment environment, but we aren't going to because they are
              not needed at runtime anyway. -->

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2.java
@@ -30,6 +30,7 @@ import java.security.spec.InvalidKeySpecException;
  * This is a parent class for PBKDF2 algorithms.
  *
  */
+@Deprecated
 public class SeguePBKDF2 {
     private final String algorithm;
     private final Integer keyLength;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v3.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v3.java
@@ -19,6 +19,7 @@ package uk.ac.cam.cl.dtg.segue.auth;
  * Represents an instance of a hashing scheme used in Segue.
  *
  */
+@Deprecated
 public class SeguePBKDF2v3 extends SeguePBKDF2 implements ISegueHashingAlgorithm {
     private static final String CRYPTO_ALGORITHM = "PBKDF2WithHmacSHA512";
     private static final String SALTING_ALGORITHM = "SHA1PRNG";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueSCrypt.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueSCrypt.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.auth;
+
+import org.apache.commons.codec.binary.Base64;
+import org.bouncycastle.crypto.generators.SCrypt;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+/**
+ * Represents an instance of a hashing scheme used in Segue.
+ *
+ * This is a parent class for Scrypt versions.
+ *
+ */
+public class SegueSCrypt {
+    private final Integer iterations;
+    private final Integer blockSize;
+    private final Integer parallelismFactor;
+    private final Integer keyLength;
+    private final String saltingAlgorithm;
+    private final Integer saltSize;
+
+    public SegueSCrypt(final Integer iterations, final Integer blockSize, final Integer parallelismFactor,
+                       final Integer keyLength, final String saltingAlgorithm, final Integer saltSize) {
+        this.iterations = iterations;
+        this.blockSize = blockSize;
+        this.parallelismFactor = parallelismFactor;
+        this.keyLength = keyLength;
+        this.saltingAlgorithm = saltingAlgorithm;
+        this.saltSize = saltSize;
+    }
+
+    /**
+     * Hash the password using the preconfigured hashing function.
+     *
+     * @param password
+     *            - password to hash
+     * @param salt
+     *            - random string to use as a salt.
+     * @return the Base64 encoded hashed password
+     */
+    public String hashPassword(final String password, final String salt) {
+
+        byte[] hashedPassword = computeHash(password, salt, keyLength);
+        return new String(Base64.encodeBase64(hashedPassword));
+    }
+
+    /**
+     * Compute the hash of a string using the Scrypt hashing function.
+     *
+     * @param str
+     *            - string to hash
+     * @param salt
+     *            - random string to use as a salt.
+     * @param keyLength
+     *            - the desired output key length
+     * @return a byte array of the hash
+     */
+    public byte[] computeHash(final String str, final String salt, final int keyLength) {
+        byte[] strBytes = str.getBytes();
+        byte[] saltBytes = salt.getBytes();
+
+        return SCrypt.generate(strBytes, saltBytes, iterations, blockSize, parallelismFactor, keyLength);
+    }
+
+    /**
+     * Helper method to generate a base64 encoded salt.
+     *
+     * @return generate a base64 encoded secure salt.
+     * @throws NoSuchAlgorithmException
+     *             - problem locating the algorithm.
+     */
+    public String generateSalt() throws NoSuchAlgorithmException {
+        SecureRandom sr = SecureRandom.getInstance(saltingAlgorithm);
+
+        byte[] salt = new byte[saltSize];
+        sr.nextBytes(salt);
+
+        return new String(Base64.encodeBase64(salt));
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueSCryptv1.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueSCryptv1.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.auth;
+
+public class SegueSCryptv1 extends SegueSCrypt implements ISegueHashingAlgorithm {
+    private static final Integer ITERATIONS = 65536;
+    private static final Integer BLOCK_SIZE = 8;
+    private static final Integer PARALLELISM_FACTOR = 1;
+    private static final Integer KEY_LENGTH = 64;  // bytes
+    private static final String SALTING_ALGORITHM = "SHA1PRNG";
+    private static final int SALT_SIZE = 16;  // bytes
+
+    public SegueSCryptv1() {
+        super(ITERATIONS, BLOCK_SIZE, PARALLELISM_FACTOR, KEY_LENGTH, SALTING_ALGORITHM, SALT_SIZE);
+    }
+
+    @Override
+    public String hashingAlgorithmName() {
+        return "SegueSCryptv1";
+    }
+
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -80,6 +80,7 @@ import uk.ac.cam.cl.dtg.segue.auth.SegueLocalAuthenticator;
 import uk.ac.cam.cl.dtg.segue.auth.SeguePBKDF2v1;
 import uk.ac.cam.cl.dtg.segue.auth.SeguePBKDF2v2;
 import uk.ac.cam.cl.dtg.segue.auth.SeguePBKDF2v3;
+import uk.ac.cam.cl.dtg.segue.auth.SegueSCryptv1;
 import uk.ac.cam.cl.dtg.segue.auth.SegueTOTPAuthenticator;
 import uk.ac.cam.cl.dtg.segue.auth.TwitterAuthenticator;
 import uk.ac.cam.cl.dtg.segue.comm.EmailCommunicator;
@@ -543,14 +544,16 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Provides
     private static SegueLocalAuthenticator getSegueLocalAuthenticator(final IUserDataManager database, final IPasswordDataManager passwordDataManager,
                                                                       final PropertiesLoader properties) {
-        ISegueHashingAlgorithm preferredAlgorithm = new SeguePBKDF2v3();
+        ISegueHashingAlgorithm preferredAlgorithm = new SegueSCryptv1();
         ISegueHashingAlgorithm oldAlgorithm1 = new SeguePBKDF2v1();
         ISegueHashingAlgorithm oldAlgorithm2 = new SeguePBKDF2v2();
+        ISegueHashingAlgorithm oldAlgorithm3 = new SeguePBKDF2v3();
 
         Map<String, ISegueHashingAlgorithm> possibleAlgorithms = ImmutableMap.of(
-                        preferredAlgorithm.hashingAlgorithmName(), preferredAlgorithm,
-                        oldAlgorithm1.hashingAlgorithmName(), oldAlgorithm1,
-                        oldAlgorithm2.hashingAlgorithmName(), oldAlgorithm2
+                preferredAlgorithm.hashingAlgorithmName(), preferredAlgorithm,
+                oldAlgorithm1.hashingAlgorithmName(), oldAlgorithm1,
+                oldAlgorithm2.hashingAlgorithmName(), oldAlgorithm2,
+                oldAlgorithm3.hashingAlgorithmName(), oldAlgorithm3
         );
 
         return new SegueLocalAuthenticator(database, passwordDataManager, properties, possibleAlgorithms, preferredAlgorithm);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -18,6 +18,8 @@ package uk.ac.cam.cl.dtg.segue.auth;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
+import uk.ac.cam.cl.dtg.isaac.dos.users.LocalUserCredential;
+import uk.ac.cam.cl.dtg.isaac.dos.users.RegisteredUser;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.IncorrectCredentialsProvidedException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.InvalidPasswordException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoCredentialsAvailableException;
@@ -25,8 +27,6 @@ import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.users.IPasswordDataManager;
 import uk.ac.cam.cl.dtg.segue.dao.users.IUserDataManager;
-import uk.ac.cam.cl.dtg.isaac.dos.users.LocalUserCredential;
-import uk.ac.cam.cl.dtg.isaac.dos.users.RegisteredUser;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import java.security.NoSuchAlgorithmException;
@@ -45,24 +45,26 @@ import static org.junit.Assert.fail;
  * 
  */
 public class SegueLocalAuthenticatorTest {
-	
-	private IUserDataManager userDataManager;
-	private IPasswordDataManager passwordDataManager;
-	private PropertiesLoader propertiesLoader;
 
-	private ISegueHashingAlgorithm preferredAlgorithm = new SeguePBKDF2v3();
-	private ISegueHashingAlgorithm oldAlgorithm1 = new SeguePBKDF2v1();
+    private IUserDataManager userDataManager;
+    private IPasswordDataManager passwordDataManager;
+    private PropertiesLoader propertiesLoader;
+
+    private ISegueHashingAlgorithm preferredAlgorithm = new SegueSCryptv1();
+    private ISegueHashingAlgorithm oldAlgorithm1 = new SeguePBKDF2v1();
     private ISegueHashingAlgorithm oldAlgorithm2 = new SeguePBKDF2v2();
+    private ISegueHashingAlgorithm oldAlgorithm3 = new SeguePBKDF2v3();
 
     Map<String, ISegueHashingAlgorithm> possibleAlgorithms = ImmutableMap.of(
             preferredAlgorithm.hashingAlgorithmName(), preferredAlgorithm,
             oldAlgorithm1.hashingAlgorithmName(), oldAlgorithm1,
-            oldAlgorithm2.hashingAlgorithmName(), oldAlgorithm2
+            oldAlgorithm2.hashingAlgorithmName(), oldAlgorithm2,
+            oldAlgorithm3.hashingAlgorithmName(), oldAlgorithm3
     );
 
 	/**
 	 * Initial configuration of tests.
-	 * 
+	 *
 	 * @throws Exception
 	 *             - test exception
 	 */


### PR DESCRIPTION
Use the BouncyCastle library to provide the SCrypt algorithm, and choose strong (perhaps overly strong) parameters for it. I implemented it as a versioned subclass just in case we want to adjust the parameters after deployment and thus need a nice naming convention. The parameters do seem to be [those recommended by OWASP now](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#scrypt) however.

On isaac-1, the algorithm manages 2.4 H/s with N=65536 (i.e. 410-420ms), but would manage 4.8 H/s with a smaller N=32768 (i.e. 209ms) which was the recommended value from 2017.  The slow, stronger, choice in this commit is the same speed as the existing preferred `SeguePBKDF2v3` algorithm, so I suggest we deploy it and see that it behaves as expected in the wild.

I have tested the algorithm in our code and get a hash of:
```
Z/MIkioalvBS8L0L9AW+CSPcSWW4fOgxvY4MBA80HitFlVaOSocy+dHsHPhSLiwg8cDPx2n/PZ91ALu747wm/A==
```
for `password` with a salt of `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`. You can see from [GCHQ CyberChef that this is the expected SCrypt hash for these values](https://gchq.github.io/CyberChef/#recipe=Scrypt(%7B'option':'UTF8','string':'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'%7D,65536,8,1,64)From_Hex('Auto')To_Base64('A-Za-z0-9%2B/%3D')&input=cGFzc3dvcmQ) given the settings I use in `SegueSCryptv1` 🎉 

There are some whitespace issues (tabs vs spaces 🙃) confusing the PR, so it may be best reviewed ignoring whitespace.
