### PR TITLE
Add country field to user object

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
@@ -82,6 +82,7 @@ public class IsaacApplicationRegister extends Application {
             // Registers segue singleton endpoints as /isaac/segue/api
             // invoke optional service initialisation
             this.singletons.add(injector.getInstance(SchoolLookupServiceFacade.class));
+            this.singletons.add(injector.getInstance(CountryLookupFacade.class));
 
             // initialise segue framework.
             this.singletons.add(injector.getInstance(SegueContentFacade.class));

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/RegisteredUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/RegisteredUser.java
@@ -37,6 +37,8 @@ public class RegisteredUser extends AbstractSegueUser {
     private Date registrationDate;
     private String schoolId;
     private String schoolOther;
+    private String countryCode;
+
     private List<UserContext> registeredContexts;
     private Date registeredContextsLastConfirmed;
 
@@ -79,9 +81,13 @@ public class RegisteredUser extends AbstractSegueUser {
      */
     @JsonCreator
     public RegisteredUser(@JsonProperty("id") final Long id,
-            @JsonProperty("givenName") final String givenName, @JsonProperty("familyName") final String familyName,
-            @JsonProperty("email") final String email, @JsonProperty("role") final Role role,
-            @JsonProperty("dateOfBirth") final Date dateOfBirth, @JsonProperty("gender") final Gender gender,
+            @JsonProperty("givenName") final String givenName,
+            @JsonProperty("familyName") final String familyName,
+            @JsonProperty("email") final String email,
+            @JsonProperty("role") final Role role,
+            @JsonProperty("dateOfBirth") final Date dateOfBirth,
+            @JsonProperty("gender") final Gender gender,
+            @JsonProperty("countryCode") final String countryCode,
             @JsonProperty("registrationDate") final Date registrationDate,
             @JsonProperty("lastUpdated") final Date lastUpdated,
             @JsonProperty("emailToVerify") final String emailToVerify,
@@ -94,6 +100,7 @@ public class RegisteredUser extends AbstractSegueUser {
         this.role = role;
         this.dateOfBirth = dateOfBirth;
         this.gender = gender;
+        this.countryCode = countryCode;
         this.registrationDate = registrationDate;
         this.lastUpdated = lastUpdated;
         this.emailToVerify = emailToVerify;
@@ -256,6 +263,25 @@ public class RegisteredUser extends AbstractSegueUser {
     public final void setGender(final Gender gender) {
         this.gender = gender;
     }
+
+    /**
+     * Gets the country code.
+     *
+     * @return The country code
+     */
+    public final String getCountryCode() {
+        return countryCode;
+    }
+
+    /**
+     * Sets the country code.
+     *
+     * @param countryCode The country code to set
+     */
+    public final void setCountryCode(final String countryCode) {
+        this.countryCode = countryCode;
+    }
+
 
     /**
      * Gets the registrationDate.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserFromAuthProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserFromAuthProvider.java
@@ -15,6 +15,9 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dos.users;
 
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Null;
+
 import java.util.Date;
 
 /**
@@ -29,6 +32,7 @@ public class UserFromAuthProvider {
     private Date dateOfBirth;
     private Gender gender;
     private EmailVerificationStatus emailVerificationStatus;
+    private String countryCode;
 
     /**
      * Full constructor for the User object.
@@ -49,10 +53,13 @@ public class UserFromAuthProvider {
      *            - date of birth to help with monitoring
      * @param gender
      *            - gender of the user
+     * @param country
+     *            - country of the user (as ISO 3166 alpha-2 country code)
      */
     public UserFromAuthProvider(final String providerUserId, final String givenName, final String familyName,
-            final String email, final EmailVerificationStatus emailVerificationStatus, final Role role, 
-            final Date dateOfBirth, final Gender gender) {
+            final String email, final EmailVerificationStatus emailVerificationStatus, @Nullable final Role role,
+                                @Nullable final Date dateOfBirth, @Nullable final Gender gender,
+                                @Nullable final String country) {
         this.providerUserId = providerUserId;
         this.familyName = familyName;
         this.givenName = givenName;
@@ -60,6 +67,7 @@ public class UserFromAuthProvider {
         this.emailVerificationStatus = emailVerificationStatus;
         this.dateOfBirth = dateOfBirth;
         this.gender = gender;
+        this.countryCode = country;
     }
 
     /**
@@ -123,5 +131,14 @@ public class UserFromAuthProvider {
      */
     public Gender getGender() {
         return gender;
+    }
+
+    /**
+     * Gets the country code.
+     *
+     * @return the country code.
+     */
+    public String getCountryCode() {
+        return countryCode;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/RegisteredUserDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/RegisteredUserDTO.java
@@ -39,6 +39,7 @@ public class RegisteredUserDTO extends AbstractSegueUserDTO {
     private Date dateOfBirth;
     private Gender gender;
     private Date registrationDate;
+    private String countryCode;
 
     private String schoolId;
     private String schoolOther;
@@ -72,12 +73,16 @@ public class RegisteredUserDTO extends AbstractSegueUserDTO {
      */
     @JsonCreator
     public RegisteredUserDTO(
-            @JsonProperty("givenName") final String givenName, @JsonProperty("familyName") final String familyName,
+            @JsonProperty("givenName") final String givenName,
+            @JsonProperty("familyName") final String familyName,
             @JsonProperty("email") final String email, 
             @JsonProperty("verificationStatus") final EmailVerificationStatus emailVerificationStatus,
             @JsonProperty("dateOfBirth") final Date dateOfBirth,
-            @JsonProperty("gender") final Gender gender, @JsonProperty("registrationDate") final Date registrationDate,
-            @JsonProperty("schoolId") final String schoolId) {
+            @JsonProperty("gender") final Gender gender,
+            @JsonProperty("registrationDate") final Date registrationDate,
+            @JsonProperty("schoolId") final String schoolId,
+            @JsonProperty("countryCode") final String countryCode
+    ) {
         this.familyName = familyName;
         this.givenName = givenName;
         this.email = email;
@@ -85,6 +90,7 @@ public class RegisteredUserDTO extends AbstractSegueUserDTO {
         this.gender = gender;
         this.registrationDate = registrationDate;
         this.schoolId = schoolId;
+        this.countryCode = countryCode;
         this.emailVerificationStatus = emailVerificationStatus;
     }
 
@@ -321,6 +327,24 @@ public class RegisteredUserDTO extends AbstractSegueUserDTO {
      */
     public void setSchoolOther(final String schoolOther) {
         this.schoolOther = schoolOther;
+    }
+
+    /**
+     * Gets the country code.
+     *
+     * @return The country code.
+     */
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    /**
+     * Sets the country code.
+     *
+     * @param countryCode The country code.
+     */
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -561,6 +561,9 @@ public final class Constants {
         EMAIL_PREFERENCE
     }
 
+    public static final String CUSTOM_COUNTRY_CODES = "CUSTOM_COUNTRY_CODES";
+    public static final String PRIORITY_COUNTRY_CODES = "PRIORITY_COUNTRY_CODES";
+
     /**
      * Private constructor to prevent this class being created.
      */

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/CountryLookupFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/CountryLookupFacade.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Matthew Trew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.cl.dtg.segue.api;
+
+import com.google.inject.Inject;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.annotations.GZIP;
+import uk.ac.cam.cl.dtg.segue.api.managers.CountryLookupManager;
+
+import java.util.Locale;
+
+@Path("/countries")
+@Tag(name = "/countries")
+public class CountryLookupFacade {
+
+    private final CountryLookupManager countryLookupManager;
+
+    @Inject
+    public CountryLookupFacade(CountryLookupManager countryLookupManager) {
+        this.countryLookupManager = countryLookupManager;
+
+    }
+
+    @GET
+    @Path("/")
+    @Produces(MediaType.APPLICATION_JSON)
+    @GZIP
+    @Operation(summary = "Get a sorted map of all ISO 3166 country codes and display names.")
+    public Response countries() {
+        return Response.ok(countryLookupManager.getISOCountryCodesAndNames(Locale.ENGLISH.getLanguage())).build();
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/CountryLookupFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/CountryLookupFacade.java
@@ -45,8 +45,17 @@ public class CountryLookupFacade {
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
-    @Operation(summary = "Get a sorted map of all ISO 3166 country codes and display names.")
+    @Operation(summary = "Get a sorted map of all known country codes and display names.")
     public Response countries() {
-        return Response.ok(countryLookupManager.getISOCountryCodesAndNames(Locale.ENGLISH.getLanguage())).build();
+        return Response.ok(countryLookupManager.getCountryCodesAndNames()).build();
+    }
+
+    @GET
+    @Path("/priority")
+    @Produces(MediaType.APPLICATION_JSON)
+    @GZIP
+    @Operation(summary = "Get a sorted map of priority country codes and display names.")
+    public Response priorityCountries() {
+        return Response.ok(countryLookupManager.getPriorityCountryCodesAndNames()).build();
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/CountryLookupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/CountryLookupManager.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Matthew Trew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.cl.dtg.segue.api.managers;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class CountryLookupManager {
+
+    /**
+     * Maps of ISO country codes to display names in a particular language, keyed by language code.
+     */
+    public Map<String, Map<String, String>> isoCountryNamesCache;
+
+    public CountryLookupManager() {
+        isoCountryNamesCache = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Checks if the provided country code is known.
+     *
+     * @param countryCode an ISO 3166 alpha-2 country code.
+     * @return true if the country code is known, false otherwise.
+     */
+    public static boolean isKnownCountryCode(String countryCode) {
+        return List.of(Locale.getISOCountries()).contains(countryCode);
+    }
+
+    /**
+     * Returns a sorted {@link Map} of ISO 3166 country codes to display names for a particular language.
+     * The map is cached for re-use.
+     *
+     * @param isoLanguageCode An ISO 639 language code. The returned display names will be in this language.
+     * @return A {@link Map} of ISO 3166 alpha-2 country codes to display names, sorted alphabetically by display name.
+     */
+    public Map<String, String> getISOCountryCodesAndNames(String isoLanguageCode) {
+        if (null == isoCountryNamesCache.get(isoLanguageCode)) {
+            isoCountryNamesCache.put(isoLanguageCode, getSortedISOCountryCodesAndNamesForLanguage(isoLanguageCode));
+        }
+        return isoCountryNamesCache.get(isoLanguageCode);
+    }
+
+    private Map<String, String> getSortedISOCountryCodesAndNamesForLanguage(String isoLanguageCode) {
+        Map<String, String> countries = new HashMap<>();
+
+        for (String countryCode : Locale.getISOCountries()) {
+            countries.put(countryCode, new Locale(isoLanguageCode, countryCode).getDisplayCountry());
+        }
+
+        // Sort alphabetically by display name, ascending
+        return countries.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticator.java
@@ -250,7 +250,7 @@ public class FacebookAuthenticator implements IOAuth2Authenticator {
 			}
 
 			return new UserFromAuthProvider(userInfo.getId(), userInfo.getFirstName(),
-					userInfo.getLastName(), email, emailStatus, null, null, null);
+					userInfo.getLastName(), email, emailStatus, null, null, null, null);
 		} else {
 			throw new NoUserException("No user could be created from provider details!");
 		}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticator.java
@@ -248,7 +248,7 @@ public class GoogleAuthenticator implements IOAuth2Authenticator {
             }
 
             return new UserFromAuthProvider(userInfo.getId(), userInfo.getGivenName(), userInfo.getFamilyName(),
-                    email, emailStatus, null, null, null);
+                    email, emailStatus, null, null, null, null);
 
         } else {
             throw new NoUserException("No user could be created from provider details!");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticator.java
@@ -203,7 +203,7 @@ public class TwitterAuthenticator implements IOAuth1Authenticator {
                 }
 
                 return new UserFromAuthProvider(String.valueOf(userInfo.getId()), givenName, familyName, email,
-                        emailStatus, null, null, null);
+                        emailStatus, null, null, null, null);
             } else {
                 throw new NoUserException("No user could be created from provider details!");
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/UnknownCountryCodeException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/UnknownCountryCodeException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Matthew Trew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.ac.cam.cl.dtg.segue.auth.exceptions;
+
+public class UnknownCountryCodeException extends Exception {
+    public UnknownCountryCodeException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -69,6 +69,7 @@ import uk.ac.cam.cl.dtg.isaac.quiz.IsaacSymbolicLogicValidator;
 import uk.ac.cam.cl.dtg.isaac.quiz.IsaacSymbolicValidator;
 import uk.ac.cam.cl.dtg.isaac.quiz.PgQuestionAttempts;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.api.managers.CountryLookupManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.ExternalAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.GroupManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.IExternalAccountManager;
@@ -189,6 +190,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     private static SchoolListReader schoolListReader = null;
     private static AssignmentManager assignmentManager = null;
     private static IGroupObserver groupObserver = null;
+    private static CountryLookupManager countryLookupManager = null;
 
     private static Collection<Class<? extends ServletContextListener>> contextListeners;
     private static final Map<String, Reflections> reflections = com.google.common.collect.Maps.newHashMap();
@@ -856,6 +858,17 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
         }
 
         return misuseMonitor;
+    }
+
+    @Inject
+    @Provides
+    @Singleton
+    private CountryLookupManager getCountryLookupManager() {
+        if (null == countryLookupManager) {
+            countryLookupManager = new CountryLookupManager();
+            log.info("Creating singleton of CountryLookupManager");
+        }
+        return countryLookupManager;
     }
 
     /**

--- a/src/main/resources/db_scripts/migrations/2023-03-add-user-country-field.sql
+++ b/src/main/resources/db_scripts/migrations/2023-03-add-user-country-field.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ONLY public.users ADD COLUMN country_code char(2)
+    DEFAULT null;

--- a/src/main/resources/db_scripts/migrations/2023-03-add-user-country-field.sql
+++ b/src/main/resources/db_scripts/migrations/2023-03-add-user-country-field.sql
@@ -1,2 +1,2 @@
-ALTER TABLE ONLY public.users ADD COLUMN country_code char(2)
-    DEFAULT null;
+ALTER TABLE ONLY public.users ADD COLUMN country_code VARCHAR(255)
+    DEFAULT NULL;

--- a/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
+++ b/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.5 (Debian 13.5-1.pgdg110+1)
--- Dumped by pg_dump version 13.5 (Debian 13.5-1.pgdg110+1)
+-- Dumped from database version 12.9 (Debian 12.9-1.pgdg110+1)
+-- Dumped by pg_dump version 12.9 (Debian 12.9-1.pgdg110+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -718,7 +718,8 @@ CREATE TABLE public.users (
     email_to_verify text,
     email_verification_token text,
     session_token integer DEFAULT 0 NOT NULL,
-    deleted boolean DEFAULT false NOT NULL
+    deleted boolean DEFAULT false NOT NULL,
+    country_code character varying(255) DEFAULT NULL
 );
 
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -156,33 +156,33 @@ public class IsaacTest {
         // A bit scrappy, but hopefully sufficient.
         studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, true, null, null);
 
-        student = new RegisteredUserDTO("Some", "Student", "test-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "");
+        student = new RegisteredUserDTO("Some", "Student", "test-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null);
         student.setRole(Role.STUDENT);
         student.setId(++id);
 
-        teacher = new RegisteredUserDTO("Some", "Teacher", "test-teacher@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "");
+        teacher = new RegisteredUserDTO("Some", "Teacher", "test-teacher@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null);
         teacher.setRole(Role.TEACHER);
         teacher.setId(++id);
 
-        secondTeacher = new RegisteredUserDTO("Second", "Teacher", "second-teacher@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.PREFER_NOT_TO_SAY, somePastDate, "");
+        secondTeacher = new RegisteredUserDTO("Second", "Teacher", "second-teacher@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.PREFER_NOT_TO_SAY, somePastDate, "", null);
         secondTeacher.setRole(Role.TEACHER);
         secondTeacher.setId(++id);
 
-        otherTeacher = new RegisteredUserDTO("Other", "Teacher", "other-teacher@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.OTHER, somePastDate, "");
+        otherTeacher = new RegisteredUserDTO("Other", "Teacher", "other-teacher@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.OTHER, somePastDate, "", null);
         otherTeacher.setRole(Role.TEACHER);
         otherTeacher.setId(++id);
 
         noone = null;
 
-        secondStudent = new RegisteredUserDTO("Second", "Student", "second-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "");
+        secondStudent = new RegisteredUserDTO("Second", "Student", "second-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null);
         secondStudent.setRole(Role.STUDENT);
         secondStudent.setId(++id);
 
-        otherStudent = new RegisteredUserDTO("Other", "Student", "other-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "");
+        otherStudent = new RegisteredUserDTO("Other", "Student", "other-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null);
         otherStudent.setRole(Role.STUDENT);
         otherStudent.setId(++id);
 
-        adminUser = new RegisteredUserDTO("Test", "Admin", "test-admin@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.UNKNOWN, somePastDate, "");
+        adminUser = new RegisteredUserDTO("Test", "Admin", "test-admin@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.UNKNOWN, somePastDate, "", null);
         adminUser.setRole(Role.ADMIN);
         adminUser.setId(++id);
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GroupManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GroupManagerTest.java
@@ -30,14 +30,14 @@ public class GroupManagerTest extends AbstractManagerTest {
     @Test
     public void orderUsersByName_ordersBySurnamePrimarily() throws Exception {
         List<RegisteredUserDTO> users = Stream.of(
-                new RegisteredUserDTO("A", "Ab", "aab@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, ""),
-                new RegisteredUserDTO("B", "Ar", "bar@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, ""),
-                new RegisteredUserDTO("C", "Ax", "caz@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, ""),
-                new RegisteredUserDTO(null, "Ax", "NONEax@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, ""),
-                new RegisteredUserDTO("A", "Ba", "dba@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, ""),
-                new RegisteredUserDTO("B", "Bb", "ebb@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, ""),
-                new RegisteredUserDTO("C", "Bf", "fbf@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, ""),
-                new RegisteredUserDTO("A", null, "aNONE@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "")
+                new RegisteredUserDTO("A", "Ab", "aab@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null),
+                new RegisteredUserDTO("B", "Ar", "bar@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null),
+                new RegisteredUserDTO("C", "Ax", "caz@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null),
+                new RegisteredUserDTO(null, "Ax", "NONEax@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null),
+                new RegisteredUserDTO("A", "Ba", "dba@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null),
+                new RegisteredUserDTO("B", "Bb", "ebb@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null),
+                new RegisteredUserDTO("C", "Bf", "fbf@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null),
+                new RegisteredUserDTO("A", null, "aNONE@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null)
         ).peek(user -> user.setId((long) ("" + user.getGivenName() + user.getFamilyName()).hashCode())).collect(Collectors.toList());
 
         List<RegisteredUserDTO> shuffledUsers = new ArrayList<>(users);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -192,7 +192,7 @@ public class UserManagerTest {
         String validDateString = sdf.format(calendar.getTime());
 
         RegisteredUser returnUser = new RegisteredUser(validUserId, "TestFirstName", "TestLastName", "", Role.STUDENT,
-                new Date(), Gender.MALE, new Date(), null, null, null,null);
+                new Date(), Gender.MALE, null, new Date(), null, null, null,null);
         returnUser.setId(validUserId);
         returnUser.setSessionToken(0);
 
@@ -369,7 +369,7 @@ public class UserManagerTest {
 
         // User object back from provider
         UserFromAuthProvider providerUser = new UserFromAuthProvider(someProviderUniqueUserId, "TestFirstName",
-                "TestLastName", "test@test.com", EmailVerificationStatus.VERIFIED, Role.STUDENT, new Date(), Gender.MALE);
+                "TestLastName", "test@test.com", EmailVerificationStatus.VERIFIED, Role.STUDENT, new Date(), Gender.MALE, null);
 
         // Mock get User Information from provider call
         expect(((IFederatedAuthenticator) dummyAuth).getUserInfo(someProviderGeneratedLookupValue)).andReturn(
@@ -381,7 +381,7 @@ public class UserManagerTest {
                 .atLeastOnce();
 
         RegisteredUser mappedUser = new RegisteredUser(null, "TestFirstName", "testLastName", "test@test.com", Role.STUDENT,
-                new Date(), Gender.MALE, new Date(), null, null,null, null);
+                new Date(), Gender.MALE, null, new Date(), null, null, null, null);
         mappedUser.setSessionToken(0);
 
         expect(dummyDatabase.getAuthenticationProvidersByUsers(Collections.singletonList(mappedUser)))
@@ -539,7 +539,7 @@ public class UserManagerTest {
         HttpServletRequest request = createMock(HttpServletRequest.class);
 
         RegisteredUser mappedUser = new RegisteredUser(null, "TestFirstName", "testLastName", "test@test.com", Role.STUDENT,
-                new Date(), Gender.MALE, new Date(), null, null,null, null);
+                new Date(), Gender.MALE, null, new Date(), null, null, null, null);
         mappedUser.setSessionToken(0);
 
         String validUserId = "123";
@@ -580,7 +580,7 @@ public class UserManagerTest {
         String validDateString = sdf.format(calendar.getTime());
 
         RegisteredUser mappedUser = new RegisteredUser(null, "TestFirstName", "testLastName", "test@test.com", Role.STUDENT,
-                new Date(), Gender.MALE, new Date(), null, null,null, null);
+                new Date(), Gender.MALE, null, new Date(), null, null, null, null);
         mappedUser.setSessionToken(0);
 
         Map<String, String> validSessionInformation = getSessionInformationAsAMap(authManager, validUserId,
@@ -620,7 +620,7 @@ public class UserManagerTest {
 
         String validUserId = "123";
         RegisteredUser mappedUser = new RegisteredUser(null, "TestFirstName", "testLastName", "test@test.com", Role.STUDENT,
-                new Date(), Gender.MALE, new Date(), null, null,null, null);
+                new Date(), Gender.MALE, null, new Date(), null, null, null, null);
         mappedUser.setSessionToken(0);
 
         Calendar calendar = Calendar.getInstance();
@@ -657,7 +657,7 @@ public class UserManagerTest {
 
         String validUserId = "123";
         RegisteredUser mappedUser = new RegisteredUser(null, "TestFirstName", "testLastName", "test@test.com", Role.STUDENT,
-                new Date(), Gender.MALE, new Date(), null, null,null, null);
+                new Date(), Gender.MALE, null, new Date(), null, null, null, null);
         mappedUser.setSessionToken(1);
         Integer incorrectSessionToken = 0;
 


### PR DESCRIPTION
Also creates an endpoint, `/countries`, through which the list of known countries (ISO 3166 country codes) can be retrieved.

---

**Pull Request Check List**
- ~~Unit Tests & Regression Tests Added (Optional)~~
- ~~Removed Unnecessary Logs/System.Outs/Comments/TODOs~~
- [x] Added enough Logging to monitor expected behaviour change
- ~~Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped~~
- ~~Security - Data Exposure - PII is not stored or sent unencrypted~~
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Security - Access Control - Check authorisation on every new endpoint
- ~~Security - New dependency - configured sensibly not relying on defaults~~
- ~~Security - New dependency - Searched for any know vulnerabilities~~
- ~~Security - New dependency - Signed up team to mailing list~~
- ~~Security - New dependency - Added to dependency list~~
- [x] DB schema changes - postgres-rutherford-create-script updated
- [x] DB schema changes - upgrade script created matching create script
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
