### PR TITLE
Feature/consolidate search queries

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -27,6 +27,7 @@ import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.api.services.ContentSummarizerService;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.IStatisticsManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
@@ -63,6 +64,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -220,8 +222,9 @@ public class IsaacController extends AbstractIsaacFacade {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "Invalid document types.").toResponse();
             }
 
-            ResultsWrapper<ContentDTO> searchResults = this.contentManager.siteWideSearch(
-                    searchString, documentTypes, showNoFilterContent, startIndex, limit);
+            ResultsWrapper<ContentDTO> searchResults = this.contentManager.searchForContent(
+                    searchString, null, null, null, null, null, null,
+                    new HashSet<>(documentTypes), startIndex, limit, showNoFilterContent);
 
             ImmutableMap<String, String> logMap = new ImmutableMap.Builder<String, String>()
                     .put(TYPE_FIELDNAME, types)

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -373,12 +373,12 @@ public class PagesFacade extends AbstractIsaacFacade {
             ResultsWrapper<ContentDTO> c;
             c = contentManager.searchForContent(
                     validatedSearchString,
-                    fieldsToMatch.getOrDefault(ID_FIELDNAME, Set.of()),
-                    fieldsToMatch.getOrDefault(TAGS_FIELDNAME, Set.of()),
-                    fieldsToMatch.getOrDefault(LEVEL_FIELDNAME, Set.of()),
-                    fieldsToMatch.getOrDefault(STAGE_FIELDNAME, Set.of()),
-                    fieldsToMatch.getOrDefault(DIFFICULTY_FIELDNAME, Set.of()),
-                    fieldsToMatch.getOrDefault(EXAM_BOARD_FIELDNAME, Set.of()),
+                    fieldsToMatch.get(ID_FIELDNAME),
+                    fieldsToMatch.get(TAGS_FIELDNAME),
+                    fieldsToMatch.get(LEVEL_FIELDNAME),
+                    fieldsToMatch.get(STAGE_FIELDNAME),
+                    fieldsToMatch.get(DIFFICULTY_FIELDNAME),
+                    fieldsToMatch.get(EXAM_BOARD_FIELDNAME),
                     fieldsToMatch.getOrDefault(TYPE_FIELDNAME, Set.of(QUESTION_TYPE)),
                     newStartIndex,
                     newLimit,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -430,10 +430,8 @@ public final class Constants {
     public static final String TITLE_FIELDNAME = "title";
     public static final String TYPE_FIELDNAME = "type";
     public static final String TAGS_FIELDNAME = "tags";
-    public static final String VALUE_FIELDNAME = "value";
     public static final String LEVEL_FIELDNAME = "level";
     public static final String SUMMARY_FIELDNAME = "summary";
-    public static final String CHILDREN_FIELDNAME = "children";
     public static final String DATE_FIELDNAME = "date";
     public static final String ADDRESS_PSEUDO_FIELDNAME = "address";
     public static final String[] ADDRESS_PATH_FIELDNAME = {"location", "address"};

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -354,14 +354,7 @@ public class GitContentManager {
                 .searchFor(new SearchInField(Constants.DIFFICULTY_FIELDNAME, difficulties).strategy(Strategy.SIMPLE).required(true))
                 .searchFor(new SearchInField(Constants.EXAM_BOARD_FIELDNAME, examBoards).strategy(Strategy.SIMPLE).required(true))
 
-                // Exact matches
-                .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH))
-                .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH))
-                .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms).priority(Priority.HIGH))
-                .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, searchTerms).priority(Priority.HIGH))
-                .searchFor(new SearchInField(Constants.SEARCHABLE_CONTENT_FIELDNAME, searchTerms))
-
-                // Fuzzy matches (exact matches will match these criteria too)
+                // Fuzzy matches
                 .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
@@ -410,14 +403,7 @@ public class GitContentManager {
                 // Further filtering
                 .includeContentTypes(Set.copyOf(documentTypes))
 
-                // Exact matches
-                .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH))
-                .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH))
-                .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms).priority(Priority.HIGH))
-                .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, searchTerms).priority(Priority.HIGH))
-                .searchFor(new SearchInField(Constants.SEARCHABLE_CONTENT_FIELDNAME, searchTerms))
-
-                // Fuzzy matches (exact matches will match these criteria too)
+                // Fuzzy matches
                 .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -345,17 +345,29 @@ public class GitContentManager {
                 this.showOnlyPublishedContent,
                 this.hideRegressionTestContent,
                 !showNoFilterContent)
