### PR TITLE
Better question_id LIKE matching

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
@@ -54,7 +54,7 @@ import static uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager.extractPageIdF
  */
 public class PgQuestionAttempts implements IQuestionAttemptManager {
     private static final Logger log = LoggerFactory.getLogger(PgQuestionAttempts.class);
-    private static final int MAX_PAGE_IDS_TO_MATCH = 200;
+    private static final int MAX_PAGE_IDS_TO_MATCH = 100;
             
     private final PostgresSqlDb database;
     private final ObjectMapper objectMapper;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
@@ -325,8 +325,9 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
                 }
 
                 for (String pageId : uniquePageIds) {
-                    // Using LIKE matching on part IDs, so add wildcard to each page ID:
-                    pst.setString(index++, pageId + "%");
+                    // Using LIKE matching on part IDs; add % wildcard to end of each page ID, and ensure any underscores
+                    // in the ID are escaped and not treated as wildcard characters themselves:
+                    pst.setString(index++, pageId.replace("_", "\\_") + "%");
                 }
 
                 try (ResultSet results = pst.executeQuery()) {


### PR DESCRIPTION
When we use LIKE matching to find question IDs based on the page ID, we do `question_id LIKE 'page_id%'`. However, the underscore character commonly found in our page IDs is treated as a wildcard, which means that the index scan looks for `>= page` and `< pagf` rather than using the full intended `>= page_id` and `< page_ie`!

Coupled to the fact that each set of book questions shares a common prefix (e.g. `gcse_`), this means that the matches were needlessly broad and the subsequent filtering was then having to remove many rows and pages that could easily have been excluded in the index scan.

Adding this escaping leads to a ~50% speedup for a common query for our most active users.

I'm 99% confident this escaping is always safe, and have tested it locally.