### PR TITLE
Question loading refactor

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -506,7 +506,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                 questionPageIds.add(questionPage.getId());
             }
             Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> questionAttempts;
-            questionAttempts = this.questionManager.getMatchingQuestionAttempts(groupMembers, questionPageIds);
+            questionAttempts = this.questionManager.getMatchingLightweightQuestionAttempts(groupMembers, questionPageIds);
 
             Map<RegisteredUserDTO, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>>
                     questionAttemptsForAllUsersOfInterest = new HashMap<>();
@@ -733,7 +733,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
             List<String> questionPageIds = gameboardItems.stream().map(GameboardItem::getId).collect(Collectors.toList());
             Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> questionAttempts;
             try {
-                questionAttempts = this.questionManager.getMatchingQuestionAttempts(groupMembers, questionPageIds);
+                questionAttempts = this.questionManager.getMatchingLightweightQuestionAttempts(groupMembers, questionPageIds);
             } catch (IllegalArgumentException e) {
                 questionAttempts = new HashMap<>();
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -255,7 +255,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
                 userQuestionAttempts = this.questionManager.getQuestionAttemptsByUser(randomUser);
             } else {
                 List<String> gameboardPageIds = unAugmentedGameboard.getContents().stream().map(GameboardItem::getId).collect(Collectors.toList());
-                userQuestionAttempts = this.questionManager.getMatchingQuestionAttempts((RegisteredUserDTO) randomUser, gameboardPageIds);
+                userQuestionAttempts = this.questionManager.getMatchingLightweightQuestionAttempts((RegisteredUserDTO) randomUser, gameboardPageIds);
             }
 
             // Calculate the ETag

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -30,9 +30,11 @@ import uk.ac.cam.cl.dtg.isaac.api.managers.InvalidGameboardException;
 import uk.ac.cam.cl.dtg.isaac.api.managers.NoWildcardException;
 import uk.ac.cam.cl.dtg.isaac.dos.GameboardCreationMethod;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacWildcard;
+import uk.ac.cam.cl.dtg.isaac.dos.LightweightQuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardItem;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardListDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
@@ -67,6 +69,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.Maps.immutableEntry;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
@@ -239,13 +242,20 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             GameboardDTO gameboard;
 
             AbstractSegueUserDTO randomUser = this.userManager.getCurrentUser(httpServletRequest);
-            Map<String, Map<String, List<QuestionValidationResponse>>> userQuestionAttempts = this.questionManager
-                    .getQuestionAttemptsByUser(randomUser);
 
             GameboardDTO unAugmentedGameboard = gameManager.getGameboard(gameboardId);
             if (null == unAugmentedGameboard) {
                 return new SegueErrorResponse(Status.NOT_FOUND, "No Gameboard found for the id specified.")
                         .toResponse();
+            }
+
+            Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>> userQuestionAttempts;
+
+            if (randomUser instanceof AnonymousUserDTO) {
+                userQuestionAttempts = this.questionManager.getQuestionAttemptsByUser(randomUser);
+            } else {
+                List<String> gameboardPageIds = unAugmentedGameboard.getContents().stream().map(GameboardItem::getId).collect(Collectors.toList());
+                userQuestionAttempts = this.questionManager.getMatchingQuestionAttempts((RegisteredUserDTO) randomUser, gameboardPageIds);
             }
 
             // Calculate the ETag

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -460,8 +460,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                     userIdForRandomisation = ((RegisteredUserDTO) user).getId().toString();
                 }
 
-                content = this.questionManager.augmentQuestionObjects(content, userIdForRandomisation,
-                        userQuestionAttempts);
+                this.questionManager.augmentQuestionObjects(content, userIdForRandomisation, userQuestionAttempts);
 
                 // the request log
                 getLogManager().logEvent(user, httpServletRequest, IsaacServerLogType.VIEW_QUESTION, logEntry);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -455,7 +455,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                     userIdForRandomisation = registeredUser.getId().toString();
 
                     List<String> relatedQuestionIds = new ArrayList<>(getRelatedContentIds(content));
-                    relatedQuestionAttempts = questionManager.getMatchingQuestionAttempts(registeredUser, relatedQuestionIds);
+                    relatedQuestionAttempts = questionManager.getMatchingLightweightQuestionAttempts(registeredUser, relatedQuestionIds);
 
                     questionAttempts = questionManager.getQuestionAttemptsByUserForQuestion(registeredUser, questionId);
                 }
