### PR TITLE
Numeric question exact match unit check improvement

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -513,10 +513,19 @@ public class IsaacNumericValidator implements IValidator {
                                                         final Quantity answerFromUser) {
 
         log.debug("\t[exactStringMatch]");
+        boolean wasACorrectAnswerWithUsersSelectedUnit = false;
 
-        for (Choice c : isaacNumericQuestion.getChoices()) {
+        // Goes through correct answers first, in order to work out whether any correct answers match the units that
+        // the user selected.
+        List<Choice> orderedChoices = getOrderedChoices(isaacNumericQuestion.getChoices());
+        for (Choice c : orderedChoices) {
             if (c instanceof Quantity) {
                 Quantity quantityFromQuestion = (Quantity) c;
+
+                // Record whether the units the user selected match the units of a correct answer
+                if (isaacNumericQuestion.getRequireUnits()) {
+                    wasACorrectAnswerWithUsersSelectedUnit |= quantityFromQuestion.getUnits().equals(answerFromUser.getUnits()) && quantityFromQuestion.isCorrect();
+                }
 
                 StringBuilder userStringForComparison = new StringBuilder();
                 userStringForComparison.append(answerFromUser.getValue().trim());
@@ -531,14 +540,14 @@ public class IsaacNumericValidator implements IValidator {
                 }
 
                 if (questionAnswerString.toString().trim().equals(userStringForComparison.toString().trim())) {
-                    Boolean unitFeedback = null;
+                    Boolean unitsCorrect = null;
                     if (isaacNumericQuestion.getRequireUnits()) {
-                        unitFeedback = quantityFromQuestion.getUnits().equals(answerFromUser.getUnits());
+                        unitsCorrect = wasACorrectAnswerWithUsersSelectedUnit || quantityFromQuestion.isCorrect();
                     }
 
                     return new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser,
                             quantityFromQuestion.isCorrect(), (Content) quantityFromQuestion.getExplanation(),
-                            quantityFromQuestion.isCorrect(), unitFeedback, new Date());
+                            quantityFromQuestion.isCorrect(), unitsCorrect, new Date());
                 }
             }
         }


### PR DESCRIPTION
Allows incorrect units to be marked as such in numeric q "exact match" checks.

`/questions/orbiting_moon` is a good test case - 1410 kJ is a known wrong answer, but kJ is never a correct unit (occurs in none of the correct answers). However when you give 1410 kJ as the answer, the unit isn't marked as incorrect. Funnily enough, the unit _is_ marked as incorrect if you answer with 1410.0 kJ.