### PR TITLE
View students quiz answers only after set date

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -19,6 +19,7 @@ import uk.ac.cam.cl.dtg.segue.api.Constants.LogType;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -209,7 +210,7 @@ public final class Constants {
     /**
      * Quiz constants
      */
-    public static final long QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(123, 5, 5, 0, 0, 0); // 2023-06-05
+    public static final long QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(123, Calendar.JUNE, 12, 0, 0, 0); // 12/06/2023
 
     /**
      * Private constructor to prevent this class being created.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -19,6 +19,7 @@ import uk.ac.cam.cl.dtg.segue.api.Constants.LogType;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -204,6 +205,11 @@ public final class Constants {
     public enum IsaacMailGunTemplate {
         ASSIGNMENT
     }
+
+    /**
+     * Quiz constants
+     */
+    public static final long QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(2023, 5, 26, 0, 0, 0);
 
     /**
      * Private constructor to prevent this class being created.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -209,7 +209,7 @@ public final class Constants {
     /**
      * Quiz constants
      */
-    public static final long QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(2023, 6, 5, 0, 0, 0);
+    public static final long QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(123, 5, 5, 0, 0, 0); // 2023-06-05
 
     /**
      * Private constructor to prevent this class being created.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -209,7 +209,7 @@ public final class Constants {
     /**
      * Quiz constants
      */
-    public static final long QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(2023, 5, 26, 0, 0, 0);
+    public static final long QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(2023, 6, 5, 0, 0, 0);
 
     /**
      * Private constructor to prevent this class being created.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1475,7 +1475,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             RegisteredUserDTO student = this.userManager.getUserDTOById(userId);
 
-            if (!user.getId().equals(student.getId()) && assignment.getCreationDate().getTime() < QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) {
+            if (!isUserAnAdmin(userManager, user) && !user.getId().equals(student.getId()) && assignment.getCreationDate().getTime() < QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
                         "You cannot view student's answers to test assignments created before "
                                 + new Date(QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) + ".").toResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1475,6 +1475,12 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             RegisteredUserDTO student = this.userManager.getUserDTOById(userId);
 
+            if (!user.getId().equals(student.getId()) && assignment.getCreationDate().getTime() < QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) {
+                return new SegueErrorResponse(Status.FORBIDDEN,
+                        "You cannot view student's answers to test assignments created before "
+                                + new Date(QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) + ".").toResponse();
+            }
+
             if (!groupManager.isUserInGroup(student, group)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
                     "That student is not in the group that was assigned this test.").toResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1475,12 +1475,6 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             RegisteredUserDTO student = this.userManager.getUserDTOById(userId);
 
-            if (!isUserAnAdmin(userManager, user) && !user.getId().equals(student.getId()) && assignment.getCreationDate().getTime() < QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) {
-                return new SegueErrorResponse(Status.FORBIDDEN,
-                        "You cannot view student's answers to test assignments created before "
-                                + new Date(QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) + ".").toResponse();
-            }
-
             if (!groupManager.isUserInGroup(student, group)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
                     "That student is not in the group that was assigned this test.").toResponse();
@@ -1496,6 +1490,12 @@ public class QuizFacade extends AbstractIsaacFacade {
             if (quizAttempt == null || quizAttempt.getCompletedDate() == null) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
                     "That student has not completed this test assignment.").toResponse();
+            }
+
+            if (!isUserAnAdmin(userManager, user) && !user.getId().equals(student.getId()) && assignment.getCreationDate().getTime() < QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) {
+                return new SegueErrorResponse(Status.FORBIDDEN,
+                        "You cannot view student's answers to test assignments created before "
+                                + new Date(QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) + ".").toResponse();
             }
 
             IsaacQuizDTO quiz = quizManager.findQuiz(quizAttempt.getQuizId());

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -18,6 +18,7 @@ package uk.ac.cam.cl.dtg.isaac;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
+import uk.ac.cam.cl.dtg.isaac.api.Constants;
 import uk.ac.cam.cl.dtg.isaac.api.managers.QuizManager;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuestionBase;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuiz;
@@ -62,7 +63,12 @@ public class IsaacTest {
     protected static Date somePastDate = new Date(System.currentTimeMillis() - 7*24*60*60*1000);
     protected static Date someFurtherPastDate = new Date(System.currentTimeMillis() - 14*24*60*60*1000);
     protected static Date someFutureDate = new Date(System.currentTimeMillis() + 7*24*60*60*1000);
+    protected static Date someDateBeforeQuizAnswerView = new Date(Constants.QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP - 24*60*60*1000);
+    protected static Date someDateAfterQuizAnswerView = new Date(Constants.QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP + 24*60*60*1000);
+    protected static Date someDateMuchAfterQuizAnswerView = new Date(System.currentTimeMillis() + 14*24*60*60*1000);
     protected IsaacQuizDTO studentQuiz;
+    protected IsaacQuizDTO studentQuizPreQuizAnswerChange;
+    protected IsaacQuizDTO studentQuizPostQuizAnswerChange;
     protected IsaacQuiz studentQuizDO;
     protected IsaacQuizDTO teacherQuiz;
     protected IsaacQuizDTO otherQuiz;
@@ -84,6 +90,8 @@ public class IsaacTest {
     protected UserGroupDTO studentInactiveGroup;
 
     protected QuizAssignmentDTO studentAssignment;
+    protected QuizAssignmentDTO studentAssignmentPreQuizAnswerChange;
+    protected QuizAssignmentDTO studentAssignmentPostQuizAnswerChange;
     protected QuizAssignmentDTO overdueAssignment;
     private QuizAssignmentDTO completedAssignment;
     protected ImmutableList<Long> studentGroups;
@@ -95,6 +103,8 @@ public class IsaacTest {
     protected QuizAttemptDTO studentAttempt;
     protected QuizAttemptDTO overdueAttempt;
     protected QuizAttemptDTO completedAttempt;
+    protected QuizAttemptDTO completedAttemptPreQuizAnswerChange;
+    protected QuizAttemptDTO completedAttemptPostQuizAnswerChange;
     protected QuizAttemptDTO overdueCompletedAttempt;
     protected QuizAttemptDTO otherAttempt;
     protected QuizAttemptDTO ownAttempt;
@@ -150,6 +160,8 @@ public class IsaacTest {
         quizSection2.setChildren(ImmutableList.of(question2, question3));
 
         studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
+        studentQuizPreQuizAnswerChange = new IsaacQuizDTO("studentQuizPreQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
+        studentQuizPostQuizAnswerChange = new IsaacQuizDTO("studentQuizPostQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
         teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, false, ImmutableList.of("STUDENT"), null, null);
         otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.DETAILED_FEEDBACK, null);
 
@@ -207,19 +219,23 @@ public class IsaacTest {
 
         completedAssignment = new QuizAssignmentDTO(++id, studentQuiz.getId(), teacher.getId(), studentGroup.getId(), someFurtherPastDate, somePastDate, QuizFeedbackMode.OVERALL_MARK);
         studentAssignment = new QuizAssignmentDTO(++id, studentQuiz.getId(), teacher.getId(), studentGroup.getId(), somePastDate, someFutureDate, QuizFeedbackMode.DETAILED_FEEDBACK);
+        studentAssignmentPreQuizAnswerChange = new QuizAssignmentDTO(++id, studentQuizPreQuizAnswerChange.getId(), teacher.getId(), studentGroup.getId(), someDateBeforeQuizAnswerView, someDateAfterQuizAnswerView, QuizFeedbackMode.DETAILED_FEEDBACK);
+        studentAssignmentPostQuizAnswerChange = new QuizAssignmentDTO(++id, studentQuizPostQuizAnswerChange.getId(), teacher.getId(), studentGroup.getId(), someDateAfterQuizAnswerView, someDateMuchAfterQuizAnswerView, QuizFeedbackMode.DETAILED_FEEDBACK);
         overdueAssignment = new QuizAssignmentDTO(++id, studentQuiz.getId(), teacher.getId(), studentGroup.getId(), someFurtherPastDate, somePastDate, QuizFeedbackMode.SECTION_MARKS);
         otherAssignment = new QuizAssignmentDTO(++id, teacherQuiz.getId(), teacher.getId(), studentGroup.getId(), somePastDate, someFutureDate, QuizFeedbackMode.OVERALL_MARK);
 
         studentInactiveIgnoredAssignment = new QuizAssignmentDTO(++id, teacherQuiz.getId(), teacher.getId(), studentInactiveGroup.getId(), somePastDate, someFutureDate, QuizFeedbackMode.OVERALL_MARK);
         studentInactiveAssignment = new QuizAssignmentDTO(++id, teacherQuiz.getId(), teacher.getId(), studentInactiveGroup.getId(), someFurtherPastDate, someFutureDate, QuizFeedbackMode.OVERALL_MARK);
 
-        studentAssignments = ImmutableList.of(completedAssignment, studentAssignment, overdueAssignment, otherAssignment, studentInactiveAssignment);
+        studentAssignments = ImmutableList.of(completedAssignment, studentAssignment, studentAssignmentPreQuizAnswerChange, studentAssignmentPostQuizAnswerChange, overdueAssignment, otherAssignment, studentInactiveAssignment);
 
         teacherAssignmentsToTheirGroups = ImmutableList.<QuizAssignmentDTO>builder().addAll(studentAssignments).add(studentInactiveIgnoredAssignment).build();
 
         studentAttempt = new QuizAttemptDTO(++id, student.getId(), studentQuiz.getId(), studentAssignment.getId(), somePastDate, null);
         overdueAttempt = new QuizAttemptDTO(++id, student.getId(), studentQuiz.getId(), overdueAssignment.getId(), somePastDate, null);
         completedAttempt = new QuizAttemptDTO(++id, student.getId(), studentQuiz.getId(), studentAssignment.getId(), somePastDate, new Date());
+        completedAttemptPreQuizAnswerChange = new QuizAttemptDTO(++id, student.getId(), studentQuizPreQuizAnswerChange.getId(), studentAssignmentPreQuizAnswerChange.getId(), somePastDate, new Date());
+        completedAttemptPostQuizAnswerChange = new QuizAttemptDTO(++id, student.getId(), studentQuizPostQuizAnswerChange.getId(), studentAssignmentPostQuizAnswerChange.getId(), somePastDate, new Date());
         overdueCompletedAttempt = new QuizAttemptDTO(++id, student.getId(), studentQuiz.getId(), overdueAssignment.getId(), somePastDate, new Date());
         otherAttempt = new QuizAttemptDTO(++id, student.getId(), teacherQuiz.getId(), otherAssignment.getId(), somePastDate, null);
 
@@ -227,7 +243,7 @@ public class IsaacTest {
         ownAttempt = new QuizAttemptDTO(++id, student.getId(), otherQuiz.getId(), null, somePastDate, null);
         attemptOnNullFeedbackModeQuiz = new QuizAttemptDTO(101L, student.getId(), teacherQuiz.getId(), null, somePastDate, somePastDate);
 
-        studentAttempts = ImmutableList.of(studentAttempt, overdueAttempt, completedAttempt, overdueCompletedAttempt, otherAttempt, ownAttempt, ownCompletedAttempt, attemptOnNullFeedbackModeQuiz);
+        studentAttempts = ImmutableList.of(studentAttempt, overdueAttempt, completedAttempt, completedAttemptPreQuizAnswerChange, completedAttemptPostQuizAnswerChange, overdueCompletedAttempt, otherAttempt, ownAttempt, ownCompletedAttempt, attemptOnNullFeedbackModeQuiz);
     }
 
     protected void initializeMocks() throws ContentManagerException, SegueDatabaseException {
@@ -237,6 +253,8 @@ public class IsaacTest {
             expect(m.getAvailableQuizzes(true,"STUDENT", 0, 9000)).andStubReturn(wrap(studentQuizSummary));
             expect(m.getAvailableQuizzes(false,"TEACHER", 0, 9000)).andStubReturn(wrap(studentQuizSummary, teacherQuizSummary));
             expect(m.findQuiz(studentQuiz.getId())).andStubReturn(studentQuiz);
+            expect(m.findQuiz(studentQuizPreQuizAnswerChange.getId())).andStubReturn(studentQuizPreQuizAnswerChange);
+            expect(m.findQuiz(studentQuizPostQuizAnswerChange.getId())).andStubReturn(studentQuizPostQuizAnswerChange);
             expect(m.findQuiz(teacherQuiz.getId())).andStubReturn(teacherQuiz);
             expect(m.findQuiz(otherQuiz.getId())).andStubReturn(otherQuiz);
             expect(m.extractSectionObjects(studentQuiz)).andStubReturn(ImmutableList.of(quizSection1, quizSection2));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -279,16 +279,6 @@ public class QuizFacadeTest extends AbstractFacadeTest {
     public void getQuizAssignmentAttempt() {
         QuizAttemptDTO augmentedQuiz = new QuizAttemptDTO();
 
-        // Test data for checking whether teachers can only view students attempts after a particular date (the date
-        // when we added this change to the privacy policy)
-        Date someDateBeforeQuizAnswerView = new Date(Constants.QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP - 24*60*60*1000);
-        Date someDateAfterQuizAnswerView = new Date(Constants.QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP + 24*60*60*1000);
-        Date someDateMuchAfterQuizAnswerView = new Date(System.currentTimeMillis() + 14*24*60*60*1000);
-        QuizAssignmentDTO studentAssignmentPreQuizAnswerChange = new QuizAssignmentDTO(studentAssignment.getId() + 1, studentQuiz.getId(), teacher.getId(), studentGroup.getId(), someDateBeforeQuizAnswerView, someDateAfterQuizAnswerView, QuizFeedbackMode.DETAILED_FEEDBACK);
-        QuizAssignmentDTO studentAssignmentPostQuizAnswerChange = new QuizAssignmentDTO(studentAssignment.getId() + 2, studentQuiz.getId(), teacher.getId(), studentGroup.getId(), someDateAfterQuizAnswerView, someDateMuchAfterQuizAnswerView, QuizFeedbackMode.DETAILED_FEEDBACK);
-        QuizAttemptDTO completedAttemptForPreQuizAnswerChange = new QuizAttemptDTO(completedAttempt.getId() + 1, student.getId(), studentQuiz.getId(), studentAssignmentPreQuizAnswerChange.getId(), somePastDate, new Date());
-        QuizAttemptDTO completedAttemptForPostQuizAnswerChange = new QuizAttemptDTO(completedAttempt.getId() + 2, student.getId(), studentQuiz.getId(), studentAssignmentPostQuizAnswerChange.getId(), somePastDate, new Date());
-
         forEndpoint(() -> quizFacade.getQuizAssignmentAttempt(httpServletRequest, studentAssignment.getId(), student.getId()),
             requiresLogin(),
             as(studentsTeachersOrAdmin(),
@@ -308,18 +298,35 @@ public class QuizFacadeTest extends AbstractFacadeTest {
                 prepare(quizAttemptManager, m -> expect(m.getByQuizAssignmentAndUser(studentAssignment, student)).andReturn(studentAttempt)),
                 failsWith(Status.FORBIDDEN)
             ),
-            as(studentsTeachersOrAdmin(),
-                    prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignmentPreQuizAnswerChange)).andReturn(studentGroup)),
-                    prepare(associationManager, m -> expect(m.hasPermission(currentUser(), student)).andReturn(true)),
-                    prepare(quizAttemptManager, m -> expect(m.getByQuizAssignmentAndUser(studentAssignmentPreQuizAnswerChange, student)).andReturn(completedAttemptForPreQuizAnswerChange)),
-                    prepare(quizQuestionManager, m -> expect(m.augmentFeedbackFor(completedAttemptForPreQuizAnswerChange, studentQuiz, QuizFeedbackMode.DETAILED_FEEDBACK)).andReturn(augmentedQuiz)),
-                    failsWith(Status.FORBIDDEN)
+            forbiddenForEveryoneElse()
+        );
+
+        forEndpoint(() -> quizFacade.getQuizAssignmentAttempt(httpServletRequest, studentAssignmentPreQuizAnswerChange.getId(), student.getId()),
+            requiresLogin(),
+            as(anyOf(teacher, secondTeacher),
+                prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignmentPreQuizAnswerChange)).andReturn(studentGroup)),
+                prepare(associationManager, m -> expect(m.hasPermission(currentUser(), student)).andReturn(true)),
+                prepare(quizAttemptManager, m -> expect(m.getByQuizAssignmentAndUser(studentAssignmentPreQuizAnswerChange, student)).andReturn(completedAttemptPreQuizAnswerChange)),
+                failsWith(Status.FORBIDDEN)
             ),
+            as(adminUser,
+                prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignmentPreQuizAnswerChange)).andReturn(studentGroup)),
+                prepare(associationManager, m -> expect(m.hasPermission(currentUser(), student)).andReturn(true)),
+                prepare(quizAttemptManager, m -> expect(m.getByQuizAssignmentAndUser(studentAssignmentPreQuizAnswerChange, student)).andReturn(completedAttemptPreQuizAnswerChange)),
+                prepare(quizQuestionManager, m -> expect(m.augmentFeedbackFor(completedAttemptPreQuizAnswerChange, studentQuizPreQuizAnswerChange, QuizFeedbackMode.DETAILED_FEEDBACK)).andReturn(augmentedQuiz)),
+                succeeds(),
+                check(response -> assertEquals(((QuizAttemptFeedbackDTO) response.getEntity()).getAttempt().getQuiz(), augmentedQuiz.getQuiz()))
+            ),
+            forbiddenForEveryoneElse()
+        );
+
+        forEndpoint(() -> quizFacade.getQuizAssignmentAttempt(httpServletRequest, studentAssignmentPostQuizAnswerChange.getId(), student.getId()),
+            requiresLogin(),
             as(studentsTeachersOrAdmin(),
                 prepare(quizAssignmentManager, m -> expect(m.getGroupForAssignment(studentAssignmentPostQuizAnswerChange)).andReturn(studentGroup)),
                 prepare(associationManager, m -> expect(m.hasPermission(currentUser(), student)).andReturn(true)),
-                prepare(quizAttemptManager, m -> expect(m.getByQuizAssignmentAndUser(studentAssignmentPostQuizAnswerChange, student)).andReturn(completedAttemptForPostQuizAnswerChange)),
-                prepare(quizQuestionManager, m -> expect(m.augmentFeedbackFor(completedAttemptForPostQuizAnswerChange, studentQuiz, QuizFeedbackMode.DETAILED_FEEDBACK)).andReturn(augmentedQuiz)),
+                prepare(quizAttemptManager, m -> expect(m.getByQuizAssignmentAndUser(studentAssignmentPostQuizAnswerChange, student)).andReturn(completedAttemptPostQuizAnswerChange)),
+                prepare(quizQuestionManager, m -> expect(m.augmentFeedbackFor(completedAttemptPostQuizAnswerChange, studentQuizPostQuizAnswerChange, QuizFeedbackMode.DETAILED_FEEDBACK)).andReturn(augmentedQuiz)),
                 succeeds(),
                 check(response -> assertEquals(((QuizAttemptFeedbackDTO) response.getEntity()).getAttempt().getQuiz(), augmentedQuiz.getQuiz()))
             ),


### PR DESCRIPTION
Only allows teachers to view student test/quiz answers after the privacy policy change. 

Before this change, they were technically able to see students answers already (if they knew the right incantation), but that wasn't inline with our data policy.

The actual date should be updated just before this gets released. 