### PR TITLE
Discard missing alt text errors for event thumbnails

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -945,8 +945,9 @@ public class ContentIndexer {
 
             // check that there is some alt text.
             if (f.getAltText() == null || f.getAltText().isEmpty()) {
-                if (!(f instanceof Video)) {
-                    // Videos probably don't need alt text unless there is a good reason.
+                if (!(f instanceof Video) && !f.getId().equals("eventThumbnail")) {
+                    // Videos probably don't need alt text unless there is a good reason. It's not important that event
+                    // thumbnails have alt text, so we don't record errors for those either.
                     this.registerContentProblem(content, "No altText attribute set for media element: " + f.getSrc()
                             + " in Git source file " + content.getCanonicalSourceFile(), indexProblemCache);
                 }


### PR DESCRIPTION
Very small change - it does rely on the oddity that all event page thumbnails share the same id, which seems kind of wrong? Shouldn't they have their own separate type instead?

I tested this locally with one of the regression test events, and it works as expected.