### PR TITLE
Add log events for content error reporting

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -179,6 +179,8 @@ public final class Constants {
         CLIENT_SIDE_ERROR,
         LOGIN_MODAL_SHOWN,
         REVIEW_TEACHER_CONNECTIONS,
+        REPORT_CONTENT_ACCORDION_SECTION,
+        REPORT_CONTENT_PAGE
     }
     public static final Set<String> ISAAC_CLIENT_LOG_TYPES = Arrays.stream(IsaacClientLogType.values()).map(IsaacClientLogType::name).collect(Collectors.toSet());
 


### PR DESCRIPTION
This PR registers two new log event types for content errors reported in pages and accordions.

---

**Pull Request Check List**
- ~~Unit Tests & Regression Tests Added (Optional)~~
- ~~Removed Unnecessary Logs/System.Outs/Comments/TODOs~~
- [x] Added enough Logging to monitor expected behaviour change
- ~~Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped~~
- ~~Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- ~~Security - Access Control - Check authorisation on every new endpoint~~
- ~~Security - New dependency - configured sensibly not relying on defaults~~
- ~~Security - New dependency - Searched for any know vulnerabilities~~
- ~~Security - New dependency - Signed up team to mailing list~~
- ~~Security - New dependency - Added to dependency list~~
- ~~DB schema changes - postgres-rutherford-create-script updated~~
- ~~DB schema changes - upgrade script created matching create script~~
- ~~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~~
- [ ] Peer-Reviewed
