### PR TITLE
Reorder validator improvements

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
@@ -127,7 +127,16 @@ public class IsaacClozeValidator implements IValidator {
 
                 // ... look for a match to the submitted answer.
                 if (trustedChoiceItemIds.size() != submittedItemIds.size()) {
-                    feedback = new Content("You did not provide a valid answer; it does not contain an item for each gap.");
+                    if (itemChoice.isCorrect()) {
+                        // Assume a correct choice has correct number of gaps. (Legacy incorrect options may be missing items!).
+                        // It should not be possible to cause this size mismatch from a compliant frontend; it should submit null placeholders.
+                        if (trustedChoiceItemIds.size() > submittedItemIds.size()) {
+                            feedback = new Content("You did not provide a valid answer; it does not contain an item for each gap.");
+                        } else {
+                            feedback = new Content("You did not provide a valid answer; it contains more items than gaps.");
+                        }
+                    }
+                    // If the lengths aren't equal, we can't compare to this choice:
                     continue;
                 }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.isaac.quiz;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,19 +26,19 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.Item;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ItemChoice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Validator that only provides functionality to validate Cloze questions.
  */
 public class IsaacClozeValidator implements IValidator {
     private static final Logger log = LoggerFactory.getLogger(IsaacClozeValidator.class);
-    private static final String NULL_CLOZE_ITEM_ID = "NULL_CLOZE_ITEM";
+    protected static final String NULL_CLOZE_ITEM_ID = "NULL_CLOZE_ITEM";
 
     @Override
     public final QuestionValidationResponse validateQuestionResponse(final Question question, final Choice answer) {
@@ -63,15 +62,17 @@ public class IsaacClozeValidator implements IValidator {
         IsaacClozeQuestion clozeQuestion = (IsaacClozeQuestion) question;
         ItemChoice submittedChoice = (ItemChoice) answer;
 
+
+        List<String> submittedItemIds = Collections.emptyList();
+        Set<String> allowedItemIds = Collections.emptySet();
+
         // STEP 0: Is it even possible to answer this question?
 
         if (null == clozeQuestion.getChoices() || clozeQuestion.getChoices().isEmpty()) {
             log.error("Question does not have any answers. " + question.getId() + " src: "
                     + question.getCanonicalSourceFile());
             feedback = new Content("This question does not have any correct answers!");
-        }
-
-        if (null == clozeQuestion.getItems() || clozeQuestion.getItems().isEmpty()) {
+        } else if (null == clozeQuestion.getItems() || clozeQuestion.getItems().isEmpty()) {
             log.error("ItemQuestion does not have any items. " + question.getId() + " src: "
                     + question.getCanonicalSourceFile());
             feedback = new Content("This question does not have any items to choose from!");
@@ -79,80 +80,88 @@ public class IsaacClozeValidator implements IValidator {
 
         // STEP 1: Did they provide a valid answer?
 
-        if (null == feedback && (null == submittedChoice.getItems() || submittedChoice.getItems().isEmpty())) {
-            feedback = new Content("You did not provide an answer.");
-        }
-
-        Set<String> submittedItemIdSet = null;
-        Set<String> allowedItemIds;
-        if (null != submittedChoice.getItems() && null != clozeQuestion.getItems()) {
-            submittedItemIdSet = submittedChoice.getItems().stream().map(Item::getId).collect(Collectors.toSet());
-            allowedItemIds = clozeQuestion.getItems().stream().map(Item::getId).collect(Collectors.toSet());
-            allowedItemIds.add(NULL_CLOZE_ITEM_ID);
-            if (!allowedItemIds.containsAll(submittedItemIdSet)) {
-                feedback = new Content("You did not provide a valid answer; it contained unrecognised items");
+        if (null == feedback) {
+            if (null == submittedChoice.getItems() || submittedChoice.getItems().isEmpty()) {
+                feedback = new Content("You did not provide an answer.");
+            } else if (submittedChoice.getItems().stream().anyMatch(i -> i.getClass() != Item.class)) {
+                feedback = new Content("Your answer is not in a recognised format!");
+            } else {
+                allowedItemIds = Stream.concat(Stream.of(NULL_CLOZE_ITEM_ID), clozeQuestion.getItems().stream().map(Item::getId)).collect(Collectors.toSet());
+                submittedItemIds = submittedChoice.getItems().stream().map(Item::getId).collect(Collectors.toList());
+                if (!allowedItemIds.containsAll(submittedItemIds)) {
+                    feedback = new Content("Your answer contained unrecognised items.");
+                } else if (submittedItemIds.stream().allMatch(NULL_CLOZE_ITEM_ID::equals)) {
+                    // At least one item in the list must be non-null, else this is a blank submission!
+                    feedback = new Content("You did not provide an answer!");
+                }
             }
         }
 
         // STEP 2: If they did, does their answer match a known answer?
 
-        if (null == feedback && null != submittedItemIdSet) {
+        if (null == feedback) {
             // Sort the choices so that we match incorrect choices last, taking precedence over correct ones.
             List<Choice> orderedChoices = getOrderedChoices(clozeQuestion.getChoices());
 
             // For all the choices on this question...
             for (Choice c : orderedChoices) {
 
-                // ... that are ItemChoices ...
-                if (!(c instanceof ItemChoice)) {
-                    log.error(String.format(
-                            "Validator for question (%s) expected there to be an ItemChoice. Instead it found a %s.",
-                            clozeQuestion.getId(), c.getClass().toString()));
+                // ... that are ItemChoices (and not subclasses) ...
+                if (!ItemChoice.class.equals(c.getClass())) {
+                    log.error(String.format("Expected ItemChoice in question (%s), instead found %s!", clozeQuestion.getId(), c.getClass().toString()));
                     continue;
                 }
 
                 ItemChoice itemChoice = (ItemChoice) c;
 
-                // ... and that have items ...
+                // ... and that have valid items ...
                 if (null == itemChoice.getItems() || itemChoice.getItems().isEmpty()) {
-                    log.error("Expected list of Items, but none found in choice for question id: "
-                            + clozeQuestion.getId());
+                    log.error(String.format("Expected list of Items, but none found in choice for question id (%s)!", clozeQuestion.getId()));
                     continue;
                 }
+                if (itemChoice.getItems().stream().anyMatch(i -> i.getClass() != Item.class)) {
+                    log.error(String.format("Expected list of Items, but something else found in choice for question id (%s)!", clozeQuestion.getId()));
+                    continue;
+                }
+                List<String> trustedChoiceItemIds = itemChoice.getItems().stream().map(Item::getId).collect(Collectors.toList());
 
                 // ... look for a match to the submitted answer.
-                if (itemChoice.getItems().size() != submittedChoice.getItems().size()) {
+                if (trustedChoiceItemIds.size() != submittedItemIds.size()) {
+                    feedback = new Content("You did not provide a valid answer; it does not contain an item for each gap.");
                     continue;
                 }
 
-                List<String> submittedItemIds = new ArrayList<>();
-                List<String> choiceItemIds = new ArrayList<>();
+                boolean allowSubsetMatch = null != itemChoice.isAllowSubsetMatch() && itemChoice.isAllowSubsetMatch();
 
-                // Run through the submitted items:
-                for (Item item : submittedChoice.getItems()) {
-                    submittedItemIds.add(item.getId());
+                boolean submissionMatches = true;
+                for (int i = 0; i < trustedChoiceItemIds.size(); i++) {
+                    String trustedItemId = trustedChoiceItemIds.get(i);
+                    String submittedItemId = submittedItemIds.get(i);
+
+                    if (NULL_CLOZE_ITEM_ID.equals(trustedItemId)) {
+                        // It doesn't matter what the submission has here, but only if we are allowed subset matching:
+                        if (!allowSubsetMatch) {
+                            log.error(String.format("ItemChoice does not allow subset match but contains NULL item in question (%s)!", clozeQuestion.getId()));
+                            submissionMatches = false;
+                            break;
+                        }
+                    //} else if (allowSubsetMatch && NULL_CLOZE_ITEM_ID.equals(submittedItemId)) {
+                        // If the user has left a gap blank, and we are allowed subset matching, then this counts
+                        // as a match whatever the trustedChoice has here.
+                        // We have already checked above that not _all_ of the submitted items are null.
+                    } else {
+                        if (!trustedItemId.equals(submittedItemId)) {
+                            // Break early if the submitted item at this spot doesn't match the expected item:
+                            submissionMatches = false;
+                            break;
+                        }
+                    }
                 }
-                // Run through the items in the question:
-                for (Item item : itemChoice.getItems()) {
-                    choiceItemIds.add(item.getId());
-                }
 
-                // Do not allow subset matching by default, and only allow if the cloze question does not have replacement/item duplication enabled
-                boolean allowSubsetMatch = (null != itemChoice.isAllowSubsetMatch() && itemChoice.isAllowSubsetMatch()) && (null != clozeQuestion.getWithReplacement() && !clozeQuestion.getWithReplacement());
-
-                Set<String> choiceItemIdSet = new HashSet<>(choiceItemIds);
-                /* If the intersection of the submitted and choice ids is equal to the choice ones, then
-                   this means that:
-                    - choiceItemIdSet.size() <= submittedItemIds.size()
-                    - All choice ids are within the set of submitted ids
-                 */
-                if (allowSubsetMatch && Sets.intersection(submittedItemIdSet, choiceItemIdSet).equals(choiceItemIdSet)) {
+                if (submissionMatches) {
                     responseCorrect = itemChoice.isCorrect();
                     feedback = (Content) itemChoice.getExplanation();
-                    break;
-                } else if (choiceItemIds.equals(submittedItemIds)) {
-                    responseCorrect = itemChoice.isCorrect();
-                    feedback = (Content) itemChoice.getExplanation();
+                    // Since choices are ordered, this is the best we can do, so stop looking:
                     break;
                 }
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -770,7 +770,11 @@ public class ContentIndexer {
             }
 
             // content type specific checks
+            try {
             this.recordContentTypeSpecificError(sha, c, indexProblemCache);
+            } catch (NullPointerException e) {
+                log.warn("Failed processing content errors in file: " + c.getCanonicalSourceFile());
+            }
         }
 
         // Find all references to missing content.

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidatorTest.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2022 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.quiz;
+
+import com.google.api.client.util.Lists;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacClozeQuestion;
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuickQuestion;
+import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Item;
+import uk.ac.cam.cl.dtg.isaac.dos.content.ItemChoice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.ParsonsChoice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.ParsonsItem;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class IsaacClozeValidatorTest {
+    private IsaacClozeValidator validator;
+    private IsaacClozeQuestion someClozeQuestion;
+    // Some items:
+    private final Item item1 = new Item("id001", "A");
+    private final Item item2 = new Item("id002", "B");
+    private final Item item3 = new Item("id003", "C");
+    private final Item NULL_PLACEHOLDER = new Item(IsaacClozeValidator.NULL_CLOZE_ITEM_ID, null);
+
+    private final String incorrectExplanation = "INCORRECT";
+    private final String subsetMatchExplanation = "SUBSET";
+    private final String defaultExplanation = "DEFAULT";
+
+    /**
+     * Initial configuration of tests.
+     */
+    @Before
+    public final void setUp() {
+        validator = new IsaacClozeValidator();
+
+        // Set up the question object:
+        someClozeQuestion = new IsaacClozeQuestion();
+
+        List<Choice> answerList = Lists.newArrayList();
+        ItemChoice someIncorrectChoice = new ItemChoice();
+        ItemChoice someSubsetChoice = new ItemChoice();
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someClozeQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        // Correct and incorrect choices the same:
+        someCorrectAnswer.setItems(ImmutableList.of(item1, item3));
+        someCorrectAnswer.setCorrect(true);
+        someIncorrectChoice.setItems(ImmutableList.of(item1, item2));
+        someIncorrectChoice.setCorrect(false);
+        someIncorrectChoice.setAllowSubsetMatch(false);
+        someIncorrectChoice.setExplanation(new Content(incorrectExplanation));
+        someSubsetChoice.setItems(ImmutableList.of(NULL_PLACEHOLDER, item3));
+        someSubsetChoice.setAllowSubsetMatch(true);
+        someSubsetChoice.setExplanation(new Content(subsetMatchExplanation));
+
+        // Add both choices to question, incorrect first:
+        answerList.add(someIncorrectChoice);
+        answerList.add(someSubsetChoice);
+        answerList.add(someCorrectAnswer);
+        someClozeQuestion.setChoices(answerList);
+    }
+
+    /*
+        Test that correct answers are recognised.
+    */
+    @Test
+    public final void isaacClozeValidator_CorrectItems_CorrectResponseShouldBeReturned() {
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, item3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertTrue(response.isCorrect());
+    }
+
+    /*
+        Test that incorrect answers are not recognised.
+    */
+    @Test
+    public final void isaacClozeValidator_IncorrectItems_IncorrectResponseShouldBeReturned() {
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item2, item3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+    }
+
+    /*
+        Test that subset match answers can be matched.
+    */
+    @Test
+    public final void isaacClozeValidator_UserSubsetMatch_IncorrectResponseShouldBeReturned() {
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item2, item3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertEquals(subsetMatchExplanation, response.getExplanation().getValue());
+    }
+
+    /*
+        Test that known incorrect answers can be matched.
+    */
+    @Test
+    public final void isaacClozeValidator_KnownIncorrect_IncorrectResponseShouldBeReturned() {
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, item2));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertEquals(incorrectExplanation, response.getExplanation().getValue());
+    }
+
+    /*
+         Test that all null-placeholder answers are rejected.
+    */
+    @Test
+    public final void isaacClozeValidator_AllNull_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(NULL_PLACEHOLDER, NULL_PLACEHOLDER));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("did not provide an answer"));
+    }
+
+    /*
+        Test that answers missing items are rejected.
+    */
+    @Test
+    public final void isaacClozeValidator_NotEnoughItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("does not contain an item for each gap"));
+    }
+
+    /*
+        Test that answers with unknown items are rejected.
+    */
+    @Test
+    public final void isaacClozeValidator_UnknownItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, new Item("unknown", null)));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("unrecognised items"));
+    }
+
+    /*
+        Test that answers with no items are rejected.
+    */
+    @Test
+    public final void isaacClozeValidator_NoUserItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("did not provide an answer"));
+    }
+
+    /*
+        Test that answers with no items are rejected.
+    */
+    @Test
+    public final void isaacClozeValidator_IncorrectTypeUserItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(new ParsonsItem("id001", null, null)));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("not in a recognised format"));
+    }
+
+    /*
+        Test that missing choices are detected.
+    */
+    @Test
+    public final void isaacClozeValidator_DefaultFeedbackReturned() {
+        // Set up the question object:
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+        clozeQuestion.setDefaultFeedback(new Content(defaultExplanation));
+        clozeQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(item1));
+        someCorrectAnswer.setCorrect(true);
+        clozeQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(clozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertEquals(response.getExplanation().getValue(), defaultExplanation);
+    }
+
+    //  ---------- Tests from here test invalid questions themselves ----------
+
+    /*
+     Test that missing choices are detected.
+    */
+    @Test
+    public final void isaacClozeValidator_NoChoices_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+        clozeQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        clozeQuestion.setChoices(Lists.newArrayList());
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(clozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("not have any correct answers"));
+    }
+
+    /*
+        Test that wrong choice types are detected.
+    */
+    @Test
+    public final void isaacClozeValidator_WrongTypeChoices_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+        ParsonsItem parsonsItem = new ParsonsItem("id001", null, null);
+        clozeQuestion.setItems(ImmutableList.of(parsonsItem));
+
+        ItemChoice someCorrectAnswer = new ParsonsChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(parsonsItem));
+        someCorrectAnswer.setCorrect(true);
+        clozeQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(clozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    /*
+     Test that missing items are detected.
+    */
+    @Test
+    public final void isaacClozeValidator_NoItems_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+        clozeQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(Collections.emptyList());
+        someCorrectAnswer.setCorrect(true);
+        clozeQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(clozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    /*
+     Test that missing items are detected.
+    */
+    @Test
+    public final void isaacClozeValidator_NoItemsInQuestion_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(item1));
+        someCorrectAnswer.setCorrect(true);
+        clozeQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(clozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("does not have any items"));
+    }
+
+    /*
+     Test that incorrect item types are detected.
+    */
+    @Test
+    public final void isaacClozeValidator_ParsonsItems_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+        clozeQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(new ParsonsItem("id001", null, null)));
+        someCorrectAnswer.setCorrect(true);
+        clozeQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(clozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    /*
+        Test that null placeholders do not match if "allowSubset" is not marked.
+    */
+    @Test
+    public final void isaacClozeValidator_NullButNoSubset_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+        clozeQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(item1, NULL_PLACEHOLDER));
+        someCorrectAnswer.setCorrect(true);
+        clozeQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up identical user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, NULL_PLACEHOLDER));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(clozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    /*
+     Test that incorrect question types are detected.
+    */
+    @Test
+    public final void isaacClozeValidator_WrongQuestionType_ExceptionShouldBeThrown() {
+        IsaacQuickQuestion invalidQuestionType = new IsaacQuickQuestion();
+        invalidQuestionType.setId("invalidQuestionType");
+
+        // This should throw an exception:
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            validator.validateQuestionResponse(invalidQuestionType, new ItemChoice());
+        });
+        assertTrue(exception.getMessage().contains("only works with IsaacClozeQuestions"));
+    }
+
+    /*
+     Test that incorrect submitted choice types are detected.
+    */
+    @Test
+    public final void isaacClozeValidator_WrongChoiceType_ExceptionShouldBeThrown() {
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+
+        // This should throw an exception:
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            validator.validateQuestionResponse(clozeQuestion, new Choice());
+        });
+        assertTrue(exception.getMessage().contains("Expected ItemChoice for IsaacClozeQuestion"));
+    }
+}

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidatorTest.java
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertTrue;
  * Test class for the Item Question Validator class.
  *
  */
