### PR TITLE
Add a new validation response type for Item feedback

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ItemValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ItemValidationResponse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.dos;
+
+import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
+import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
+import uk.ac.cam.cl.dtg.isaac.dto.ItemValidationResponseDTO;
+
+import java.util.Date;
+import java.util.List;
+
+
+/**
+ *  Class for providing correctness feedback about individual items in a submitted Choice.
+ *
+ *  This is unlikely to be useful for {@link IsaacItemQuestion}'s, however, since to provide
+ *  detailed correctness feedback on them would enable questions to be answered trivially.
+ */
+@DTOMapping(ItemValidationResponseDTO.class)
+public class ItemValidationResponse extends QuestionValidationResponse {
+    private List<Boolean> itemsCorrect;
+
+    /**
+     * Default constructor for Jackson.
+     */
+    public ItemValidationResponse() {
+    }
+
+    /**
+     *  Full constructor.
+     *
+     * @param questionId - questionId.
+     * @param answer - answer.
+     * @param correct - correct.
+     * @param itemsCorrect - ordered list of correctness status of each submitted item.
+     * @param explanation - explanation.
+     * @param dateAttempted - dateAttempted.
+     */
+    public ItemValidationResponse(final String questionId, final Choice answer,
+                                  final Boolean correct, final List<Boolean> itemsCorrect,
+                                  final Content explanation, final Date dateAttempted) {
+        super(questionId, answer, correct, explanation, dateAttempted);
+        this.itemsCorrect = itemsCorrect;
+    }
+
+    public List<Boolean> getItemsCorrect() {
+        return itemsCorrect;
+    }
+
+    public void setItemsCorrect(final List<Boolean> itemsCorrect) {
+        this.itemsCorrect = itemsCorrect;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ItemValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ItemValidationResponseDTO.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.dto;
+
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacItemQuestion;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ChoiceDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ *  Class for providing correctness feedback about individual items in a submitted Choice.
+ *
+ *  This is unlikely to be useful for {@link IsaacItemQuestion}'s, however, since to provide
+ *  detailed correctness feedback on them would enable questions to be answered trivially.
+ */
+public class ItemValidationResponseDTO extends QuestionValidationResponseDTO {
+    private List<Boolean> itemsCorrect;
+
+    /**
+     * Default constructor for Jackson.
+     */
+    public ItemValidationResponseDTO() {
+    }
+
+    /**
+     *  Full constructor.
+     *
+     * @param questionId - questionId.
+     * @param answer - answer.
+     * @param correct - correct.
+     * @param itemsCorrect - ordered list of correctness status of each submitted item.
+     * @param explanation - explanation.
+     * @param dateAttempted - dateAttempted.
+     */
+    public ItemValidationResponseDTO(final String questionId, final ChoiceDTO answer,
+                                     final Boolean correct, final List<Boolean> itemsCorrect,
+                                     final ContentDTO explanation, final Date dateAttempted) {
+        super(questionId, answer, correct, explanation, dateAttempted);
+        this.itemsCorrect = itemsCorrect;
+    }
+
+    public List<Boolean> getItemsCorrect() {
+        return itemsCorrect;
+    }
+
+    public void setItemsCorrect(final List<Boolean> itemsCorrect) {
+        this.itemsCorrect = itemsCorrect;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseDeserializer.java
@@ -15,8 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.users;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -24,13 +22,15 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import uk.ac.cam.cl.dtg.segue.dao.content.ChoiceDeserializer;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentBaseDeserializer;
+import uk.ac.cam.cl.dtg.isaac.dos.ItemValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuantityValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
+import uk.ac.cam.cl.dtg.segue.dao.content.ChoiceDeserializer;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentBaseDeserializer;
+
+import java.io.IOException;
 
 /**
  * QuestionValidationResponse deserializer
@@ -80,6 +80,10 @@ public class QuestionValidationResponseDeserializer extends JsonDeserializer<Que
         String questionResponseType = root.get("answer").get("type").textValue();
         if (questionResponseType.equals("quantity")) {
             return mapper.readValue(jsonString, QuantityValidationResponse.class);
+        } else if (questionResponseType.equals("itemChoice")) {
+            // We don't actually use this validation response type for all ItemChoices, but it should
+            // be safe to use regardless of the "true" type because the null values will be excluded.
+            return mapper.readValue(jsonString, ItemValidationResponse.class);
         } else {
             return mapper.readValue(jsonString, QuestionValidationResponse.class);
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
@@ -17,6 +17,8 @@ package uk.ac.cam.cl.dtg.segue.dao.users;
 
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.metadata.Type;
+import uk.ac.cam.cl.dtg.isaac.dos.ItemValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dto.ItemValidationResponseDTO;
 import uk.ac.cam.cl.dtg.segue.dao.content.AbstractPolymorphicBidirectionalConverter;
 import uk.ac.cam.cl.dtg.isaac.dos.QuantityValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
@@ -50,6 +52,8 @@ public class QuestionValidationResponseOrikaConverter extends
 
         if (source instanceof QuantityValidationResponse) {
             return super.mapperFacade.map(source, QuantityValidationResponseDTO.class);
+        } else if (source instanceof ItemValidationResponse) {
+            return super.mapperFacade.map(source, ItemValidationResponseDTO.class);
         } else {
             // I would have expected this to cause an infinite loop / stack
             // overflow but apparently it doesn't.
@@ -69,6 +73,8 @@ public class QuestionValidationResponseOrikaConverter extends
 
         if (source instanceof QuantityValidationResponseDTO) {
             return super.mapperFacade.map(source, QuantityValidationResponse.class);
+        } else if (source instanceof ItemValidationResponseDTO) {
+            return super.mapperFacade.map(source, ItemValidationResponse.class);
         } else {
             // I would have expected this to cause an infinite loop / stack
             // overflow but apparently it doesn't.


### PR DESCRIPTION
As noted in the Javadoc, this new validation response type is named after Item questions but is unlikely to be useful for them directly. Instead it is needed for Cloze questions, which inherit from Item questions, and named generically in case it may later prove useful for Parsons questions also.