### PR TITLE
Detailed item feedback for cloze questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacClozeQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacClozeQuestion.java
@@ -32,6 +32,8 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 public class IsaacClozeQuestion extends IsaacItemQuestion {
 
     private Boolean withReplacement;
+    // Detailed feedback option not needed in the client so not in DTO:
+    private Boolean detailedItemFeedback;
 
     public Boolean getWithReplacement() {
         return withReplacement;
@@ -39,5 +41,13 @@ public class IsaacClozeQuestion extends IsaacItemQuestion {
 
     public void setWithReplacement(final Boolean withReplacement) {
         this.withReplacement = withReplacement;
+    }
+
+    public Boolean getDetailedItemFeedback() {
+        return detailedItemFeedback;
+    }
+
+    public void setDetailedItemFeedback(final Boolean detailedItemFeedback) {
+        this.detailedItemFeedback = detailedItemFeedback;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ItemValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ItemValidationResponse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.dos;
+
+import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
+import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
+import uk.ac.cam.cl.dtg.isaac.dto.ItemValidationResponseDTO;
+
+import java.util.Date;
+import java.util.List;
+
+
+/**
+ *  Class for providing correctness feedback about individual items in a submitted Choice.
+ *
+ *  This is unlikely to be useful for {@link IsaacItemQuestion}'s, however, since to provide
+ *  detailed correctness feedback on them would enable questions to be answered trivially.
+ */
+@DTOMapping(ItemValidationResponseDTO.class)
+public class ItemValidationResponse extends QuestionValidationResponse {
+    private List<Boolean> itemsCorrect;
+
+    /**
+     * Default constructor for Jackson.
+     */
+    public ItemValidationResponse() {
+    }
+
+    /**
+     *  Full constructor.
+     *
+     * @param questionId - questionId.
+     * @param answer - answer.
+     * @param correct - correct.
+     * @param itemsCorrect - ordered list of correctness status of each submitted item.
+     * @param explanation - explanation.
+     * @param dateAttempted - dateAttempted.
+     */
+    public ItemValidationResponse(final String questionId, final Choice answer,
+                                  final Boolean correct, final List<Boolean> itemsCorrect,
+                                  final Content explanation, final Date dateAttempted) {
+        super(questionId, answer, correct, explanation, dateAttempted);
+        this.itemsCorrect = itemsCorrect;
+    }
+
+    public List<Boolean> getItemsCorrect() {
+        return itemsCorrect;
+    }
+
+    public void setItemsCorrect(final List<Boolean> itemsCorrect) {
+        this.itemsCorrect = itemsCorrect;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ItemValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ItemValidationResponseDTO.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.dto;
+
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacItemQuestion;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ChoiceDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ *  Class for providing correctness feedback about individual items in a submitted Choice.
+ *
+ *  This is unlikely to be useful for {@link IsaacItemQuestion}'s, however, since to provide
+ *  detailed correctness feedback on them would enable questions to be answered trivially.
+ */
+public class ItemValidationResponseDTO extends QuestionValidationResponseDTO {
+    private List<Boolean> itemsCorrect;
+
+    /**
+     * Default constructor for Jackson.
+     */
+    public ItemValidationResponseDTO() {
+    }
+
+    /**
+     *  Full constructor.
+     *
+     * @param questionId - questionId.
+     * @param answer - answer.
+     * @param correct - correct.
+     * @param itemsCorrect - ordered list of correctness status of each submitted item.
+     * @param explanation - explanation.
+     * @param dateAttempted - dateAttempted.
+     */
+    public ItemValidationResponseDTO(final String questionId, final ChoiceDTO answer,
+                                     final Boolean correct, final List<Boolean> itemsCorrect,
+                                     final ContentDTO explanation, final Date dateAttempted) {
+        super(questionId, answer, correct, explanation, dateAttempted);
+        this.itemsCorrect = itemsCorrect;
+    }
+
+    public List<Boolean> getItemsCorrect() {
+        return itemsCorrect;
+    }
+
+    public void setItemsCorrect(final List<Boolean> itemsCorrect) {
+        this.itemsCorrect = itemsCorrect;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseDeserializer.java
@@ -15,8 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.users;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -24,13 +22,15 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import uk.ac.cam.cl.dtg.segue.dao.content.ChoiceDeserializer;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentBaseDeserializer;
+import uk.ac.cam.cl.dtg.isaac.dos.ItemValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuantityValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
+import uk.ac.cam.cl.dtg.segue.dao.content.ChoiceDeserializer;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentBaseDeserializer;
+
+import java.io.IOException;
 
 /**
  * QuestionValidationResponse deserializer
@@ -80,6 +80,10 @@ public class QuestionValidationResponseDeserializer extends JsonDeserializer<Que
         String questionResponseType = root.get("answer").get("type").textValue();
         if (questionResponseType.equals("quantity")) {
             return mapper.readValue(jsonString, QuantityValidationResponse.class);
+        } else if (questionResponseType.equals("itemChoice")) {
+            // We don't actually use this validation response type for all ItemChoices, but it should
+            // be safe to use regardless of the "true" type because the null values will be excluded.
+            return mapper.readValue(jsonString, ItemValidationResponse.class);
         } else {
             return mapper.readValue(jsonString, QuestionValidationResponse.class);
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
@@ -17,6 +17,8 @@ package uk.ac.cam.cl.dtg.segue.dao.users;
 
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.metadata.Type;
+import uk.ac.cam.cl.dtg.isaac.dos.ItemValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dto.ItemValidationResponseDTO;
 import uk.ac.cam.cl.dtg.segue.dao.content.AbstractPolymorphicBidirectionalConverter;
 import uk.ac.cam.cl.dtg.isaac.dos.QuantityValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
@@ -50,6 +52,8 @@ public class QuestionValidationResponseOrikaConverter extends
 
         if (source instanceof QuantityValidationResponse) {
             return super.mapperFacade.map(source, QuantityValidationResponseDTO.class);
+        } else if (source instanceof ItemValidationResponse) {
+            return super.mapperFacade.map(source, ItemValidationResponseDTO.class);
         } else {
             // I would have expected this to cause an infinite loop / stack
             // overflow but apparently it doesn't.
@@ -69,6 +73,8 @@ public class QuestionValidationResponseOrikaConverter extends
 
         if (source instanceof QuantityValidationResponseDTO) {
             return super.mapperFacade.map(source, QuantityValidationResponse.class);
+        } else if (source instanceof ItemValidationResponseDTO) {
+            return super.mapperFacade.map(source, ItemValidationResponse.class);
         } else {
             // I would have expected this to cause an infinite loop / stack
             // overflow but apparently it doesn't.

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidatorTest.java
@@ -18,11 +18,10 @@ package uk.ac.cam.cl.dtg.isaac.quiz;
 import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacClozeQuestion;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuickQuestion;
+import uk.ac.cam.cl.dtg.isaac.dos.ItemValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
@@ -146,6 +145,33 @@ public class IsaacClozeValidatorTest {
     }
 
     /*
+    Test that known incorrect answers can be matched.
+*/
+    @Test
+    public final void isaacClozeValidator_KnownIncorrectDetailedFeedback_IncorrectResponseShouldBeReturned() {
+        // Set up the question object:
+        IsaacClozeQuestion clozeQuestion = new IsaacClozeQuestion();
+        clozeQuestion.setItems(ImmutableList.of(item1, item2, item3));
+        clozeQuestion.setDetailedItemFeedback(true);
+
+        ItemChoice someCorrectAnswer = new ItemChoice();
+        someCorrectAnswer.setItems(ImmutableList.of(item1, item3));
+        someCorrectAnswer.setCorrect(true);
+        clozeQuestion.setChoices(ImmutableList.of(someCorrectAnswer));
+
+        // Set up user answer:
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, item2));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(clozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response instanceof ItemValidationResponse);
+        ItemValidationResponse clozeResponse = (ItemValidationResponse) response;
+        assertEquals(ImmutableList.of(true, false), clozeResponse.getItemsCorrect());
+    }
+
+    /*
          Test that all null-placeholder answers are rejected.
     */
     @Test
@@ -171,6 +197,20 @@ public class IsaacClozeValidatorTest {
         QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
         assertFalse(response.isCorrect());
         assertTrue(response.getExplanation().getValue().contains("does not contain an item for each gap"));
+    }
+
+    /*
+        Test that answers with too many items are rejected.
+    */
+    @Test
+    public final void isaacClozeValidator_TooManyItems_IncorrectResponseShouldBeReturned() {
+        ItemChoice c = new ItemChoice();
+        c.setItems(ImmutableList.of(item1, item2, item3));
+
+        // Test response:
+        QuestionValidationResponse response = validator.validateQuestionResponse(someClozeQuestion, c);
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("contains more items than gaps"));
     }
 
     /*
@@ -215,7 +255,7 @@ public class IsaacClozeValidatorTest {
     }
 
     /*
-        Test that missing choices are detected.
+        Test that default feedback is returned.
     */
     @Test
     public final void isaacClozeValidator_DefaultFeedbackReturned() {


### PR DESCRIPTION
This PR is blocked on #498 having been released, since as soon as question attempts using this new validation response are stored in the database they will be deserialised by older API versions which will fail to parse them. We need to release #498, and then wait a release cycle to merge this.

This adds a new `itemsCorrect` property to the validation response which is a list of correctnesses (true or false) for each of the submitted items.