### PR TITLE
Improve bulk actions for group management

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -17,25 +17,11 @@ package uk.ac.cam.cl.dtg.isaac.api;
 
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.opencsv.CSVWriter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jboss.resteasy.annotations.GZIP;
@@ -66,7 +52,21 @@ import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
+import uk.ac.cam.cl.dtg.util.NameFormatter;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.text.DecimalFormat;
@@ -89,7 +89,6 @@ import java.util.stream.Collectors;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager.extractPageIdFromQuestionId;
-import static uk.ac.cam.cl.dtg.util.NameFormatter.getFilteredGroupNameFromGroup;
 
 /**
  * AssignmentFacade
@@ -183,11 +182,8 @@ public class AssignmentFacade extends AbstractIsaacFacade {
 
             // we want to populate gameboard details for the assignment DTO.
             List<Long> groupIds = assignments.stream().map(AssignmentDTO::getGroupId).distinct().collect(Collectors.toList());
-            Map<Long, String> groupNameMap = new HashMap<>();
-            for (Long groupId: groupIds) {
-                UserGroupDTO group = groupManager.getGroupById(groupId);
-                groupNameMap.put(groupId, getFilteredGroupNameFromGroup(group));
-            }
+            List<UserGroupDTO> groups = groupManager.getGroupsByIds(groupIds, false);
+            Map<Long, String> groupNameMap = groups.stream().collect(Collectors.toMap(UserGroupDTO::getId, NameFormatter::getFilteredGroupNameFromGroup));
 
             for (AssignmentDTO assignment : assignments) {
                 assignment.setGameboard(gameboardsMap.get(assignment.getGameboardId()));

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -398,6 +398,14 @@ public class GroupManager {
         return convertGroupToDTO(group);
     }
 
+    public List<UserGroupDTO> getGroupsByIds(final List<Long> groupIds, final Boolean augmentGroups) throws SegueDatabaseException {
+
+        List<UserGroup> groups = groupDatabase.findGroupsByIds(groupIds);
+
+        return convertGroupsToDTOs(groups, augmentGroups);
+
+    }
+
     /**
      * Add a user to the list of additional managers who are allowed to manage the group.
      *
@@ -758,16 +766,14 @@ public class GroupManager {
         return groupProgressSummary;
     }
 
-    public <T extends IAssignmentLike> List<T> filterItemsBasedOnMembershipContext(List<T> assignments, Long userId) throws SegueDatabaseException {
-        Map<Long, Map<Long, GroupMembershipDTO>> groupIdToUserMembershipInfoMap = Maps.newHashMap();
+    public <T extends IAssignmentLike> List<T> filterItemsBasedOnMembershipContext(final List<T> assignments, final Long userId) throws SegueDatabaseException {
         List<T> results = Lists.newArrayList();
 
-        for (T assignment : assignments) {
-            if (!groupIdToUserMembershipInfoMap.containsKey(assignment.getGroupId())) {
-                groupIdToUserMembershipInfoMap.put(assignment.getGroupId(), this.getUserMembershipMapForGroup(assignment.getGroupId()));
-            }
+        Map<Long, GroupMembership> groupMembershipMap = groupDatabase.getGroupMembershipMapForUser(userId);
 
-            GroupMembershipDTO membershipRecord = groupIdToUserMembershipInfoMap.get(assignment.getGroupId()).get(userId);
+        for (T assignment : assignments) {
+
+            GroupMembership membershipRecord = groupMembershipMap.get(assignment.getGroupId());
             // if they are inactive and they became inactive before the assignment was sent we want to skip the assignment.
             Date assignmentStartDate = null;
             if (assignment instanceof AssignmentDTO) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserGroupPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserGroupPersistenceManager.java
@@ -86,6 +86,15 @@ public interface IUserGroupPersistenceManager {
     UserGroup findGroupById(Long groupId) throws SegueDatabaseException;
 
     /**
+     * Get a list of groups by IDs.
+     *
+     * @param groupIds the IDs of the groups in question.
+     * @return a list of the group objects
+     * @throws SegueDatabaseException on error
+     */
+    List<UserGroup> findGroupsByIds(List<Long> groupIds) throws SegueDatabaseException;
+
+    /**
      * Create a group that users can be assigned to.
      * 
      * This is only to support organisation of accounts that can access data about other users.
@@ -181,6 +190,14 @@ public interface IUserGroupPersistenceManager {
      * @throws SegueDatabaseException
      */
     Map<Long, GroupMembership> getGroupMembershipMap(Long groupId) throws SegueDatabaseException;
