### PR TITLE
Cookie updates

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -80,6 +80,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.eclipse.jetty.http.HttpCookie.SAME_SITE_STRICT_COMMENT;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
@@ -508,8 +509,9 @@ public class UserAuthenticationManager {
             logoutCookie.setPath("/");
             logoutCookie.setMaxAge(0);  // This will lead to it being removed by the browser immediately.
             logoutCookie.setHttpOnly(true);
-            // TODO - set sameSite=Lax at minimum when Jetty supports this (9.4.x)
             logoutCookie.setSecure(true);
+            // TODO - set sameSite without the setComment hack when setAttribute is available.
+            logoutCookie.setComment(SAME_SITE_STRICT_COMMENT);
 
             response.addCookie(logoutCookie);
         } catch (IllegalStateException e) {
@@ -928,8 +930,9 @@ public class UserAuthenticationManager {
             authCookie.setMaxAge(sessionExpiryTimeInSeconds);
             authCookie.setPath("/");
             authCookie.setHttpOnly(true);
-            // TODO - set sameSite=Lax at minimum when Jetty supports this (9.4.x)
             authCookie.setSecure(true);
+            // TODO - set sameSite without the setComment hack when setAttribute is available.
+            authCookie.setComment(SAME_SITE_STRICT_COMMENT);
 
             log.debug(String.format("Creating AuthCookie for user (%s) with value %s", userId, authCookie.getValue()));
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -95,7 +95,6 @@ public class UserAuthenticationManager {
     private final EmailManager emailManager;
     private final ObjectMapper serializationMapper;
     private final boolean checkOriginHeader;
-    private final boolean setSecureCookies;
     
     private final Map<AuthenticationProvider, IAuthenticator> registeredAuthProviders;
 
@@ -126,9 +125,7 @@ public class UserAuthenticationManager {
 
         this.emailManager = emailQueue;
         this.serializationMapper = new ObjectMapper();
-        boolean isProduction = properties.getProperty(Constants.SEGUE_APP_ENVIRONMENT).equals(EnvironmentType.PROD.name());
-        this.checkOriginHeader = isProduction;
-        this.setSecureCookies = isProduction;
+        this.checkOriginHeader = properties.getProperty(Constants.SEGUE_APP_ENVIRONMENT).equals(EnvironmentType.PROD.name());
     }
 
     /**
@@ -511,10 +508,10 @@ public class UserAuthenticationManager {
             logoutCookie.setPath("/");
             logoutCookie.setMaxAge(0);  // This will lead to it being removed by the browser immediately.
             logoutCookie.setHttpOnly(true);
-            logoutCookie.setSecure(setSecureCookies);
             // TODO - set sameSite=Lax at minimum when Jetty supports this (9.4.x)
+            logoutCookie.setSecure(true);
 
-            response.addCookie(logoutCookie);  // lgtm [java/insecure-cookie]  false positive due to conditional above!
+            response.addCookie(logoutCookie);
         } catch (IllegalStateException e) {
             log.info("The session has already been invalidated. " + "Unable to logout again...", e);
         }
@@ -931,12 +928,12 @@ public class UserAuthenticationManager {
             authCookie.setMaxAge(sessionExpiryTimeInSeconds);
             authCookie.setPath("/");
             authCookie.setHttpOnly(true);
-            authCookie.setSecure(setSecureCookies);
             // TODO - set sameSite=Lax at minimum when Jetty supports this (9.4.x)
+            authCookie.setSecure(true);
 
             log.debug(String.format("Creating AuthCookie for user (%s) with value %s", userId, authCookie.getValue()));
 
-            response.addCookie(authCookie);  // lgtm [java/insecure-cookie]  false positive due to conditional above!
+            response.addCookie(authCookie);
             
         } catch (JsonProcessingException e1) {
             log.error("Unable to save cookie.", e1);

--- a/web-api-live.xml
+++ b/web-api-live.xml
@@ -60,4 +60,12 @@
         </param-value>
     </context-param>
 
+    <session-config>
+        <cookie-config>
+            <comment>__SAME_SITE_STRICT__</comment>
+            <http-only>true</http-only>
+            <secure>true</secure>
+        </cookie-config>
+    </session-config>
+
 </web-app>

--- a/web-api-local.xml
+++ b/web-api-local.xml
@@ -60,4 +60,12 @@
         </param-value>
     </context-param>
 
+    <session-config>
+        <cookie-config>
+            <comment>__SAME_SITE_STRICT__</comment>
+            <http-only>true</http-only>
+            <secure>true</secure>
+        </cookie-config>
+    </session-config>
+
 </web-app>


### PR DESCRIPTION
This moves all our cookies to be set with the Secure and HttpOnly flags (previously the JSESSIONID was not, nor were local dev cookies), and sets SameSite=Strict on all the cookies (previous we were implicitly using SameSite=Lax in modern browsers).

I think this is fine; the difference between Lax (what we have been implicitly using before now) and Strict is about top-level navigations and third-party triggered GET requests.
We don't use any cookies on the very-top-level GET; that goes to the frontend which is stateless.
I also do not think that third-party origins should be making authenticated GET requests (our CORS would stop the response being used in most cases anyhow), so that should also be safe.
The [SameSite attribute is supported](https://caniuse.com/same-site-cookie-attribute) on all the browsers we care about.

If this breaks, moving to SAME_SITE_LAX_COMMENT is the next one to try.

This change to `web-api-local.xml` may break local development using Safari, if it [still does not do the sensible thing](https://bugs.webkit.org/show_bug.cgi?id=218980) Chrome and Firefox do by allowing insecure "Secure" cookie to be set on localhost origins. It won't affect the live sites at all, and if we _really_ need to test something in Safari it's straightforward to remove temporarily.