### PR TITLE
Migrate API to java 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: temurin
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -12,7 +12,9 @@ COPY --from=target /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-
 RUN chmod 755 /var/lib/jetty/webapps/*
 RUN chown jetty /var/lib/jetty/webapps/*
 
-#RUN sed -i -e 's#dev/random#dev/./urandom#g' $JAVA_HOME/jre/lib/security/java.security
+# The Jetty Docker image provides a version of JavaMail incompatible with JDK11,
+# remove the bundled version:
+RUN rm -r /usr/local/jetty/lib/mail
 
 # prepare things so that jetty runs in the docker entrypoint
 USER jetty

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -6,7 +6,7 @@ COPY . /isaac-api
 RUN mvn package -Dmaven.test.skip=true
 
 # create clean jetty docker container
-FROM jetty:9.4.48-jre8-openjdk as server
+FROM jetty:9.4.48-jdk11-eclipse-temurin as server
 USER root
 COPY --from=target /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-api.war
 RUN chmod 755 /var/lib/jetty/webapps/*

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,5 +1,5 @@
 # Step : Download dependencies so that they are cached in the docker layer if the pom file doesn't change
-FROM maven:3.8.1-openjdk-8 as target
+FROM maven:3.8.6-eclipse-temurin-11 as target
 WORKDIR /isaac-api
 COPY pom.xml .
 RUN mvn dependency:go-offline

--- a/Dockerfile-etl
+++ b/Dockerfile-etl
@@ -12,7 +12,9 @@ COPY --from=target /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-
 RUN chmod 755 /var/lib/jetty/webapps/*
 RUN chown jetty /var/lib/jetty/webapps/*
 
-#RUN sed -i -e 's#dev/random#dev/./urandom#g' $JAVA_HOME/jre/lib/security/java.security
+# The Jetty Docker image provides a version of JavaMail incompatible with JDK11,
+# remove the bundled version:
+RUN rm -r /usr/local/jetty/lib/mail
 
 # prepare things so that jetty runs in the docker entrypoint
 USER jetty

--- a/Dockerfile-etl
+++ b/Dockerfile-etl
@@ -6,7 +6,7 @@ COPY . /isaac-api
 RUN mvn package -Dmaven.test.skip=true -P etl
 
 # create clean jetty docker container
-FROM jetty:9.4.48-jre8-openjdk as server
+FROM jetty:9.4.48-jdk11-eclipse-temurin as server
 USER root
 COPY --from=target /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-api.war
 RUN chmod 755 /var/lib/jetty/webapps/*

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,17 @@
         </dependency>
 
         <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
+            <version>1.6.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>3.26.0-GA</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,17 +49,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>javax.activation</artifactId>
-            <version>1.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.6.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>3.26.0-GA</version>


### PR DESCRIPTION
**Pull Request Check List**
- ~~Unit Tests & Regression Tests Added (Optional)~~
- ~~Removed Unnecessary Logs/System.Outs/Comments/TODOs~~
- ~~Added enough Logging to monitor expected behaviour change~~
- ~~Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped~~
- ~~Security - Data Exposure - PII is not stored or sent unencrypted~~
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- ~~Security - Access Control - Check authorisation on every new endpoint~~
- ~~Security - New dependency - configured sensibly not relying on defaults~~
- ~~Security - New dependency - Searched for any know vulnerabilities~~
- ~~Security - New dependency - Signed up team to mailing list~~
- ~~Security - New dependency - Added to dependency list~~
- ~~DB schema changes - postgres-rutherford-create-script updated~~
- ~~DB schema changes - upgrade script created matching create script~~
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
