### PR TITLE
Add limit query param to school search endpoint

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/SchoolLookupServiceFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/SchoolLookupServiceFacade.java
@@ -74,6 +74,8 @@ public class SchoolLookupServiceFacade {
      *            - find by urn.
      * @param searchQuery
      *            - query to search fields against.
+     * @param limit
+     *            - limit the number of results returned.
      * @return A response containing a list of school objects or a SegueErrorResponse.
      */
     @GET
@@ -82,7 +84,7 @@ public class SchoolLookupServiceFacade {
     @GZIP
     @Operation(summary = "List all schools matching provided criteria.")
     public Response schoolSearch(@Context final Request request, @QueryParam("query") final String searchQuery,
-            @QueryParam("urn") final String schoolURN) {
+            @QueryParam("urn") final String schoolURN, @QueryParam("limit") final Integer limit) {
 
         if ((null == searchQuery || searchQuery.isEmpty()) && (null == schoolURN || schoolURN.isEmpty())) {
             return new SegueErrorResponse(Status.BAD_REQUEST, "You must provide a search query or school URN")
@@ -110,7 +112,7 @@ public class SchoolLookupServiceFacade {
             if (schoolURN != null && !schoolURN.isEmpty()) {
                 list = Arrays.asList(schoolListReader.findSchoolById(schoolURN));
             } else {
-                list = schoolListReader.findSchoolByNameOrPostCode(searchQuery);    
+                list = schoolListReader.findSchoolByNameOrPostCode(searchQuery, limit);
             }
             
         } catch (UnableToIndexSchoolsException | SegueSearchException | IOException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/SchoolListReader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/SchoolListReader.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.util.Lists;
 import com.google.inject.Inject;
+import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.dos.users.School;
@@ -77,23 +78,27 @@ public class SchoolListReader {
 
     /**
      * findSchoolByNameOrPostCode.
-     * 
+     *
      * @param searchQuery
      *            - school to search for - either name or postcode.
+     * @param limit
+     *            - the number of results to return.
      * @return list of schools matching the criteria or an empty list.
      * @throws UnableToIndexSchoolsException
      *             - if there is an error access the index of schools.
      */
-    public List<School> findSchoolByNameOrPostCode(final String searchQuery) throws UnableToIndexSchoolsException, SegueSearchException {
+    public List<School> findSchoolByNameOrPostCode(final String searchQuery, @Nullable final Integer limit) throws UnableToIndexSchoolsException, SegueSearchException {
         if (!this.ensureSchoolList()) {
             log.error("Unable to ensure school search cache.");
             throw new UnableToIndexSchoolsException("unable to ensure the cache has been populated");
         }
 
+        Integer queryLimit = limit == null ? DEFAULT_RESULTS_LIMIT : limit;
+
         // FIXME: for one release cycle, we need backwards compatibility and so cannot use the fieldsThatMustMatch property
         // It should be set to ImmutableMap.of("closed", ImmutableList.of("false"))
         List<String> schoolSearchResults = searchProvider.fuzzySearch(SCHOOLS_INDEX_BASE, SCHOOLS_INDEX_TYPE.SCHOOL_SEARCH.toString(),
-                searchQuery, 0, DEFAULT_RESULTS_LIMIT, null, null, SCHOOL_URN_FIELDNAME_POJO,
+                searchQuery, 0, queryLimit, null, null, SCHOOL_URN_FIELDNAME_POJO,
                 SCHOOL_ESTABLISHMENT_NAME_FIELDNAME_POJO, SCHOOL_POSTCODE_FIELDNAME_POJO)
                 .getResults();
 


### PR DESCRIPTION
Small PR to add an optional limit query param to the school search endpoint

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- ~Added enough Logging to monitor expected behaviour change~
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- ~Security - Access Control - Check authorisation on every new endpoint~
- ~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~
- [ ] Peer-Reviewed
