### PR TITLE
Add merged test coverage report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,7 @@
                         <segue.version>${segue.version}</segue.version>
                     </systemPropertyVariables>
                     <useSystemClassLoader>false</useSystemClassLoader>
+                    <argLine>${surefire.jacoco.args}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -504,6 +505,7 @@
                         <test.config.location>src/test/resources/segue-integration-test-config.properties</test.config.location>
                     </systemPropertyVariables>
                     <useSystemClassLoader>false</useSystemClassLoader>
+                    <argLine>${failsafe.jacoco.args}</argLine>
                 </configuration>
                 <executions>
                     <execution>
@@ -565,16 +567,76 @@
                 <version>0.8.4</version>
                 <executions>
                     <execution>
+                        <id>before-unit-test-execution</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</destFile>
+                            <propertyName>surefire.jacoco.args</propertyName>
+                        </configuration>
                     </execution>
                     <execution>
-                        <id>report</id>
+                        <id>after-unit-test-execution</id>
                         <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-unit-test-coverage-report</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>before-integration-test-execution</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco-output/jacoco-integration-tests.exec</destFile>
+                            <propertyName>failsafe.jacoco.args</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>after-integration-test-execution</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-output/jacoco-integration-tests.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-integration-test-coverage-report</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>merge-unit-and-integration-tests</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>merge</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${project.build.directory}/jacoco-output/</directory>
+                                    <includes>
+                                        <include>*.exec</include>
+                                    </includes>
+                                </fileSet>
+                            </fileSets>
+                            <destFile>${project.build.directory}/jacoco-output/merged.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>create-merged-report</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-output/merged.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This PR uses JaCoCo's "merge" goal to combine unit and integration test coverage, which is picked up by Codecov. Individual unit and integration test coverage reports are kept, so those can still be referred to if needed.

---

**Pull Request Check List**
- ~~Unit Tests & Regression Tests Added (Optional)~~
- ~~Removed Unnecessary Logs/System.Outs/Comments/TODOs~~
- ~~Added enough Logging to monitor expected behaviour change~~
- ~~Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped~~
- ~~Security - Data Exposure - PII is not stored or sent unencrypted~~
- ~~Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)~~
- ~~Security - Access Control - Check authorisation on every new endpoint~~
- ~~Security - New dependency - configured sensibly not relying on defaults~~
- ~~Security - New dependency - Searched for any know vulnerabilities~~
- ~~Security - New dependency - Signed up team to mailing list~~
- ~~Security - New dependency - Added to dependency list~~
- ~~DB schema changes - postgres-rutherford-create-script updated~~
- ~~DB schema changes - upgrade script created matching create script~~
- ~~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~~
- [ ] Peer-Reviewed
