### PR TITLE
Update some dependencies to address security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <resteasy.version>6.0.3.Final</resteasy.version>
         <guice.version>5.1.0</guice.version>
         <oauth-client.version>1.33.3</oauth-client.version>
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.13.4</jackson.version>
         <jackson-databind.version>2.13.3</jackson-databind.version>
         <powermock.version>2.0.9</powermock.version>
         <swagger-ui-version>4.13.2</swagger-ui-version>
@@ -373,7 +373,7 @@
         <dependency>
             <groupId>com.mailjet</groupId>
             <artifactId>mailjet-client</artifactId>
-            <version>5.2.0</version>
+            <version>5.2.1</version>
         </dependency>
 
         <dependency>
@@ -669,7 +669,7 @@
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client-gson</artifactId>
-                <version>1.41.8</version>
+                <version>1.42.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- asyncutil is going nowhere but at least we are safe because the vulnerability only affects Java <= 1.6
- snakeyaml was vulnerable but an update to jackson fixed it
- the rest is fairly mild and also don't have immediate fixes