+
+    /**
+     * Create a map of group id to membership status for a specified user.
+     * @param userId of interest
+     * @return Map of group ID to the user's group membership status
+     * @throws SegueDatabaseException on error
+     */
+    Map<Long, GroupMembership> getGroupMembershipMapForUser(Long userId) throws SegueDatabaseException;
 
     /**
      * getGroupMembershipList.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
@@ -15,6 +15,21 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao.users;
 
+import com.google.api.client.util.Lists;
+import com.google.api.client.util.Sets;
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.dos.GroupMembership;
+import uk.ac.cam.cl.dtg.isaac.dos.GroupMembershipStatus;
+import uk.ac.cam.cl.dtg.isaac.dos.GroupStatus;
+import uk.ac.cam.cl.dtg.isaac.dos.UserGroup;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
+
+import jakarta.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -22,27 +37,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.google.api.client.util.Sets;
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.Validate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
-import uk.ac.cam.cl.dtg.isaac.dos.GroupMembership;
-import uk.ac.cam.cl.dtg.isaac.dos.GroupMembershipStatus;
-import uk.ac.cam.cl.dtg.isaac.dos.GroupStatus;
-import uk.ac.cam.cl.dtg.isaac.dos.UserGroup;
-import com.google.api.client.util.Lists;
-import com.google.inject.Inject;
-
-import jakarta.annotation.Nullable;
+import java.util.stream.Collectors;
 
 /**
  * PgUserGroupPersistenceManager.
@@ -282,6 +282,40 @@ public class PgUserGroupPersistenceManager implements IUserGroupPersistenceManag
     }
 
     @Override
+    public List<UserGroup> findGroupsByIds(final List<Long> groupIds) throws SegueDatabaseException {
+
+        if (null == groupIds || groupIds.size() == 0) {
+            return Collections.emptyList();
+        }
+
+        String query = "SELECT * FROM groups WHERE id IN ("
+                + groupIds.stream().map(g -> "?").collect(Collectors.joining(", "))
+                + ") AND group_status <> ?;";
+
+        try (Connection conn = database.getDatabaseConnection();
+             PreparedStatement pst = conn.prepareStatement(query)
+        ) {
+            int index = 1;
+            for (Long groupId : groupIds) {
+                pst.setLong(index++, groupId);
+            }
+            pst.setString(index, GroupStatus.DELETED.name());
+
+            try (ResultSet results = pst.executeQuery()) {
+                List<UserGroup> listOfResults = Lists.newArrayList();
+                while (results.next()) {
+                    listOfResults.add(this.buildGroup(results));
+                }
+
+                return listOfResults;
+            }
+
+        } catch (SQLException e) {
+            throw new SegueDatabaseException("Postgres exception", e);
+        }
+    }
+
+    @Override
     public void deleteGroup(final Long groupId) throws SegueDatabaseException {
         this.deleteGroup(groupId, true);
     }
@@ -335,6 +369,29 @@ public class PgUserGroupPersistenceManager implements IUserGroupPersistenceManag
                 Map<Long, GroupMembership> mapOfResults = Maps.newHashMap();
                 while (results.next()) {
                     mapOfResults.put(results.getLong("user_id"), this.buildMembershipRecord(results));
+                }
+                return mapOfResults;
+            }
+        } catch (SQLException e) {
+            throw new SegueDatabaseException("Postgres exception", e);
+        }
+    }
+
+    @Override
+    public Map<Long, GroupMembership> getGroupMembershipMapForUser(final Long userId) throws SegueDatabaseException {
+        String query = "SELECT * FROM group_memberships INNER JOIN groups ON " +
+                "groups.id = group_memberships.group_id WHERE user_id = ? AND status <> ? AND group_status <> ?";
+        try (Connection conn = database.getDatabaseConnection();
+             PreparedStatement pst = conn.prepareStatement(query);
+        ) {
+            pst.setLong(1, userId);
+            pst.setString(2, GroupMembershipStatus.DELETED.name());
+            pst.setString(3, GroupStatus.DELETED.name());
+
+            try (ResultSet results = pst.executeQuery()) {
+                Map<Long, GroupMembership> mapOfResults = Maps.newHashMap();
+                while (results.next()) {
+                    mapOfResults.put(results.getLong("group_id"), this.buildMembershipRecord(results));
                 }
                 return mapOfResults;
             }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -17,30 +17,34 @@ package uk.ac.cam.cl.dtg.isaac;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import ma.glasnost.orika.MapperFacade;
 import org.junit.Before;
 import uk.ac.cam.cl.dtg.isaac.api.Constants;
+import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.QuizManager;
+import uk.ac.cam.cl.dtg.isaac.dos.GroupMembership;
+import uk.ac.cam.cl.dtg.isaac.dos.GroupMembershipStatus;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuestionBase;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuiz;
 import uk.ac.cam.cl.dtg.isaac.dos.QuizFeedbackMode;
+import uk.ac.cam.cl.dtg.isaac.dos.users.EmailVerificationStatus;
+import uk.ac.cam.cl.dtg.isaac.dos.users.Gender;
+import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuestionBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizSectionDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAssignmentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAttemptDTO;
-import uk.ac.cam.cl.dtg.segue.api.managers.GroupManager;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
-import uk.ac.cam.cl.dtg.isaac.dos.GroupMembershipStatus;
-import uk.ac.cam.cl.dtg.isaac.dos.users.EmailVerificationStatus;
-import uk.ac.cam.cl.dtg.isaac.dos.users.Gender;
-import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
 import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.UserGroupDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.QuizSummaryDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.GroupMembershipDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryWithEmailAddressDTO;
+import uk.ac.cam.cl.dtg.segue.api.managers.GroupManager;
+import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.users.IUserGroupPersistenceManager;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,8 +57,8 @@ import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.getCurrentArguments;
+import static org.easymock.EasyMock.partialMockBuilder;
 import static org.powermock.api.easymock.PowerMock.createMock;
-import static org.powermock.api.easymock.PowerMock.createPartialMockForAllMethodsExcept;
 import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.reset;
 import static org.powermock.api.easymock.PowerMock.verify;
@@ -119,6 +123,7 @@ public class IsaacTest {
     protected IsaacQuestionBase questionPageQuestionDO;
 
     protected GroupManager groupManager;
+    protected IUserGroupPersistenceManager groupDatabase;
     protected QuizManager quizManager;
 
     protected Map<Object, MockConfigurer> defaultsMap = new HashMap<>();
@@ -260,7 +265,19 @@ public class IsaacTest {
             expect(m.extractSectionObjects(studentQuiz)).andStubReturn(ImmutableList.of(quizSection1, quizSection2));
         });
 
-        groupManager = createPartialMockForAllMethodsExcept(GroupManager.class, "filterItemsBasedOnMembershipContext");
+        // We want to actually test the behaviour of the real GroupManager::filterItemsBasedOnMembershipContext, but
+        // otherwise want to mock the methods. Unfortunately, this method internally calls the groupDatabase object
+        // we cannot mock straightforwardly, hence this partial mock madness.
+        groupDatabase = createMock(IUserGroupPersistenceManager.class);
+        UserAccountManager userAccountManager = createMock(UserAccountManager.class);
+        GameManager gameManager = createMock(GameManager.class);
+        MapperFacade mapperFacade = createMock(MapperFacade.class);
+        groupManager = partialMockBuilder(GroupManager.class)
+                .withConstructor(groupDatabase, userAccountManager, gameManager, mapperFacade)
+                .addMockedMethod("getGroupById").addMockedMethod("isUserInGroup").addMockedMethod("getGroupMembershipList", RegisteredUserDTO.class, boolean.class)
+                .addMockedMethod("getUsersInGroup").addMockedMethod("getUserMembershipMapForGroup").addMockedMethod("getAllGroupsOwnedAndManagedByUser")
+                .createMock();
+
         expect(groupManager.getGroupById(anyLong())).andStubAnswer(() -> {
             Object[] arguments = getCurrentArguments();
             if (arguments[0] == studentGroup.getId()) {
@@ -281,19 +298,17 @@ public class IsaacTest {
         });
         expect(groupManager.getGroupMembershipList(student, false)).andStubReturn(ImmutableList.of(studentGroup, studentInactiveGroup));
         expect(groupManager.getGroupMembershipList(secondStudent, false)).andStubReturn(ImmutableList.of(studentGroup));
-        expect(groupManager.getUserMembershipMapForGroup(studentGroup.getId())).andStubReturn(
-            ImmutableMap.of(
-                student.getId(), new GroupMembershipDTO(studentGroup.getId(), student.getId(), GroupMembershipStatus.ACTIVE, null, somePastDate),
-                secondStudent.getId(), new GroupMembershipDTO(studentGroup.getId(), secondStudent.getId(), GroupMembershipStatus.ACTIVE, null, somePastDate)
-            )
-        );
-        Date beforeSomePastDate = new Date(somePastDate.getTime() - 1000L);
-        expect(groupManager.getUserMembershipMapForGroup(studentInactiveGroup.getId())).andStubReturn(
-            Collections.singletonMap(student.getId(), new GroupMembershipDTO(studentGroup.getId(), student.getId(), GroupMembershipStatus.INACTIVE, null, beforeSomePastDate))
-        );
         expect(groupManager.getUsersInGroup(studentGroup)).andStubReturn(ImmutableList.of(student, secondStudent));
+        Date beforeSomePastDate = new Date(somePastDate.getTime() - 1000L);
+        expect(groupDatabase.getGroupMembershipMapForUser(student.getId())).andStubReturn(ImmutableMap.of(
+                studentGroup.getId(), new GroupMembership(studentGroup.getId(), student.getId(), GroupMembershipStatus.ACTIVE, null, somePastDate),
+                studentInactiveGroup.getId(), new GroupMembership(studentInactiveGroup.getId(), student.getId(), GroupMembershipStatus.INACTIVE, null, beforeSomePastDate)
+        ));
+        expect(groupDatabase.getGroupMembershipMapForUser(student.getId())).andStubReturn(ImmutableMap.of(
+                studentGroup.getId(), new GroupMembership(studentGroup.getId(), secondStudent.getId(), GroupMembershipStatus.ACTIVE, null, somePastDate)
+        ));
 
-        replay(quizManager, groupManager);
+        replay(quizManager, groupManager, groupDatabase, userAccountManager, gameManager, mapperFacade);
     }
 
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -33,17 +33,12 @@ import uk.ac.cam.cl.dtg.isaac.api.services.AssignmentService;
 import uk.ac.cam.cl.dtg.isaac.api.services.ContentSummarizerService;
 import uk.ac.cam.cl.dtg.isaac.dos.QuizFeedbackMode;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.QuestionValidationResponseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAssignmentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAttemptDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizAttemptFeedbackDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizFeedbackDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuizUserFeedbackDTO;
-import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
-import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
-import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
-import uk.ac.cam.cl.dtg.isaac.dto.QuestionValidationResponseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.isaac.dto.UserGroupDTO;
@@ -52,6 +47,11 @@ import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.QuizSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
+import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import jakarta.ws.rs.core.EntityTag;
@@ -174,7 +174,7 @@ public class QuizFacadeTest extends AbstractFacadeTest {
         expect(contentManager.getContentDOById(studentQuizDO.getId())).andStubReturn(studentQuizDO);
         expect(contentManager.getContentDOById(questionPageQuestionDO.getId())).andStubReturn(questionPageQuestionDO);
 
-        replay(requestForCaching, properties, logManager, contentManager, contentSummarizerService, quizManager, groupManager, quizAssignmentManager,
+        replay(requestForCaching, properties, logManager, contentManager, contentSummarizerService, quizManager, quizAssignmentManager,
             assignmentService, quizAttemptManager, quizQuestionManager, associationManager);
     }
 


### PR DESCRIPTION
This adds two new database methods for loading bulk group information: one to bulk load groups themselves, and one to load a user's group membership status specifically rather than group by group.

Loading the groups in bulk, and only optionally augmenting them with owner and manager information, removes the need for many database queries: before the /assignments endpoint required `n_groups x (2 + n_managers_per_group)` queries to load group data, from which only the group name was used. Now it requires just 1 query since most of the information was not needed and can be skipped.

We also then filtered the assignments by the user's group membership status, but the only way to do this was to load the statuses for _all_ users in a group, for each group. This adds a new endpoint to load a specific user's group status for all their groups, reducing the number of queries required down to always 1.

For /assignments this reduces the total number of queries from `~ (n_groups x (3 + n_managers_per_group)) + n_teachers + 4` down to `6 + n_teachers` which is a vast improvement!

(I re-ordered some imports, since IntelliJ's "Optimise Imports" was unhappy with their ordering, but this are safe to ignore).