### PR TITLE
Allow assignments to be scheduled on the same date as they are due

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -1026,7 +1026,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                     continue;
                 }
 
-                if (null != assignmentDTO.getDueDate() && assignmentDTO.isBeforeDueDate(new Date())) {
+                if (null != assignmentDTO.getDueDate() && !assignmentDTO.isBeforeDueDate(new Date())) {
                     assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be due in the past."));
                     continue;
                 }
@@ -1037,7 +1037,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin more than one year in the future."));
                         continue;
                     }
-                    if (null != assignmentDTO.getDueDate() && assignmentDTO.isBeforeDueDate(assignmentDTO.getScheduledStartDate())) {
+                    if (null != assignmentDTO.getDueDate() && !assignmentDTO.isBeforeDueDate(assignmentDTO.getScheduledStartDate())) {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin after it is due."));
                         continue;
                     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -73,6 +73,7 @@ import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -1038,7 +1039,10 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin more than one year in the future."));
                         continue;
                     }
-                    if (null != assignmentDTO.getDueDate() && assignmentDTO.getScheduledStartDate().after(assignmentDTO.getDueDate())) {
+                    Calendar cal = Calendar.getInstance();
+                    cal.setTimeInMillis(assignmentDTO.getScheduledStartDate().getTime());
+                    cal.set(Calendar.HOUR_OF_DAY, 0);
+                    if (null != assignmentDTO.getDueDate() && cal.getTime().compareTo(assignmentDTO.getDueDate()) > 0) {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin after it is due."));
                         continue;
                     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -1026,7 +1026,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                     continue;
                 }
 
-                if (null != assignmentDTO.getDueDate() && !assignmentDTO.isBeforeDueDate(new Date())) {
+                if (null != assignmentDTO.getDueDate() && !assignmentDTO.dueDateIsAfter(new Date())) {
                     assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be due in the past."));
                     continue;
                 }
@@ -1037,7 +1037,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin more than one year in the future."));
                         continue;
                     }
-                    if (null != assignmentDTO.getDueDate() && !assignmentDTO.isBeforeDueDate(assignmentDTO.getScheduledStartDate())) {
+                    if (null != assignmentDTO.getDueDate() && !assignmentDTO.dueDateIsAfter(assignmentDTO.getScheduledStartDate())) {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin after it is due."));
                         continue;
                     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -1026,11 +1026,9 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                     continue;
                 }
 
-                if (null != assignmentDTO.getDueDate()) {
-                    if (assignmentDTO.getDueDate().before(new Date())) {
-                        assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be due in the past."));
-                        continue;
-                    }
+                if (null != assignmentDTO.getDueDate() && assignmentDTO.isBeforeDueDate(new Date())) {
+                    assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be due in the past."));
+                    continue;
                 }
 
                 if (null != assignmentDTO.getScheduledStartDate()) {
@@ -1039,10 +1037,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin more than one year in the future."));
                         continue;
                     }
-                    Calendar cal = Calendar.getInstance();
-                    cal.setTimeInMillis(assignmentDTO.getScheduledStartDate().getTime());
-                    cal.set(Calendar.HOUR_OF_DAY, 0);
-                    if (null != assignmentDTO.getDueDate() && cal.getTime().compareTo(assignmentDTO.getDueDate()) > 0) {
+                    if (null != assignmentDTO.getDueDate() && assignmentDTO.isBeforeDueDate(assignmentDTO.getScheduledStartDate())) {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin after it is due."));
                         continue;
                     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -1041,6 +1041,14 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "The assignment cannot be scheduled to begin after it is due."));
                         continue;
                     }
+                    // If the assignment will have started in the next hour (meaning it might miss the related emails
+                    // being scheduled), then remove it so that the assignment is set immediately.
+                    Calendar cal = Calendar.getInstance();
+                    cal.setTime(new Date());
+                    cal.add(Calendar.HOUR_OF_DAY, 1);
+                    if (assignmentDTO.getScheduledStartDate().before(cal.getTime())) {
+                        assignmentDTO.setScheduledStartDate(null);
+                    }
                 }
 
                 try {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -393,7 +393,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             }
 
             // Check the due date hasn't passed
-            if (quizAssignment.getDueDate() != null && !quizAssignment.isBeforeDueDate(new Date())) {
+            if (quizAssignment.getDueDate() != null && !quizAssignment.dueDateIsAfter(new Date())) {
                 return new SegueErrorResponse(Status.FORBIDDEN, "The due date for this test has passed.").toResponse();
             }
 
@@ -683,7 +683,7 @@ public class QuizFacade extends AbstractIsaacFacade {
                     "You can only mark assignments incomplete for groups you own or manage.").toResponse();
             }
 
-            if (assignment.getDueDate() != null && assignment.isBeforeDueDate(new Date())) {
+            if (assignment.getDueDate() != null && assignment.dueDateIsAfter(new Date())) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "You cannot mark a test attempt as incomplete while it is still due.").toResponse();
             }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -683,8 +683,8 @@ public class QuizFacade extends AbstractIsaacFacade {
                     "You can only mark assignments incomplete for groups you own or manage.").toResponse();
             }
 
