### PR TITLE
Improved question attempt loading

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -368,12 +368,13 @@ public class GameManager {
         Validate.notNull(user);
 
         List<GameboardDTO> usersGameboards = this.gameboardPersistenceManager.getGameboardsByUserId(user);
-        Map<String, Map<String, List<QuestionValidationResponse>>> questionAttemptsFromUser = questionManager
-                .getQuestionAttemptsByUser(user);
-
         if (null == usersGameboards || usersGameboards.isEmpty()) {
             return new GameboardListDTO();
         }
+
+        List<String> questionPageIds = usersGameboards.stream().map(GameboardDTO::getContents).flatMap(Collection::stream).map(GameboardItem::getId).collect(Collectors.toList());
+        Map<String, Map<String, List<LightweightQuestionValidationResponse>>> questionAttemptsFromUser =
+                questionManager.getMatchingQuestionAttempts(user, questionPageIds);
 
         List<GameboardDTO> resultToReturn = Lists.newArrayList();
 
@@ -735,7 +736,7 @@ public class GameManager {
      *             - if there is an error retrieving the content requested.
      */
     private GameboardDTO augmentGameboardWithQuestionAttemptInformation(final GameboardDTO gameboardDTO,
-                                                                        final Map<String, Map<String, List<QuestionValidationResponse>>> questionAttemptsFromUser)
+                                                                        final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>> questionAttemptsFromUser)
             throws ContentManagerException {
         if (null == gameboardDTO) {
             return null;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -410,6 +410,22 @@ public class QuestionManager {
         return this.questionAttemptPersistenceManager.getQuestionAttemptsByUsersAndQuestionPrefix(userIds,
                 questionPageIds);
     }
+
+    /**
+     *  Helper method for attempts from a single user.
+     *
+     * @see #getMatchingQuestionAttempts(List, List)
+     *
+     * @param user who we are interested in.
+     * @param questionPageIds we want to look up.
+     * @return a map of user id to question page id to question_id to list of attempts.
+     * @throws SegueDatabaseException if there is a database error.
+     */
+    public Map<String, Map<String, List<LightweightQuestionValidationResponse>>> getMatchingQuestionAttempts(
+            final RegisteredUserDTO user, final List<String> questionPageIds) throws SegueDatabaseException {
+
+        return this.getMatchingQuestionAttempts(Collections.singletonList(user), questionPageIds).get(user.getId());
+    }
     
     /**
      * mergeAnonymousQuestionAttemptsIntoRegisteredUser.


### PR DESCRIPTION
This produces long horrific-to-read queries, but it is at least 10x faster for all the cases I have tested, even pathological cases. The repeated OR clauses allow the database to perform much better index scans and avoid the need to filter results matching every question part ID against a (very large) regex.

I have tested it with 800 question IDs in the list (the most any group on the live site currently has), and there it is much (20 times) faster than the 12kb(!) regular expression generated with the old code.

This method was already used for assignment progress, so those (and CSV files) should see immediate major gains. In this PR I also use the improved method for My Gameboards, since it was also straightforward to use it there. It has an even larger impact there since the old method also used to deserialise all of the JSON from every attempt unnecessarily, which added another major overhead.

---

There are several other places that would benefit from using `getMatchingQuestionAttempts` instead of `getQuestionAttemptsByUser`, but cannot (easily) due to the way the code is written:
 - My Assignments:
    -  Here we don't have the gameboards or their contents until we call `getGameboards(gameboardIds, questionAttemptsByUser)`, but we need the question attempts before we can call this method. We can't use the `getGameboards(gameboardIds)` method and then augment because the augment method is private and I am unsure why so don't yet want to change it.
 - Related content for questions, concepts and topic summaries:
    - Here we don't necessarily have a `RegisteredUserDTO`, but have an `AbstractSegueUserDTO` for which we cannot call `getMatchingQuestionAttempts` because it is not meaningful for anonymous users. We could rewrite the call to have two cases for the anon and registered, and this would be nice, but `augmentContentWithRelatedContent` expects `Map<String, Map<String, List<QuestionValidationResponse>>>` and the Lightweight version is a different type. We can allow both, since the full ones extend the lightweight ones, but then the type is `Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>>` and has to be changed in many places.
    - Yet another complication is that we don't have the content object to find the list of related content IDs until after the call to `findSingleResult(fieldsToMatch, userQuestionAttempts)` but this again requires the question attempts in advance . . .

 ---

The intent of this PR is to avoid the need for a new column in the database `page_id` and a new index on that. Having tested it on the analysis database, this method is ~2x slower than adding the new index, but the difference between a 10x speedup and 20x speedup is much less than a second and not worth the hassle of adding the new index when this PR will make some queries that took ~15s take under 1s anyhow.