### PR TITLE
Enable GZIP correctly

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -1145,7 +1145,6 @@ public class AssignmentFacade extends AbstractIsaacFacade {
     @DELETE
     @Path("/assign/{gameboard_id}/{group_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Delete an assignment by board ID and group ID.")
     public Response deleteAssignment(@Context final HttpServletRequest request,
                                      @PathParam("gameboard_id") final String gameboardId, @PathParam("group_id") final Long groupId) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -369,7 +369,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GET
     @Path("/{event_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Get details about a specific event.")
     public final Response getEvent(@Context final HttpServletRequest request,
             @PathParam("event_id") final String eventId) {
@@ -400,7 +399,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GET
     @Path("/bookings/count")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Count all event bookings.")
     public final Response getCountForAllEventBookings(@Context final HttpServletRequest request) {
         try {
@@ -431,7 +429,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GET
     @Path("/bookings/{booking_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Get details about an event booking.")
     public final Response getEventBookingsById(@Context final HttpServletRequest request,
                                                @PathParam("booking_id") final String bookingId) {
@@ -471,7 +468,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @POST
     @Path("{event_id}/bookings/{user_id}/promote")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Move a user from an event waiting list, reservation or cancellation to a confirmed booking.")
     public final Response promoteBooking(@Context final HttpServletRequest request,
                                          @PathParam("event_id") final String eventId,
@@ -532,7 +528,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GET
     @Path("{event_id}/bookings")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "List event bookings for a specific event.")
     public final Response adminGetEventBookingByEventId(@Context final HttpServletRequest request,
             @PathParam("event_id") final String eventId) {
@@ -567,7 +562,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GET
     @Path("{event_id}/bookings/for_group/{group_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "List event bookings for a specific event and group.")
     public final Response getEventBookingForGivenGroup(@Context final HttpServletRequest request,
                                                        @PathParam("event_id") final String eventId,
@@ -623,7 +617,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GET
     @Path("{event_id}/groups_bookings")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "List event bookings for a specific event")
     public final Response getEventBookingForAllGroups(@Context final HttpServletRequest request,
                                                        @PathParam("event_id") final String eventId) {
@@ -665,7 +658,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GET
     @Path("{event_id}/bookings/download")
     @Produces("text/csv")
-    @GZIP
     @Operation(summary = "Download event attendance csv.")
     public Response getEventBookingCSV(@Context final HttpServletRequest request,
                                                    @PathParam("event_id") final String eventId) {
@@ -793,7 +785,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @POST
     @Path("{event_id}/bookings/{user_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Create an event booking for a user.")
     public final Response createBookingForGivenUser(@Context final HttpServletRequest request,
                                                     @PathParam("event_id") final String eventId,
@@ -951,7 +942,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @POST
     @Path("{event_id}/reservations/cancel")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Cancel a reservations on an event for a set of users.")
     public final Response cancelReservations(@Context final HttpServletRequest request,
                                         @PathParam("event_id") final String eventId,
@@ -1027,7 +1017,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @POST
     @Path("{event_id}/bookings")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Create an event booking for the current user.")
     public final Response createBookingForMe(@Context final HttpServletRequest request,
                                              @PathParam("event_id") final String eventId,
@@ -1116,7 +1105,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @POST
     @Path("{event_id}/waiting_list")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Add the current user to an event waiting list.")
     public final Response addMeToWaitingList(@Context final HttpServletRequest request,
                                              @PathParam("event_id") final String eventId,
@@ -1174,7 +1162,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @DELETE
     @Path("{event_id}/bookings/cancel")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Cancel the current user's booking on an event.")
     public final Response cancelBooking(@Context final HttpServletRequest request,
                                         @PathParam("event_id") final String eventId) {
@@ -1195,7 +1182,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @DELETE
     @Path("{event_id}/bookings/{user_id}/cancel")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Cancel a user's booking on an event.")
     public final Response cancelBooking(@Context final HttpServletRequest request,
                                         @PathParam("event_id") final String eventId,
@@ -1271,7 +1257,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @POST
     @Path("{event_id}/bookings/{user_id}/resend_confirmation")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Resend an event booking confirmation to a user.")
     public final Response resendEventEmail(@Context final HttpServletRequest request,
                                            @PathParam("event_id") final String eventId,
@@ -1324,7 +1309,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @DELETE
     @Path("{event_id}/bookings/{user_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Erase a user's booking on an event.",
                   description = "This method removes the booking entirely, rather than recording the booking as cancelled.")
     public final Response deleteBooking(@Context final HttpServletRequest request,
@@ -1382,7 +1366,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     @POST
     @Path("{event_id}/bookings/{user_id}/record_attendance")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Update the attendance status of a user for an event.")
     public final Response recordEventAttendance(@Context final HttpServletRequest request,
                                                 @PathParam("event_id") final String eventId,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -257,7 +257,6 @@ public class IsaacController extends AbstractIsaacFacade {
     @GET
     @Produces("*/*")
     @Path("images/{path:.*}")
-    @GZIP
     @Operation(summary = "Get a binary object from the current content version.",
                   description = "This can only be used to get images from the content database.")
     public final Response getImageByPath(@Context final Request request, @Context final HttpServletRequest httpServletRequest,
@@ -358,7 +357,6 @@ public class IsaacController extends AbstractIsaacFacade {
     @GET
     @Produces("*/*")
     @Path("documents/{path:.*}")
-    @GZIP
     @Operation(summary = "Get a binary object from the current content version.",
                   description = "This can only be used to get PDF documents from the content database.")
     public final Response getDocumentByPath(@Context final Request request, @Context final HttpServletRequest httpServletRequest,
@@ -434,7 +432,6 @@ public class IsaacController extends AbstractIsaacFacade {
     @GET
     @Path("users/current_user/progress")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Get progress information for the current user.")
     public final Response getCurrentUserProgressInformation(@Context final HttpServletRequest request) {
         RegisteredUserDTO user;
@@ -457,7 +454,6 @@ public class IsaacController extends AbstractIsaacFacade {
     @GET
     @Path("users/current_user/snapshot")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Get snapshot for the current user.")
     public final Response getCurrentUserSnapshot(@Context final HttpServletRequest request) {
         RegisteredUserDTO user;
@@ -496,7 +492,6 @@ public class IsaacController extends AbstractIsaacFacade {
     @GET
     @Path("users/{user_id}/progress")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Get progress information for a specified user.")
     public final Response getUserProgressInformation(@Context final HttpServletRequest request,
             @PathParam("user_id") final Long userIdOfInterest) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
@@ -115,7 +115,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @GET
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "List all users granted access to the current user's data.")
     public Response getUsersWithAccess(@Context final HttpServletRequest request) throws NoUserException {
         try {
@@ -140,7 +139,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @GET
     @Path("/{userId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "List all users granted access to the specified user's data.")
     public Response getUsersWithAccessSpecificUser(@Context final HttpServletRequest request, @PathParam("userId") Long userId) throws NoUserException {
         try {
@@ -184,7 +182,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @DELETE
     @Path("/{userId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Revoke a specific user's access to the current user's data.")
     public Response revokeOwnerAssociation(@Context final HttpServletRequest request,
             @PathParam("userId") final Long userIdToRevoke) {
@@ -223,7 +220,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @DELETE
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Revoke all users granted access to the current user's data.")
     public Response revokeAllOwnerAssociations(@Context final HttpServletRequest request) {
         try {
@@ -261,7 +257,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @DELETE
     @Path("release/{userId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Release the current user's access to another user's data.")
     public Response releaseAssociation(@Context final HttpServletRequest request,
                                        @PathParam("userId") final Long associationOwner) {
@@ -302,7 +297,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @DELETE
     @Path("release")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Release the current user's access to all other users's data.")
     public Response releaseAllAssociations(@Context final HttpServletRequest request) {
         try {
@@ -337,7 +331,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @GET
     @Path("/other_users")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "List all users the current user has been granted access by.")
     public Response getCurrentAccessRights(@Context final HttpServletRequest request) throws NoUserException {
         try {
@@ -362,7 +355,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @GET
     @Path("/other_users/{userId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "List all users the specified user has been granted access by.")
     public Response getCurrentAccessRightsForSpecificUser(@Context final HttpServletRequest request, @PathParam("userId") Long userId) throws NoUserException{
         try {
@@ -407,7 +399,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @GET
     @Path("/token/{groupId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Get the group join token for the specified group.")
     public Response getAssociationToken(@Context final HttpServletRequest request,
             @PathParam("groupId") final Long groupId) {
@@ -455,7 +446,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @Path("/token/{token}/owner")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "List the users a group join token will grant access to.")
     public Response getTokenOwnerUserSummary(@Context final HttpServletRequest request,
             @PathParam("token") final String token) {
@@ -516,7 +506,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
     @Path("/use_token/{token}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Use a group join token to authorise users and join a group.",
                   description = "This should be used after listing the group owners and managers and asking the user's permission to share data.")
     public Response useToken(@Context final HttpServletRequest request, @PathParam("token") final String token) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -133,7 +133,6 @@ public class EmailFacade extends AbstractSegueFacade {
     @GET
     @Path("/email/viewinbrowser/{id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Get an email by ID.",
                   description =  "The details of the current user will be used to fill in template fields.")
     public final Response getEmailInBrowserById(@Context final HttpServletRequest request,
@@ -235,7 +234,6 @@ public class EmailFacade extends AbstractSegueFacade {
     @Path("/users/verifyemail/{userid}/{token}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Verify an email verification token is valid for use.")
     public Response validateEmailVerificationRequest(@PathParam("userid") final Long userId,
                                                      @PathParam("token") final String token) {
@@ -273,7 +271,6 @@ public class EmailFacade extends AbstractSegueFacade {
     @POST
     @Path("/users/verifyemail")
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Initiate an email verification request.",
                   description = "The email to verify must be provided as 'email' in the request body.")
     public Response generateEmailVerificationToken(@Context final HttpServletRequest request,
@@ -331,7 +328,6 @@ public class EmailFacade extends AbstractSegueFacade {
     @Path("/email/sendemail/{contentid}/{emailtype}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Send an email to all users of a specific role.")
     public final Response sendEmails(@Context final HttpServletRequest request,
 		    		@PathParam("contentid") final String contentId, 
@@ -416,7 +412,6 @@ public class EmailFacade extends AbstractSegueFacade {
     @Path("/email/sendemailwithuserids/{contentid}/{emailtype}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Send an email to a list of user IDs.")
     public final Response sendEmailsToUserIds(@Context final HttpServletRequest request,
             @PathParam("contentid") final String contentId, @PathParam("emailtype") final String emailTypeString,
@@ -511,7 +506,6 @@ public class EmailFacade extends AbstractSegueFacade {
     @Path("/email/sendprovidedemailwithuserids/{emailtype}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Send an email to a list of user IDs.")
     public final Response sendProvidedEmailWithUserIds(@Context final HttpServletRequest request,
                                               @PathParam("emailtype") final String emailTypeString,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
@@ -21,6 +21,7 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
@@ -85,6 +86,7 @@ public class GlossaryFacade extends AbstractSegueFacade {
     @GET
     @Path("terms")
     @Produces(MediaType.APPLICATION_JSON)
+    @GZIP
     @Operation(summary = "Get all the glossary terms that are indexed.")
     public final Response getTerms(@QueryParam("start_index") final String startIndex,
                                    @QueryParam("limit") final String limit) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -150,7 +150,6 @@ public class UsersFacade extends AbstractSegueFacade {
     @GET
     @Path("users/current_user")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Get information about the current user.")
     public Response getCurrentUserEndpoint(@Context final Request request,
                                            @Context final HttpServletRequest httpServletRequest,
@@ -196,7 +195,6 @@ public class UsersFacade extends AbstractSegueFacade {
     @Path("users")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Create a new user or update an existing user.")
     public Response createOrUpdateUserSettings(@Context final HttpServletRequest request,
                                                @Context final HttpServletResponse response,
@@ -312,7 +310,6 @@ public class UsersFacade extends AbstractSegueFacade {
     @POST
     @Path("users/{user_id}/resetpassword")
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Request password reset for another user.")
     public Response generatePasswordResetTokenForOtherUser(@Context final Request request,
                                                            @Context final HttpServletRequest httpServletRequest,
@@ -385,7 +382,6 @@ public class UsersFacade extends AbstractSegueFacade {
     @POST
     @Path("users/resetpassword")
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Request password reset for an email address.",
                   description = "The email address must be provided as a RegisteredUserDTO object, although only the 'email' field is required.")
     public Response generatePasswordResetToken(final RegisteredUserDTO userObject,
@@ -440,7 +436,6 @@ public class UsersFacade extends AbstractSegueFacade {
     @GET
     @Path("users/resetpassword/{token}")
     @Produces(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Verify a password reset token is valid for use.")
     public Response validatePasswordResetRequest(@PathParam("token") final String token) {
         try {
@@ -473,7 +468,6 @@ public class UsersFacade extends AbstractSegueFacade {
     @POST
     @Path("users/resetpassword/{token}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @GZIP
     @Operation(summary = "Reset an account password using a reset token.",
                   description = "The 'token' should be generated using one of the endpoints for requesting a password reset.")
     public Response resetPassword(@PathParam("token") final String token, final Map<String, String> clientResponse,

--- a/web-api-live.xml
+++ b/web-api-live.xml
@@ -55,7 +55,8 @@
             uk.ac.cam.cl.dtg.isaac.configuration.exceptionMappers.UnhandledExceptionMapper,
             uk.ac.cam.cl.dtg.isaac.configuration.exceptionMappers.OptionsMethodExceptionMapper,
             uk.ac.cam.cl.dtg.isaac.configuration.exceptionMappers.MethodNotAllowedExceptionMapper,
-            uk.ac.cam.cl.dtg.segue.configuration.exceptionMappers.JacksonInvalidFormatExceptionMapper
+            uk.ac.cam.cl.dtg.segue.configuration.exceptionMappers.JacksonInvalidFormatExceptionMapper,
+            org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor
         </param-value>
     </context-param>
 

--- a/web-api-local.xml
+++ b/web-api-local.xml
@@ -55,7 +55,8 @@
             uk.ac.cam.cl.dtg.isaac.configuration.exceptionMappers.UnhandledExceptionMapper,
             uk.ac.cam.cl.dtg.isaac.configuration.exceptionMappers.OptionsMethodExceptionMapper,
             uk.ac.cam.cl.dtg.isaac.configuration.exceptionMappers.MethodNotAllowedExceptionMapper,
-            uk.ac.cam.cl.dtg.segue.configuration.exceptionMappers.JacksonInvalidFormatExceptionMapper
+            uk.ac.cam.cl.dtg.segue.configuration.exceptionMappers.JacksonInvalidFormatExceptionMapper,
+            org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor
         </param-value>
     </context-param>
 


### PR DESCRIPTION
This PR correctly enables the `@GZIP` annotation, which has not been functional in a long time. I noticed it yesterday when looking at the `/terms` endpoint, which was one of the largest requests when loading the homepage. Despite adding the annotation, the response was still not gzipped.

It turns out we need to register an interceptor in order for RESTEasy to do this for us, which this PR does.

However, it is not sensible to GZIP all responses, as those which reflect user-generated content can be used to oracle-attack any secret data in a request body ([the BREACH attack](https://techcommunity.microsoft.com/t5/iis-support-blog/breach-vulnerability/ba-p/2385272)). Requests that do not contain PII or secrets are safe, since there is nothing worth attacking. The attack itself is unlikely to be feasible on the modern web with samesite cookies and CSP protection, but we weren't gzipping anything _before_ now anyhow, so removing it from some endpoints won't do any harm!

Adding GZIP to SVG images but not binary ones took a little complexity, but it does make a major difference to bandwidth!

The only thing to monitor with this PR is increased CPU usage and request times, but the gzipping is asynchronous and done in each request thread separately.