-            if (assignment.getDueDate() != null && assignment.dueDateIsAfter(new Date())) {
-                return new SegueErrorResponse(Status.BAD_REQUEST, "You cannot mark a test attempt as incomplete while it is still due.").toResponse();
+            if (assignment.getDueDate() != null && !assignment.dueDateIsAfter(new Date())) {
+                return new SegueErrorResponse(Status.BAD_REQUEST, "You cannot mark a test attempt as incomplete after the due date.").toResponse();
             }
 
             RegisteredUserDTO student = userManager.getUserDTOById(userId);
@@ -1662,18 +1662,8 @@ public class QuizFacade extends AbstractIsaacFacade {
         // Relying on the side-effects of getting the assignment.
         QuizAssignmentDTO quizAssignment = getQuizAssignment(quizAttempt);
 
-        if (quizAssignment != null && quizAssignment.getDueDate() != null) {
-            // Push due date to 12am of that day (start of the next day) - doesn't assume the due date is rounded to a day
-            Calendar c = Calendar.getInstance();
-            c.setTime(quizAssignment.getDueDate());
-            c.add(Calendar.DATE, 1);
-            c.set(Calendar.HOUR, 0);
-            c.set(Calendar.MINUTE, 0);
-            c.set(Calendar.SECOND, 0);
-            c.set(Calendar.MILLISECOND, 0);
-            if (c.getTime().before(new Date())) {
-                throw new ErrorResponseWrapper(new SegueErrorResponse(Status.FORBIDDEN, "The due date for this test has passed."));
-            }
+        if (quizAssignment != null && quizAssignment.getDueDate() != null && !quizAssignment.dueDateIsAfter(new Date())) {
+            throw new ErrorResponseWrapper(new SegueErrorResponse(Status.FORBIDDEN, "The due date for this test has passed."));
         }
 
         return quizAssignment;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -393,7 +393,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             }
 
             // Check the due date hasn't passed
-            if (quizAssignment.getDueDate() != null && new Date().after(quizAssignment.getDueDate())) {
+            if (quizAssignment.getDueDate() != null && !quizAssignment.isBeforeDueDate(new Date())) {
                 return new SegueErrorResponse(Status.FORBIDDEN, "The due date for this test has passed.").toResponse();
             }
 
@@ -683,7 +683,7 @@ public class QuizFacade extends AbstractIsaacFacade {
                     "You can only mark assignments incomplete for groups you own or manage.").toResponse();
             }
 
-            if (assignment.getDueDate() != null && assignment.getDueDate().before(new Date())) {
+            if (assignment.getDueDate() != null && assignment.isBeforeDueDate(new Date())) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "You cannot mark a test attempt as incomplete while it is still due.").toResponse();
             }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
@@ -152,7 +152,7 @@ public class AssignmentManager implements IAssignmentLike.Details<AssignmentDTO>
         final String gameboardURL = String.format("https://%s/assignment/%s", properties.getProperty(HOST_NAME),
                 gameboard.getId());
 
-        // If there is no date to schedule the assignment for...
+        // If there is no date to schedule the assignment for, or the start date is in the past...
         if (null == newAssignment.getScheduledStartDate()) {
             // Send the notification email immediately
             emailService.sendAssignmentEmailToGroup(newAssignment, gameboard, ImmutableMap.of("gameboardURL", gameboardURL),

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
@@ -92,7 +92,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
 
         Date now = new Date();
 
-        if (newAssignment.getDueDate() != null && newAssignment.getDueDate().before(now)) {
+        if (newAssignment.getDueDate() != null && newAssignment.isBeforeDueDate(now)) {
             throw new DueBeforeNowException();
         }
 
@@ -100,7 +100,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
             newAssignment.getGroupId());
 
         if (existingQuizAssignments.size() != 0) {
-            if (existingQuizAssignments.stream().anyMatch(qa -> qa.getDueDate() == null || qa.getDueDate().after(now))) {
+            if (existingQuizAssignments.stream().anyMatch(qa -> qa.getDueDate() == null || !qa.isBeforeDueDate(now))) {
                 log.error(String.format("Duplicated Test Assignment Exception - cannot assign the same work %s to a group %s when due date not passed",
                     newAssignment.getQuizId(), newAssignment.getGroupId()));
                 throw new DuplicateAssignmentException("You cannot reassign a test until the due date has passed.");
@@ -167,7 +167,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
 
     private List<QuizAssignmentDTO> filterActiveAssignments(List<QuizAssignmentDTO> assignments) {
         Date now = new Date();
-        return assignments.stream().filter(qa -> qa.getDueDate() == null || qa.getDueDate().after(now)).collect(Collectors.toList());
+        return assignments.stream().filter(qa -> qa.getDueDate() == null || !qa.isBeforeDueDate(now)).collect(Collectors.toList());
     }
 
     public void updateAssignment(QuizAssignmentDTO assignment, QuizAssignmentDTO updates) throws SegueDatabaseException {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
@@ -92,7 +92,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
 
         Date now = new Date();
 
-        if (newAssignment.getDueDate() != null && newAssignment.isBeforeDueDate(now)) {
+        if (newAssignment.getDueDate() != null && !newAssignment.isBeforeDueDate(now)) {
             throw new DueBeforeNowException();
         }
 
@@ -100,7 +100,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
             newAssignment.getGroupId());
 
         if (existingQuizAssignments.size() != 0) {
-            if (existingQuizAssignments.stream().anyMatch(qa -> qa.getDueDate() == null || !qa.isBeforeDueDate(now))) {
+            if (existingQuizAssignments.stream().anyMatch(qa -> qa.getDueDate() == null || qa.isBeforeDueDate(now))) {
                 log.error(String.format("Duplicated Test Assignment Exception - cannot assign the same work %s to a group %s when due date not passed",
                     newAssignment.getQuizId(), newAssignment.getGroupId()));
                 throw new DuplicateAssignmentException("You cannot reassign a test until the due date has passed.");
@@ -167,7 +167,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
 
     private List<QuizAssignmentDTO> filterActiveAssignments(List<QuizAssignmentDTO> assignments) {
         Date now = new Date();
-        return assignments.stream().filter(qa -> qa.getDueDate() == null || !qa.isBeforeDueDate(now)).collect(Collectors.toList());
+        return assignments.stream().filter(qa -> qa.getDueDate() == null || qa.isBeforeDueDate(now)).collect(Collectors.toList());
     }
 
     public void updateAssignment(QuizAssignmentDTO assignment, QuizAssignmentDTO updates) throws SegueDatabaseException {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
@@ -92,7 +92,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
 
         Date now = new Date();
 
-        if (newAssignment.getDueDate() != null && !newAssignment.isBeforeDueDate(now)) {
+        if (newAssignment.getDueDate() != null && !newAssignment.dueDateIsAfter(now)) {
             throw new DueBeforeNowException();
         }
 
@@ -100,7 +100,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
             newAssignment.getGroupId());
 
         if (existingQuizAssignments.size() != 0) {
-            if (existingQuizAssignments.stream().anyMatch(qa -> qa.getDueDate() == null || qa.isBeforeDueDate(now))) {
+            if (existingQuizAssignments.stream().anyMatch(qa -> qa.getDueDate() == null || qa.dueDateIsAfter(now))) {
                 log.error(String.format("Duplicated Test Assignment Exception - cannot assign the same work %s to a group %s when due date not passed",
                     newAssignment.getQuizId(), newAssignment.getGroupId()));
                 throw new DuplicateAssignmentException("You cannot reassign a test until the due date has passed.");
@@ -167,7 +167,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
 
     private List<QuizAssignmentDTO> filterActiveAssignments(List<QuizAssignmentDTO> assignments) {
         Date now = new Date();
-        return assignments.stream().filter(qa -> qa.getDueDate() == null || qa.isBeforeDueDate(now)).collect(Collectors.toList());
+        return assignments.stream().filter(qa -> qa.getDueDate() == null || qa.dueDateIsAfter(now)).collect(Collectors.toList());
     }
 
     public void updateAssignment(QuizAssignmentDTO assignment, QuizAssignmentDTO updates) throws SegueDatabaseException {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
@@ -32,6 +32,10 @@ public interface IAssignmentLike {
         Calendar cal = Calendar.getInstance();
         cal.setTimeInMillis(dueDate.getTime());
         cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.add(Calendar.DATE, 1);
         return cal.getTime().after(date);
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
@@ -5,6 +5,8 @@ import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
 
 import jakarta.annotation.Nullable;
+
+import java.util.Calendar;
 import java.util.Date;
 
 public interface IAssignmentLike {
@@ -19,6 +21,20 @@ public interface IAssignmentLike {
 
     @Nullable
     Date getDueDate();
+
+    default boolean isBeforeDueDate(Date date) {
+        Date dueDate = this.getDueDate();
+        if (null == dueDate) {
+            // This interprets null due dates as "assignment is due by the end of the universe"
+            return true;
+        }
+        // Compare date against midnight of the due date
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeInMillis(dueDate.getTime());
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.add(Calendar.DATE, 1);
+        return cal.getTime().before(date);
+    }
 
     interface Details<T extends IAssignmentLike> {
         String getAssignmentLikeName(T assignment) throws SegueDatabaseException, ContentManagerException;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
@@ -22,18 +22,18 @@ public interface IAssignmentLike {
     @Nullable
     Date getDueDate();
 
-    default boolean isBeforeDueDate(Date date) {
+    default boolean dueDateIsAfter(Date date) {
         Date dueDate = this.getDueDate();
         if (null == dueDate) {
             // This interprets null due dates as "assignment is due by the end of the universe"
-            return true;
+            return false;
         }
         // Compare date against midnight of the due date
         Calendar cal = Calendar.getInstance();
         cal.setTimeInMillis(dueDate.getTime());
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.add(Calendar.DATE, 1);
-        return date.before(cal.getTime());
+        return cal.getTime().after(date);
     }
 
     interface Details<T extends IAssignmentLike> {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
@@ -35,7 +35,6 @@ public interface IAssignmentLike {
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
-        cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.add(Calendar.DATE, 1);
         return cal.getTime().after(date);
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
@@ -33,7 +33,7 @@ public interface IAssignmentLike {
         cal.setTimeInMillis(dueDate.getTime());
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.add(Calendar.DATE, 1);
-        return cal.getTime().before(date);
+        return date.before(cal.getTime());
     }
 
     interface Details<T extends IAssignmentLike> {


### PR DESCRIPTION
~~By rounding down the scheduled start date to the nearest day in order to perform the comparison.~~ This now rounds the due date up to the beginning of the next day, using `isBeforeDueDate` to perform comparisons.

Should be merged with [the related app PR](https://github.com/isaacphysics/isaac-react-app/pull/663).

This also fixes an edge case where assignment emails might not be sent if an assignment start date is set to a given day or before it.

Care should be taken when reviewing to make sure the date/time logic is correct - I tried to make sure it was but these things are prone to syntactically subtle errors. 
**I think the test is failing because it was testing incorrect logic - I need a second opinion on this before I change it.**