@@ -551,7 +551,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                 relatedQuestionAttempts = questionManager.getQuestionAttemptsByUser(user);
             } else {
                 List<String> relatedQuestionIds = getRelatedContentIds(topicSummaryDTO);
-                relatedQuestionAttempts = questionManager.getMatchingQuestionAttempts((RegisteredUserDTO) user, relatedQuestionIds);
+                relatedQuestionAttempts = questionManager.getMatchingLightweightQuestionAttempts((RegisteredUserDTO) user, relatedQuestionIds);
             }
 
             this.augmentContentWithRelatedContent(topicSummaryDTO, relatedQuestionAttempts);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -521,6 +521,7 @@ public class PagesFacade extends AbstractIsaacFacade {
 
         // Calculate the ETag on current live version of the content
         // NOTE: Assumes that the latest version of the content is being used.
+        // Should this include the question attempts?
         EntityTag etag = new EntityTag(this.contentManager.getCurrentContentSHA().hashCode() + topicId.hashCode() + "");
         Response cachedResponse = generateCachedResponse(request, etag);
         if (cachedResponse != null) {
@@ -582,8 +583,11 @@ public class PagesFacade extends AbstractIsaacFacade {
                     .put(CONTENT_VERSION_FIELDNAME, this.contentManager.getCurrentContentSHA()).build();
             getLogManager().logEvent(user, httpServletRequest, IsaacServerLogType.VIEW_TOPIC_SUMMARY_PAGE, logEntry);
 
+            // If there are no question attempts, this is safe to cache.
+            boolean isPublicData = relatedQuestionAttempts.isEmpty();
+
             return Response.status(Status.OK).entity(topicSummaryDTO)
-                    .cacheControl(getCacheControl(NUMBER_SECONDS_IN_ONE_HOUR, true)).tag(etag).build();
+                    .cacheControl(getCacheControl(NUMBER_SECONDS_IN_ONE_HOUR, isPublicData)).tag(etag).build();
         } catch (SegueDatabaseException e) {
             SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
                     "Database error while looking up user information.", e);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -323,7 +323,7 @@ public class GameManager {
         List<GameboardDTO> gameboardsByIds = this.gameboardPersistenceManager.getGameboardsByIds(gameboardIds);
         List<String> questionPageIds = gameboardsByIds.stream().map(GameboardDTO::getContents).flatMap(Collection::stream).map(GameboardItem::getId).collect(Collectors.toList());
         Map<String, Map<String, List<LightweightQuestionValidationResponse>>> userQuestionAttempts =
-                questionManager.getMatchingQuestionAttempts(user, questionPageIds);
+                questionManager.getMatchingLightweightQuestionAttempts(user, questionPageIds);
         for (GameboardDTO gb : gameboardsByIds) {
             augmentGameboardWithQuestionAttemptInformation(gb, userQuestionAttempts);
         }
@@ -415,7 +415,7 @@ public class GameManager {
 
         List<String> questionPageIds = usersGameboards.stream().map(GameboardDTO::getContents).flatMap(Collection::stream).map(GameboardItem::getId).collect(Collectors.toList());
         Map<String, Map<String, List<LightweightQuestionValidationResponse>>> questionAttemptsFromUser =
-                questionManager.getMatchingQuestionAttempts(user, questionPageIds);
+                questionManager.getMatchingLightweightQuestionAttempts(user, questionPageIds);
 
         List<GameboardDTO> resultToReturn = Lists.newArrayList();
 
@@ -648,7 +648,7 @@ public class GameManager {
 
         Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>>
                 questionAttemptsForAllUsersOfInterest =
-                questionManager.getMatchingQuestionAttempts(users, questionPageIds);
+                questionManager.getMatchingLightweightQuestionAttempts(users, questionPageIds);
 
         for (RegisteredUserDTO user : users) {
             List<GameboardItem> userGameItems = Lists.newArrayList();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -374,7 +374,7 @@ public class GameManager {
      *             - if there is an error retrieving the content requested.
      */
     public final GameboardDTO getGameboard(final String gameboardId, final AbstractSegueUserDTO user,
-            final Map<String, Map<String, List<QuestionValidationResponse>>> userQuestionAttempts)
+            final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>> userQuestionAttempts)
             throws SegueDatabaseException, ContentManagerException {
 
 
@@ -750,7 +750,7 @@ public class GameManager {
      *             - if there is an error retrieving the content requested.
      */
     private GameboardDTO augmentGameboardWithQuestionAttemptInformationAndUserInformation(final GameboardDTO gameboardDTO,
-                                                                                          final Map<String, Map<String, List<QuestionValidationResponse>>> questionAttemptsFromUser,
+                                                                                          final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>> questionAttemptsFromUser,
                                                                                           final AbstractSegueUserDTO user)
             throws SegueDatabaseException, ContentManagerException {
         if (user instanceof RegisteredUserDTO) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IQuestionAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IQuestionAttemptManager.java
@@ -47,6 +47,18 @@ public interface IQuestionAttemptManager {
             throws SegueDatabaseException;
 
     /**
+     * Get a users question attempts on a specific question page.
+     *
+     * @param userId - the id of the user to search for.
+     * @param questionPageId - the id of the question.
+     * @return the questionAttempts map or an empty map if the user has not yet registered any attempts.
+     * @throws SegueDatabaseException
+     *             - If there is a database error.
+     */
+    Map<String, Map<String, List<QuestionValidationResponse>>> getQuestionAttempts(Long userId, String questionPageId)
+            throws SegueDatabaseException;
+
+    /**
      * A method that makes a single database request for a group of users and questions to get all of their attempt
      * information back.
      * 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IQuestionAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IQuestionAttemptManager.java
@@ -74,7 +74,7 @@ public interface IQuestionAttemptManager {
      *             - if a database error occurrs
      */
     Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>>
-            getQuestionAttemptsByUsersAndQuestionPrefix(List<Long> userIds, List<String> questionPage)
+        getMatchingLightweightQuestionAttempts(List<Long> userIds, List<String> questionPage)
             throws SegueDatabaseException;
     
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
@@ -284,7 +284,7 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
     
     @Override
     public Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>>
-            getQuestionAttemptsByUsersAndQuestionPrefix(final List<Long> userIds, final List<String> allQuestionPageIds)
+        getMatchingLightweightQuestionAttempts(final List<Long> userIds, final List<String> allQuestionPageIds)
             throws SegueDatabaseException {
         if (allQuestionPageIds.isEmpty()) {
             log.error("Attempted to fetch group progress for an empty gameboard.");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -412,31 +412,30 @@ public class QuestionManager {
      * @return a map of user id to question page id to question_id to list of attempts.
      * @throws SegueDatabaseException if there is a database error.
      */
-    public Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> getMatchingQuestionAttempts(
+    public Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> getMatchingLightweightQuestionAttempts(
             final List<RegisteredUserDTO> users, final List<String> questionPageIds) throws SegueDatabaseException {
         List<Long> userIds = Lists.newArrayList();
         for (RegisteredUserDTO user : users) {
             userIds.add(user.getId());
         }
 
-        return this.questionAttemptPersistenceManager.getQuestionAttemptsByUsersAndQuestionPrefix(userIds,
-                questionPageIds);
+        return this.questionAttemptPersistenceManager.getMatchingLightweightQuestionAttempts(userIds, questionPageIds);
     }
 
     /**
      *  Helper method for attempts from a single user.
      *
-     * @see #getMatchingQuestionAttempts(List, List)
+     * @see #getMatchingLightweightQuestionAttempts(List, List)
      *
      * @param user who we are interested in.
      * @param questionPageIds we want to look up.
      * @return a map of user id to question page id to question_id to list of attempts.
      * @throws SegueDatabaseException if there is a database error.
      */
-    public Map<String, Map<String, List<LightweightQuestionValidationResponse>>> getMatchingQuestionAttempts(
+    public Map<String, Map<String, List<LightweightQuestionValidationResponse>>> getMatchingLightweightQuestionAttempts(
             final RegisteredUserDTO user, final List<String> questionPageIds) throws SegueDatabaseException {
 
-        return this.getMatchingQuestionAttempts(Collections.singletonList(user), questionPageIds).get(user.getId());
+        return this.getMatchingLightweightQuestionAttempts(Collections.singletonList(user), questionPageIds).get(user.getId());
     }
     
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -219,16 +219,14 @@ public class QuestionManager {
      *            - as a map of QuestionPageId to Map of QuestionId to QuestionValidationResponseDO
      * @return augmented page - the return result is by convenience as the page provided as a parameter will be mutated.
      */
-    public SeguePageDTO augmentQuestionObjects(final SeguePageDTO page, final String userId,
+    public void augmentQuestionObjects(final SeguePageDTO page, final String userId,
             final Map<String, Map<String, List<QuestionValidationResponse>>> usersQuestionAttempts) {
 
         List<QuestionDTO> questionsToAugment = extractQuestionObjects(page);
 
-        this.augmentQuestionObjectWithAttemptInformation(page, questionsToAugment, usersQuestionAttempts);
+        augmentQuestionObjectWithAttemptInformation(page, questionsToAugment, usersQuestionAttempts);
 
         shuffleChoiceQuestionsChoices(userId, questionsToAugment);
-
-        return page;
     }
 
     /**
@@ -241,14 +239,13 @@ public class QuestionManager {
      *            - The flattened list of questions which should be augmented.
      * @param usersQuestionAttempts
      *            - as a map of QuestionPageId to Map of QuestionId to QuestionValidationResponseDO
-     * @return augmented page - the return result is by convenience as the page provided as a parameter will be mutated.
      */
-    private SeguePageDTO augmentQuestionObjectWithAttemptInformation(final SeguePageDTO page,
+    private void augmentQuestionObjectWithAttemptInformation(final SeguePageDTO page,
             final List<QuestionDTO> questionsToAugment,
             final Map<String, Map<String, List<QuestionValidationResponse>>> usersQuestionAttempts) {
 
         if (null == usersQuestionAttempts) {
-            return page;
+            return;
         }
 
         for (QuestionDTO question : questionsToAugment) {
@@ -280,7 +277,6 @@ public class QuestionManager {
             question.setBestAttempt(this.convertQuestionValidationResponseToDTO(bestAnswer));
 
         }
-        return page;
     }
 
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -27,24 +27,17 @@ import org.apache.commons.lang3.Validate;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.isaac.configuration.IsaacApplicationRegister;
-import uk.ac.cam.cl.dtg.isaac.dos.TestCase;
-import uk.ac.cam.cl.dtg.isaac.dos.TestQuestion;
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacItemQuestionDTO;
-import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval;
-import uk.ac.cam.cl.dtg.segue.api.ErrorResponseWrapper;
-import uk.ac.cam.cl.dtg.segue.configuration.SegueGuiceConfigurationModule;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
 import uk.ac.cam.cl.dtg.isaac.dos.LightweightQuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dos.TestCase;
+import uk.ac.cam.cl.dtg.isaac.dos.TestQuestion;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ChoiceQuestion;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacItemQuestionDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.QuestionValidationResponseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
@@ -63,6 +56,12 @@ import uk.ac.cam.cl.dtg.isaac.quiz.IValidator;
 import uk.ac.cam.cl.dtg.isaac.quiz.SpecifiesWith;
 import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 import uk.ac.cam.cl.dtg.isaac.quiz.ValidatorUnavailableException;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import uk.ac.cam.cl.dtg.segue.api.ErrorResponseWrapper;
+import uk.ac.cam.cl.dtg.segue.configuration.SegueGuiceConfigurationModule;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
@@ -330,7 +329,7 @@ public class QuestionManager {
             log.error("Unexpected user type. Unable to record question response");
         }
     }
-
+    
     /** Test a question of a particular type against a series of test cases **/
     public List<TestCase> testQuestion(final String questionType, final TestQuestion testDefinition)
             throws BadRequestException, ValidatorUnavailableException {
@@ -389,6 +388,22 @@ public class QuestionManager {
             // since no user is logged in assume that we want to use any anonymous attempts
             return this.questionAttemptPersistenceManager.getAnonymousQuestionAttempts(anonymousUser.getSessionId());
         }
+    }
+
+    /**
+     * Return all the attempts of a user at a specified page ID prefix.
+     *
+     * The map returned by this method is in the same format as {@link #getQuestionAttemptsByUser(AbstractSegueUserDTO)}
+     * for compatibility.
+     *
+     * @param user the user of interest
+     * @param questionPageId the page ID prefix of interest
+     * @return a map QuestionPageID -> (QuestionID -> List[QuestionValidationResponse]).
+     * @throws SegueDatabaseException on database error
+     */
+    public Map<String, Map<String, List<QuestionValidationResponse>>> getQuestionAttemptsByUserForQuestion(
+            final RegisteredUserDTO user, final String questionPageId) throws SegueDatabaseException {
+        return questionAttemptPersistenceManager.getQuestionAttempts(user.getId(), questionPageId);
     }
     
     /**


### PR DESCRIPTION
For historic reasons (MongoDB! 😡), when loading a [question page/topic summary/gameboard] we would load every single question attempt a user had ever made. We did this on question pages because we need both the attempts at the question parts on the question page, but also the attempts at any related questions. The others just inherited the approach.

For registered users we can optimise this. Instead we now load the question attempts for the specific page in full; i.e. the complete `QuestionValidationResponses`. We need these in full for the bestAttempt attribute on the question page.
For related questions and gameboard items, we can instead load `LightweightQuestionValidationResponses` since we don't need to deserialise all of the JSON to say whether they are complete or not. We can walk the content and only load the questions for the relevant question page IDs.
Anonymous users have less question attempts and there are no equivalent methods for loading a subset of attempts (they still live in one JSON blob just like MongoDB), so we just load everything for them.

There's my new favourite Java type: `Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>>` all over the place, instead of `Map<String, Map<String, List<QuestionValidationResponse>>>` or the lightweight equivalent. I had used this before in some places, but now it is everywhere. This allows us to say "we only _**need**_ Lightweight validation responses" but accept full validation responses in some cases (like anonymous users for whom we only ever have full responses). It's a pain to read, but very powerful.


---

The main place left, that this improved approach won't work for, but that still faces the main issue is the `generateTemporaryGameboard` method; i.e. making a new random gameboard. We try to load questions you have not completed; but how to we do that without loading the questions in advance?