### PR TITLE
Hotfix/stop regression test content appearing in search

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -49,6 +49,8 @@ public final class Constants {
 
     public static final String SEARCHABLE_TAG = "search_result";
     public static final String HIDE_FROM_FILTER_TAG = "nofilter";
+    public static final String REGRESSION_TEST_TAG = "regression_test";
+
     public static final String RELATED_CONTENT_FIELDNAME = "relatedContent";
 
     public static final Set<String> SITE_WIDE_SEARCH_VALID_DOC_TYPES = ImmutableSet.of(

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -663,7 +663,7 @@ public class GitContentManager {
         HashMap<String, AbstractFilterInstruction> filters = new HashMap<>();
 
         if (this.hideRegressionTestContent) {
-            filters.put("tags", new SimpleExclusionInstruction("regression_test"));
+            filters.put("tags", new SimpleExclusionInstruction(REGRESSION_TEST_TAG));
         }
         if (this.showOnlyPublishedContent) {
             filters.put("published", new SimpleFilterInstruction("true"));

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
@@ -132,7 +132,7 @@ public class IsaacSearchInstructionBuilder {
 
         // Exclude regression test content (based on config)
         if (this.excludeRegressionTestContent) {
-            instruction.mustNot(new MatchInstruction(Constants.TAGS_FIELDNAME, "false"));
+            instruction.mustNot(new MatchInstruction(Constants.TAGS_FIELDNAME, "regression_test"));
         }
 
         // Exclude "no-filter" content (based on user role)

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
@@ -132,7 +132,7 @@ public class IsaacSearchInstructionBuilder {
 
         // Exclude regression test content (based on config)
         if (this.excludeRegressionTestContent) {
-            instruction.mustNot(new MatchInstruction(Constants.TAGS_FIELDNAME, "regression_test"));
+            instruction.mustNot(new MatchInstruction(Constants.TAGS_FIELDNAME, REGRESSION_TEST_TAG));
         }
 
         // Exclude "no-filter" content (based on user role)


### PR DESCRIPTION
A small change to fix a bug causing content tagged `regression_test` to appear in search results.