### PR TITLE
Add exclusion filter for deprecated content to board generation query

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -998,7 +998,7 @@ public class GameManager {
      * @throws ContentManagerException
      *             - if there is a problem accessing the content repository.
      */
-    private List<GameboardItem> getNextQuestionsForFilter(final GameFilter gameFilter, final int index,
+    public List<GameboardItem> getNextQuestionsForFilter(final GameFilter gameFilter, final int index,
             final Long randomSeed) throws ContentManagerException {
         // get some questions
         List<GitContentManager.BooleanSearchClause> fieldsToMap = Lists.newArrayList();
@@ -1315,9 +1315,13 @@ public class GameManager {
         }
 
         // handle exclusions
-        List<String> tagsToExclude = Lists.newArrayList();
-        tagsToExclude.add(HIDE_FROM_FILTER_TAG); // add no filter constraint
-        fieldsToMatch.add(new GitContentManager.BooleanSearchClause(TAGS_FIELDNAME, BooleanOperator.NOT, tagsToExclude));
+        // exclude questions with no-filter tag
+        fieldsToMatch.add(new GitContentManager.BooleanSearchClause(TAGS_FIELDNAME, BooleanOperator.NOT,
+                Collections.singletonList(HIDE_FROM_FILTER_TAG)));
+
+        // exclude questions marked deprecated
+        fieldsToMatch.add(new GitContentManager.BooleanSearchClause(DEPRECATED_FIELDNAME, BooleanOperator.NOT,
+                Collections.singletonList("true")));
 
         return fieldsToMatch;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -424,6 +424,7 @@ public final class Constants {
     public static final String SEARCHABLE_CONTENT_FIELDNAME = "searchableContent";
     public static final String VISIBLE_TO_STUDENTS_FIELDNAME = "visibleToStudents";
     public static final String HIDDEN_FROM_ROLES_FIELDNAME = "hiddenFromRoles";
+    public static final String DEPRECATED_FIELDNAME = "deprecated";
 
     public static final String STAGE_FIELDNAME = "audience.stage";
     public static final String DIFFICULTY_FIELDNAME = "audience.difficulty";

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManagerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 Matthew Trew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.cl.dtg.isaac.api.managers;
+
+import ma.glasnost.orika.MapperFacade;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import uk.ac.cam.cl.dtg.isaac.dao.GameboardPersistenceManager;
+import uk.ac.cam.cl.dtg.isaac.dto.GameFilter;
+import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
+import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager.BooleanSearchClause;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.powermock.api.easymock.PowerMock.replay;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(GitContentManager.class)
+@PowerMockIgnore("javax.management.*")
+public class GameManagerTest {
+
+    private GitContentManager dummyContentManager;
+    private GameboardPersistenceManager dummyGameboardPersistenceManager;
+    private MapperFacade dummyMapper;
+    private QuestionManager dummyQuestionManager;
+
+    @Before
+    public void setUp() {
+        this.dummyContentManager = PowerMock.createMock(GitContentManager.class);
+        this.dummyGameboardPersistenceManager = PowerMock.createMock(GameboardPersistenceManager.class);
+        this.dummyMapper = PowerMock.createMock(MapperFacade.class);
+        this.dummyQuestionManager = PowerMock.createMock(QuestionManager.class);
+    }
+
+    @Test
+    public void getNextQuestionsForFilter_appliesExclusionFilterForDeprecatedQuestions() throws
+            ContentManagerException {
+
+        // Arrange
+        GameManager gameManager = new GameManager(
+                this.dummyContentManager,
+                this.dummyGameboardPersistenceManager,
+                this.dummyMapper,
+                this.dummyQuestionManager,
+                "latest"
+        );
+
+        // configure the mock GitContentManager to record the filters that are sent to it by getNextQuestionsForFilter()
+        Capture<List<BooleanSearchClause>> capturedFilters = Capture.newInstance();
+        EasyMock.expect(dummyContentManager.findByFieldNamesRandomOrder(
+                EasyMock.capture(capturedFilters),
+                EasyMock.anyInt(),
+                EasyMock.anyInt(),
+                EasyMock.anyLong())
+        ).andStubReturn(new ResultsWrapper<>());
+        replay(dummyContentManager);
+
+        // Act
+        gameManager.getNextQuestionsForFilter(new GameFilter(), 1, 1L);
+
+        // Assert
+        // check that one of the filters sent to GitContentManager was the deprecated question exclusion filter
+        List<BooleanSearchClause> filters = capturedFilters.getValues().get(0);
+        BooleanSearchClause deprecatedFilter = filters.stream()
+                .filter(f -> Objects.equals(f.getField(), "deprecated")).collect(Collectors.toList()).get(0);
+
+        assertNotNull(deprecatedFilter);
+        assertEquals(deprecatedFilter.getOperator(), Constants.BooleanOperator.NOT);
+        assertEquals(deprecatedFilter.getValues(), Collections.singletonList("true"));
+    }
+}


### PR DESCRIPTION
This PR adds the deprecated filter to the query used by the /gameboards endpoint to select random questions, which was returning deprecated content to the Question Finder. In other places this filtering is done on the frontend, however it isn't straightforward to do this the same way for the Question Finder. This solution works but should probably be re-visited for consistency.

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- ~~Removed Unnecessary Logs/System.Outs/Comments/TODOs~~
- ~~Added enough Logging to monitor expected behaviour change~~
- ~~Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped~~
- ~~Security - Data Exposure - PII is not stored or sent unencrypted~~
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- ~~Security - Access Control - Check authorisation on every new endpoint~~
- ~~Security - New dependency - configured sensibly not relying on defaults~~
- ~~Security - New dependency - Searched for any know vulnerabilities~~
- ~~Security - New dependency - Signed up team to mailing list~~
- ~~Security - New dependency - Added to dependency list~~
- ~~DB schema changes - postgres-rutherford-create-script updated~~
- ~~DB schema changes - upgrade script created matching create script~~
- ~~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~~
- [ ] Peer-Reviewed