+
+                // Further filtering
                 .includeContentTypes(contentTypes)
-                .searchFor(new SearchInField(Constants.ID_FIELDNAME, ids).strategy(Strategy.SIMPLE))
                 .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, tags).strategy(Strategy.SIMPLE).required(true))
                 .searchFor(new SearchInField(Constants.LEVEL_FIELDNAME, levels).strategy(Strategy.SIMPLE).required(true))
                 .searchFor(new SearchInField(Constants.STAGE_FIELDNAME, stages).strategy(Strategy.SIMPLE).required(true))
                 .searchFor(new SearchInField(Constants.DIFFICULTY_FIELDNAME, difficulties).strategy(Strategy.SIMPLE).required(true))
                 .searchFor(new SearchInField(Constants.EXAM_BOARD_FIELDNAME, examBoards).strategy(Strategy.SIMPLE).required(true))
+
+                // Exact matches
+                .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH))
+                .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH))
+                .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms).priority(Priority.HIGH))
+                .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, searchTerms).priority(Priority.HIGH))
+                .searchFor(new SearchInField(Constants.SEARCHABLE_CONTENT_FIELDNAME, searchTerms))
+
+                // Fuzzy matches (exact matches will match these criteria too)
                 .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
+                .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.SEARCHABLE_CONTENT_FIELDNAME, searchTerms).strategy(Strategy.FUZZY))
+
                 .build();
 
         // If no search terms were provided, sort by ascending alphabetical order of title.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -355,8 +355,7 @@ public class GitContentManager {
                 .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
