### PR TITLE
Introduce graph sketcher settings and reduce axis tolerance

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherSettings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherSettings.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Matthew Trew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.cl.dtg.isaac.quiz;
+
+import org.isaacphysics.graphchecker.settings.SettingsWrapper;
+
+
+/**
+ * This class defines some Isaac-specific settings for the Graph Checker. If you are thinking of changing any
+ * settings, you should run the tuner (Bluefin) to evaluate them on the sample set first.
+ */
+public class IsaacGraphSketcherSettings implements SettingsWrapper {
+
+    private static final double ISAAC_AXIS_SLOP = 0.0025;
+
+    @Override
+    public double getAxisSlop() {
+        return ISAAC_AXIS_SLOP;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherValidator.java
@@ -33,7 +33,7 @@ public class IsaacGraphSketcherValidator implements IValidator, ISpecifier {
     private static final Logger log = LoggerFactory.getLogger(IsaacGraphSketcherValidator.class);
 
     private static final AnswerToInput answerToInput = new AnswerToInput();
-    private static final Features features = new Features();
+    private static final Features features = new Features(new IsaacGraphSketcherSettings());
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
@@ -88,7 +88,6 @@ public class IsaacGraphSketcherValidator implements IValidator, ISpecifier {
 
             Input input = answerToInput.apply(graphAnswer);
 
-            // Sort the choices so that we match incorrect choices last, taking precedence over correct ones.
             List<Choice> orderedChoices = getOrderedChoices(graphSketcherQuestion.getChoices());
 
             // For all the choices on this question...


### PR DESCRIPTION
This PR changes the default graph sketcher tolerance for whether a curve intersects with the axis. The new config has been tested with the tuner which showed no unexpected impact.

Ideally this would be a configuration file reloadable at runtime, but I think this is a good first step which fixes the immediate issue observed on asymptotic graphs.

---

**Pull Request Check List**
- ~~Unit Tests & Regression Tests Added (Optional)~~
-~~Removed Unnecessary Logs/System.Outs/Comments/TODOs~~
- ~~Added enough Logging to monitor expected behaviour change~~
- ~~Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped~~
- ~~Security - Data Exposure - PII is not stored or sent unencrypted~~
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- ~~Security - Access Control - Check authorisation on every new endpoint~~
- ~~Security - New dependency - configured sensibly not relying on defaults~~
- ~~Security - New dependency - Searched for any know vulnerabilities~~
- ~~Security - New dependency - Signed up team to mailing list~~
- ~~Security - New dependency - Added to dependency list~~
- ~~DB schema changes - postgres-rutherford-create-script updated~~
- ~~DB schema changes - upgrade script created matching create script~~
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
