### PR TITLE
Re-use ES instance across integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
         <netty.version>4.1.77.Final</netty.version>
         <dependency-check.version>7.1.0</dependency-check.version>
         <ossindex.version>3.2.0</ossindex.version>
+        <surefire.jacoco.args />
+        <failsafe.jacoco.args />
     </properties>
 
     <repositories>
@@ -220,6 +222,18 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4-rule-agent</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-classloading-xstream</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
@@ -513,7 +527,7 @@
                         <segue.version>${segue.version}</segue.version>
                     </systemPropertyVariables>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <argLine>${surefire.jacoco.args}</argLine>
+                    <argLine>@{surefire.jacoco.args}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -522,13 +536,14 @@
                 <version>3.0.0-M7</version>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
+                    <reuseForks>true</reuseForks>
                     <systemPropertyVariables>
                         <segue.version>${segue.version}</segue.version>
                         <test.config.location>src/test/resources/segue-integration-test-config.properties</test.config.location>
                     </systemPropertyVariables>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <argLine>${failsafe.jacoco.args}</argLine>
+                    <!-- allowAttachSelf is necessary for PowerMock Agent on Java 11, see https://github.com/powermock/powermock/issues/979 -->
+                    <argLine>@{failsafe.jacoco.args} -Djdk.attach.allowAttachSelf=true</argLine>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacadeIT.java
@@ -20,15 +20,14 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.rule.PowerMockRule;
 import uk.ac.cam.cl.dtg.isaac.api.services.AssignmentService;
 import uk.ac.cam.cl.dtg.isaac.dto.AssignmentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.AssignmentStatusDTO;
@@ -54,12 +53,14 @@ import java.util.Date;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
-@RunWith(PowerMockRunner.class)
 @PrepareForTest({Date.class, AssignmentFacade.class})
-@PowerMockIgnore({"javax.xml.datatype.*", "javax.management.*", "javax.crypto.*", "javax.net.ssl.*", "javax.net.*", "ma.glasnost.orika.*"})
+@PowerMockIgnore({"javax.xml.datatype.*", "javax.management.*", "javax.crypto.*", "javax.net.*", "ma.glasnost.orika.*"})
 public class AssignmentFacadeIT extends IsaacIntegrationTest {
 
     private AssignmentFacade assignmentFacade;
+
+    @Rule
+    public PowerMockRule rule = new PowerMockRule();
 
     @Before
     public void setUp() throws Exception {
@@ -89,14 +90,6 @@ public class AssignmentFacadeIT extends IsaacIntegrationTest {
         pst.setString(1, ITConstants.ASSIGNMENTS_TEST_GAMEBOARD_ID);
         pst.setString(2, ITConstants.ASSIGNMENTS_DATE_TEST_GAMEBOARD_ID);
         pst.executeUpdate();
-    }
-
-    @AfterClass
-    public static void cleanUp() throws SegueDatabaseException {
-        // reset additional manager privileges setting for Daves group
-        UserGroupDTO davesGroup = groupManager.getGroupById(ITConstants.DAVE_TEACHERS_BC_GROUP_ID);
-        davesGroup.setAdditionalManagerPrivileges(false);
-        groupManager.editUserGroup(davesGroup);
     }
 
     @Test


### PR DESCRIPTION
---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