-@PowerMockIgnore({"jakarta.ws.*"})
 public class IsaacItemQuestionValidatorTest {
     private IsaacItemQuestionValidator validator;
     private IsaacItemQuestion someItemQuestion;

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacReorderValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacReorderValidatorTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2022 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.quiz;
+
+import com.google.api.client.util.Lists;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuickQuestion;
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacReorderQuestion;
+import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Item;
+import uk.ac.cam.cl.dtg.isaac.dos.content.ItemChoice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.ParsonsChoice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.ParsonsItem;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class IsaacReorderValidatorTest {
+    private IsaacReorderValidator validator;
+    private IsaacReorderQuestion someReorderQuestion;
+    // Some items:
+    private final Item item1 = new Item("id001", "A");
+    private final Item item2 = new Item("id002", "B");
+    private final Item item3 = new Item("id003", "C");
+
+    private final String incorrectExplanation = "INCORRECT";
+    private final String subsetMatchExplanation = "SUBSET";
+    private final String defaultExplanation = "DEFAULT";
+
+    /**
+     * Initial configuration of tests.
+     */
+    @Before
+    public final void setUp() {
+        validator = new IsaacReorderValidator();
+
+        // Set up the question object:
+        someReorderQuestion = new IsaacReorderQuestion();
+
+        List<Choice> answerList = Lists.newArrayList();
+        ItemChoice someIncorrectChoice = new ItemChoice();
+        ItemChoice someSubsetChoice = new ItemChoice();
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someReorderQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        // Correct and incorrect choices the same:
+        someCorrectAnswer.setItems(ImmutableList.of(item1, item2, item3));
+        someCorrectAnswer.setCorrect(true);
+        someIncorrectChoice.setItems(ImmutableList.of(item3, item2, item1));
+        someIncorrectChoice.setCorrect(false);
+        someIncorrectChoice.setAllowSubsetMatch(false);
+        someIncorrectChoice.setExplanation(new Content(incorrectExplanation));
+        someSubsetChoice.setItems(ImmutableList.of(item1, item3));
+        someSubsetChoice.setAllowSubsetMatch(true);
+        someSubsetChoice.setExplanation(new Content(subsetMatchExplanation));
+
+        // Add both choices to question, incorrect first:
+        answerList.add(someIncorrectChoice);
+        answerList.add(someSubsetChoice);
+        answerList.add(someCorrectAnswer);
+        someReorderQuestion.setChoices(answerList);
+    }
+
+    /*
+        Test that correct answers are recognised.
+    */
+    @Test
+    public final void isaacReorderValidator_CorrectItems_CorrectResponseShouldBeReturned() {
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, item2, item3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someReorderQuestion, c);
+        assertTrue(response.isCorrect());
+    }
+
+    /*
+        Test that incorrect answers are not recognised.
+    */
+    @Test
+    public final void isaacReorderValidator_IncorrectItems_IncorrectResponseShouldBeReturned() {
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item2, item1, item3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someReorderQuestion, c);
+        assertFalse(response.isCorrect());
+    }
+
+    /*
+        Test that subset match answers can be matched.
+    */
+    @Test
+    public final void isaacReorderValidator_UserSubsetMatch_IncorrectResponseShouldBeReturned() {
+        // Set up user answer with subset at end of match:
+        ItemChoice c1 = new ItemChoice();
+        c1.setItems(ImmutableList.of(item2, item1, item3));
+
+        // Test response:
+        QuestionValidationResponse response1 = validator.validateQuestionResponse(someReorderQuestion, c1);
+        assertFalse(response1.isCorrect());
+        assertEquals(subsetMatchExplanation, response1.getExplanation().getValue());
+
+        // Set up user answer with subset at start:
+        ItemChoice c2 = new ItemChoice();
+        c2.setItems(ImmutableList.of(item1, item3, item2));
+
+        // Test response:
+        QuestionValidationResponse response2 = validator.validateQuestionResponse(someReorderQuestion, c2);
+        assertFalse(response2.isCorrect());
+        assertEquals(subsetMatchExplanation, response2.getExplanation().getValue());
+    }
+
+    /*
+        Test that known incorrect answers can be matched.
+    */
+    @Test
+    public final void isaacReorderValidator_KnownIncorrect_IncorrectResponseShouldBeReturned() {
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item3, item2, item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someReorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertEquals(incorrectExplanation, response.getExplanation().getValue());
+    }
+
+    /*
+        Test that answers which are too short get feedback.
+    */
+    @Test
+    public final void isaacReorderValidator_NotEnoughItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someReorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("does not contain enough items"));
+    }
+
+    /*
+        Test that answers which are too short get feedback.
+     */
+    @Test
+    public final void isaacReorderValidator_TooManyItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, item2, item3, item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someReorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("contains too many items"));
+    }
+
+    /*
+        Test that answers with unknown items are rejected.
+    */
+    @Test
+    public final void isaacReorderValidator_UnknownItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, new Item("unknown", null)));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someReorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("unrecognised items"));
+    }
+
+    /*
+        Test that answers with no items are rejected.
+    */
+    @Test
+    public final void isaacReorderValidator_NoUserItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someReorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("did not provide an answer"));
+    }
+
+    /*
+        Test that answers with incorrect type items are rejected.
+    */
+    @Test
+    public final void isaacReorderValidator_IncorrectTypeUserItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(new ParsonsItem("id001", null, null)));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someReorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("not in a recognised format"));
+    }
+
+    /*
+        Test that default feedback works.
+    */
+    @Test
+    public final void isaacReorderValidator_DefaultFeedbackReturned() {
+        // Set up the question object:
+        IsaacReorderQuestion reorderQuestion = new IsaacReorderQuestion();
+        reorderQuestion.setDefaultFeedback(new Content(defaultExplanation));
+        reorderQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(item1));
+        someCorrectAnswer.setCorrect(true);
+        reorderQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(reorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertEquals(response.getExplanation().getValue(), defaultExplanation);
+    }
+
+    //  ---------- Tests from here test invalid questions themselves ----------
+
+    /*
+     Test that missing choices are detected.
+    */
+    @Test
+    public final void isaacReorderValidator_NoChoices_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacReorderQuestion reorderQuestion = new IsaacReorderQuestion();
+        reorderQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        reorderQuestion.setChoices(Lists.newArrayList());
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(reorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("not have any correct answers"));
+    }
+
+    /*
+        Test that wrong choice types are detected.
+    */
+    @Test
+    public final void isaacReorderValidator_WrongTypeChoices_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacReorderQuestion reorderQuestion = new IsaacReorderQuestion();
+        ParsonsItem parsonsItem = new ParsonsItem("id001", null, null);
+        reorderQuestion.setItems(ImmutableList.of(parsonsItem));
+
+        ItemChoice someCorrectAnswer = new ParsonsChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(parsonsItem));
+        someCorrectAnswer.setCorrect(true);
+        reorderQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(reorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    /*
+     Test that missing items are detected.
+    */
+    @Test
+    public final void isaacReorderValidator_NoItems_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacReorderQuestion reorderQuestion = new IsaacReorderQuestion();
+        reorderQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(Collections.emptyList());
+        someCorrectAnswer.setCorrect(true);
+        reorderQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(reorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    /*
+     Test that missing items are detected.
+    */
+    @Test
+    public final void isaacReorderValidator_NoItemsInQuestion_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacReorderQuestion reorderQuestion = new IsaacReorderQuestion();
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(item1));
+        someCorrectAnswer.setCorrect(true);
+        reorderQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(reorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("does not have any items"));
+    }
+
+    /*
+     Test that incorrect item types are detected.
+    */
+    @Test
+    public final void isaacReorderValidator_ParsonsItems_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacReorderQuestion reorderQuestion = new IsaacReorderQuestion();
+        reorderQuestion.setItems(ImmutableList.of(item1, item2, item3));
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(new ParsonsItem("id001", null, null)));
+        someCorrectAnswer.setCorrect(true);
+        reorderQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(reorderQuestion, c);
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    /*
+     Test that incorrect question types are detected.
+    */
+    @Test
+    public final void isaacReorderValidator_WrongQuestionType_ExceptionShouldBeThrown() {
+        IsaacQuickQuestion invalidQuestionType = new IsaacQuickQuestion();
+        invalidQuestionType.setId("invalidQuestionType");
+
+        // This should throw an exception:
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            validator.validateQuestionResponse(invalidQuestionType, new ItemChoice());
+        });
+        assertTrue(exception.getMessage().contains("only works with IsaacReorderQuestions"));
+    }
+
+    /*
+     Test that incorrect submitted choice types are detected.
+    */
+    @Test
+    public final void isaacReorderValidator_WrongChoiceType_ExceptionShouldBeThrown() {
+        IsaacReorderQuestion reorderQuestion = new IsaacReorderQuestion();
+
+        // This should throw an exception:
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            validator.validateQuestionResponse(reorderQuestion, new Choice());
+        });
+        assertTrue(exception.getMessage().contains("Expected ItemChoice for IsaacReorderQuestion"));
+    }
+}


### PR DESCRIPTION
This PR extends #487, and so should be merged after it. The diff might be easier to view just [between this PR and the previous one](https://github.com/isaacphysics/isaac-api/compare/feature/cloze-validator-improvements...feature/reorder-validator-improvements) rather than onto master directly yet.

As for cloze questions, this adds support for subset matching to reorder questions. It also adds some feedback for length mismatches between the right answer and a user's submission.