-                .searchFor(new SearchInField(Constants.VALUE_FIELDNAME, searchTerms).strategy(Strategy.FUZZY))
-                .searchFor(new SearchInField(Constants.CHILDREN_FIELDNAME, searchTerms).strategy(Strategy.FUZZY))
+                .searchFor(new SearchInField(Constants.SEARCHABLE_CONTENT_FIELDNAME, searchTerms).strategy(Strategy.FUZZY))
                 .build();
 
         // If no search terms were provided, sort by ascending alphabetical order of title.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -382,7 +382,10 @@ public class GitContentManager {
         // Add a required filtering rule for each field that has a value
         for (Map.Entry<String, Set<String>> entry : filterFieldNamesToValues.entrySet()) {
             if (entry.getValue() != null && !entry.getValue().isEmpty()) {
-                searchInstructionBuilder.searchFor(new SearchInField(entry.getKey(), entry.getValue()).strategy(Strategy.SIMPLE).required(true));
+                boolean applyOrFilterBetweenValues = Constants.ID_FIELDNAME.equals(entry.getKey());
+                searchInstructionBuilder.searchFor(new SearchInField(entry.getKey(), entry.getValue())
+                        .strategy(Strategy.SIMPLE)
+                        .required(!applyOrFilterBetweenValues));
             }
         }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -67,6 +67,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics.CACHE_METRICS_COLLECTOR;
 
 /**
@@ -329,81 +330,31 @@ public class GitContentManager {
         return (ResultsWrapper<ContentDTO>) cache.getIfPresent(k);
     }
 
-    public final ResultsWrapper<ContentDTO> searchForContent(@Nullable final String searchString, final Set<String> ids,
-                                                             final Set<String> tags, final Set<String> levels, final Set<String> stages,
-                                                             final Set<String> difficulties, final Set<String> examBoards,
-                                                             final Set<String> contentTypes, final Integer startIndex,
-                                                             final Integer limit, final boolean showNoFilterContent)
-            throws ContentManagerException {
+    public final ResultsWrapper<ContentDTO> searchForContent(
+            @Nullable final String searchString,
+            @Nullable final Set<String> ids, @Nullable final Set<String> tags, @Nullable Set<String> levels,
+            @Nullable Set<String> stages, @Nullable Set<String> difficulties, @Nullable Set<String> examBoards,
+            final Set<String> contentTypes, final Integer startIndex, final Integer limit, final boolean showNoFilterContent
+    ) throws ContentManagerException {
 
-        Set<String> searchTerms = Set.of();
+        // Create a set of search terms from the initial search string
+        Set<String> searchTerms = new HashSet<>();
         if (searchString != null && !searchString.isBlank()) {
+            searchTerms.add(searchString);
+            // If it is a search phrase, also try to match each word individually
+            if (searchString.contains(" ")) {
+                searchTerms.addAll(Arrays.asList(searchString.split(" ")));
+            }
             searchTerms = Arrays.stream(searchString.split(" ")).collect(Collectors.toSet());
         }
 
-        BooleanInstruction matchInstruction = new IsaacSearchInstructionBuilder(searchProvider,
-                this.showOnlyPublishedContent,
-                this.hideRegressionTestContent,
-                !showNoFilterContent)
+        IsaacSearchInstructionBuilder searchInstructionBuilder = new IsaacSearchInstructionBuilder(
+                searchProvider, this.showOnlyPublishedContent, this.hideRegressionTestContent, !showNoFilterContent)
 
-                // Further filtering
+                // Restrict content types
                 .includeContentTypes(contentTypes)
-                .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, tags).strategy(Strategy.SIMPLE).required(true))
-                .searchFor(new SearchInField(Constants.LEVEL_FIELDNAME, levels).strategy(Strategy.SIMPLE).required(true))
-                .searchFor(new SearchInField(Constants.STAGE_FIELDNAME, stages).strategy(Strategy.SIMPLE).required(true))
-                .searchFor(new SearchInField(Constants.DIFFICULTY_FIELDNAME, difficulties).strategy(Strategy.SIMPLE).required(true))
-                .searchFor(new SearchInField(Constants.EXAM_BOARD_FIELDNAME, examBoards).strategy(Strategy.SIMPLE).required(true))
 
-                // Fuzzy matches
-                .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
-                .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
-                .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
-                .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
-                .searchFor(new SearchInField(Constants.SEARCHABLE_CONTENT_FIELDNAME, searchTerms).strategy(Strategy.FUZZY))
-
-                .build();
-
-        // If no search terms were provided, sort by ascending alphabetical order of title.
-        Map<String, Constants.SortOrder> sortOrder = null;
-
-        if (searchTerms.isEmpty()) {
-            sortOrder = new HashMap<>();
-            sortOrder.put(Constants.TITLE_FIELDNAME + "." + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX, Constants.SortOrder.ASC);
-        }
-
-        ResultsWrapper<String> searchHits = searchProvider.nestedMatchSearch(
-                contentIndex,
-                CONTENT_TYPE,
-                startIndex,
-                limit,
-                matchInstruction,
-                sortOrder
-        );
-
-        List<Content> searchResults = mapper.mapFromStringListToContentList(searchHits.getResults());
-
-        return new ResultsWrapper<>(mapper.getDTOByDOList(searchResults), searchHits.getTotalResults());
-    }
-
-    public final ResultsWrapper<ContentDTO> siteWideSearch(
-            final String searchString, final List<String> documentTypes,
-            final boolean showNoFilterContent, final Integer startIndex, final Integer limit
-    ) throws  ContentManagerException {
-
-        Set<String> searchTerms = Set.of();
-        if (searchString != null && !searchString.isBlank()) {
-            searchTerms = Arrays.stream(searchString.split(" ")).collect(Collectors.toSet());
-        }
-
-        BooleanInstruction matchInstruction = new IsaacSearchInstructionBuilder(searchProvider,
-                this.showOnlyPublishedContent,
-                this.hideRegressionTestContent,
-                !showNoFilterContent)
-
-                // Further filtering
-                .includeContentTypes(Set.copyOf(documentTypes))
-
-                // Fuzzy matches
+                // Fuzzy search term matches
                 .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
                 .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms).priority(Priority.HIGH).strategy(Strategy.FUZZY))
@@ -416,17 +367,39 @@ public class GitContentManager {
 
                 // Event specific queries
                 .searchFor(new SearchInField(Constants.ADDRESS_PSEUDO_FIELDNAME, searchTerms))
-                .includePastEvents(false)
+                .includePastEvents(false);
 
-                .build();
+
+        // Additional per-field filters if specified
+        Map<String, Set<String>> filterFieldNamesToValues = new HashMap<>() {{
+            this.put(ID_FIELDNAME, ids);
+            this.put(TAGS_FIELDNAME, tags);
+            this.put(LEVEL_FIELDNAME, levels);
+            this.put(STAGE_FIELDNAME, stages);
+            this.put(DIFFICULTY_FIELDNAME, difficulties);
+            this.put(EXAM_BOARD_FIELDNAME, examBoards);
+        }};
+        // Add a required filtering rule for each field that has a value
+        for (Map.Entry<String, Set<String>> entry : filterFieldNamesToValues.entrySet()) {
+            if (entry.getValue() != null && !entry.getValue().isEmpty()) {
+                searchInstructionBuilder.searchFor(new SearchInField(entry.getKey(), entry.getValue()).strategy(Strategy.SIMPLE).required(true));
+            }
+        }
+
+        // If no search terms were provided, sort by ascending alphabetical order of title.
+        Map<String, Constants.SortOrder> sortOrder = null;
+        if (searchTerms.isEmpty()) {
+            sortOrder = new HashMap<>();
+            sortOrder.put(Constants.TITLE_FIELDNAME + "." + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX, Constants.SortOrder.ASC);
+        }
 
         ResultsWrapper<String> searchHits = searchProvider.nestedMatchSearch(
                 contentIndex,
                 CONTENT_TYPE,
                 startIndex,
                 limit,
-                matchInstruction,
-                null
+                searchInstructionBuilder.build(),
+                sortOrder
         );
 
         List<Content> searchResults = mapper.mapFromStringListToContentList(searchHits.getResults());

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
@@ -165,15 +165,22 @@ public abstract class IsaacIntegrationTest {
         }
     }
 
+    private static String getClassLoaderResourcePath(final String resource) {
+        return IsaacIntegrationTest.class.getClassLoader().getResource(resource)
+                .getPath()
+                // ":" is removed from the resource path for Windows compatibility
+                .replace(":", "");
+    }
+
     @BeforeClass
     public static void setUpClass() {
         postgres = new PostgreSQLContainer<>("postgres:12")
                 .withEnv("POSTGRES_HOST_AUTH_METHOD", "trust")
                 .withUsername("rutherford")
-                .withFileSystemBind(IsaacIntegrationTest.class.getClassLoader().getResource("db_scripts/postgres-rutherford-create-script.sql").getPath(), "/docker-entrypoint-initdb.d/00-isaac-create.sql")
-                .withFileSystemBind(IsaacIntegrationTest.class.getClassLoader().getResource("db_scripts/postgres-rutherford-functions.sql").getPath(), "/docker-entrypoint-initdb.d/01-isaac-functions.sql")
-                .withFileSystemBind(IsaacIntegrationTest.class.getClassLoader().getResource("db_scripts/quartz_scheduler_create_script.sql").getPath(), "/docker-entrypoint-initdb.d/02-isaac-quartz.sql")
-                .withFileSystemBind(IsaacIntegrationTest.class.getClassLoader().getResource("test-postgres-rutherford-data-dump.sql").getPath(), "/docker-entrypoint-initdb.d/03-data-dump.sql")
+                .withFileSystemBind(getClassLoaderResourcePath("db_scripts/postgres-rutherford-create-script.sql"), "/docker-entrypoint-initdb.d/00-isaac-create.sql")
+                .withFileSystemBind(getClassLoaderResourcePath("db_scripts/postgres-rutherford-functions.sql"), "/docker-entrypoint-initdb.d/01-isaac-functions.sql")
+                .withFileSystemBind(getClassLoaderResourcePath("db_scripts/quartz_scheduler_create_script.sql"), "/docker-entrypoint-initdb.d/02-isaac-quartz.sql")
+                .withFileSystemBind(getClassLoaderResourcePath("test-postgres-rutherford-data-dump.sql"), "/docker-entrypoint-initdb.d/03-data-dump.sql")
         ;
 
         // TODO It would be nice if we could pull the version from pom.xml


### PR DESCRIPTION
This alters the code so that queries to the teacher gameboard builder and the site-wide search use the same ElasticSearch query with different filters. This will provide more reliable results.
In doing so I was able to experiment with different query options and improve on our test suite of awkward search results from failing on 12 out of 54 searches to only failing on 6 out of 54 searches.
Test cases: https://github.com/isaacphysics/isaac-scripts/blob/master/python_files/search_tests.csv

---

**Pull Request Check List**
- Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
