### PR TITLE
Avoid caching mutable objects

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -737,7 +737,7 @@ public class GameboardPersistenceManager {
             // Search for questions that match the ids.
             ResultsWrapper<ContentDTO> results;
             try {
-                results = this.contentManager.getContentMatchingIds(
+                results = this.contentManager.getUnsafeCachedContentDTOsMatchingIds(
                         questionsIds, 0, contentDescriptorBatch.size());
             } catch (ContentManagerException e) {
                 results = new ResultsWrapper<ContentDTO>();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
@@ -143,7 +143,7 @@ public class GlossaryFacade extends AbstractSegueFacade {
 
         ResultsWrapper<ContentDTO> c;
         try {
-            c = this.contentManager.getByIdPrefix(term_id, 0, 10000);
+            c = this.contentManager.getUnsafeCachedDTOsByIdPrefix(term_id, 0, 10000);
             if (null == c) {
                 SegueErrorResponse error = new SegueErrorResponse(Status.NOT_FOUND, "No glossary term found with id: " + term_id);
                 log.debug(error.getErrorMessage());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -779,7 +779,7 @@ public class StatisticsManager implements IStatisticsManager {
 
         // Search for questions that match the ids.
         ResultsWrapper<ContentDTO> allMatchingIds =
-                this.contentManager.getContentMatchingIds(ids,
+                this.contentManager.getUnsafeCachedContentDTOsMatchingIds(ids,
                         0, ids.size());
 
         List<ContentDTO> questionsForGameboard = allMatchingIds.getResults();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -254,8 +254,8 @@ public class GitContentManager {
      * @return a ResultsWrapper of the matching content.
      * @throws ContentManagerException on failure to return the objects.
      */
-    public ResultsWrapper<ContentDTO> getByIdPrefix(final String idPrefix, final int startIndex,
-                                                    final int limit) throws ContentManagerException {
+    public ResultsWrapper<ContentDTO> getUnsafeCachedDTOsByIdPrefix(final String idPrefix, final int startIndex,
+                                                                    final int limit) throws ContentManagerException {
 
         String k = "getByIdPrefix~" + getCurrentContentSHA() + "~" + idPrefix + "~" + startIndex + "~" + limit;
         if (!cache.asMap().containsKey(k)) {
@@ -285,8 +285,8 @@ public class GitContentManager {
      * @return a ResultsWrapper of the matching content.
      * @throws ContentManagerException on failure to return the objects.
      */
-    public ResultsWrapper<ContentDTO> getContentMatchingIds(final Collection<String> ids,
-                                                            final int startIndex, final int limit)
+    public ResultsWrapper<ContentDTO> getUnsafeCachedContentDTOsMatchingIds(final Collection<String> ids,
+                                                                            final int startIndex, final int limit)
             throws ContentManagerException {
 
         String k = "getContentMatchingIds~" + getCurrentContentSHA() + "~" + ids.toString() + "~" + startIndex + "~" + limit;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -30,16 +30,15 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.database.GitDb;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.QuestionDTO;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.database.GitDb;
 import uk.ac.cam.cl.dtg.segue.search.AbstractFilterInstruction;
-import uk.ac.cam.cl.dtg.segue.search.BooleanInstruction;
 import uk.ac.cam.cl.dtg.segue.search.ISearchProvider;
 import uk.ac.cam.cl.dtg.segue.search.IsaacSearchInstructionBuilder;
 import uk.ac.cam.cl.dtg.segue.search.IsaacSearchInstructionBuilder.Priority;
@@ -158,10 +157,9 @@ public class GitContentManager {
     /**
      *  Get a DTO object by its ID or return null.
      *
-     *  This may return a cached object, and will temporarily cache the object.
-     *  Do not modify the returned DTO object.
-     *  The object will be retrieved in DO form, and mapped to a DTO. Both versions will be
-     *  locally cached to avoid re-querying the data store and the deserialization costs.
+     *  The object will be retrieved in DO form, and mapped to a DTO.
+     *  The DO version will be cached to avoid re-querying the data store, but the DTO
+     *  will not be cached to avoid mutations poisoning the cache.
      *
      * @param id the content object ID.
      * @return the content DTO object.
@@ -174,10 +172,9 @@ public class GitContentManager {
     /**
      *  Get a DTO object by its ID or return null.
      *
-     *  This may return a cached object, and will temporarily cache the object.
-     *  Do not modify the returned DTO object.
-     *  The object will be retrieved in DO form, and mapped to a DTO. Both versions will be
-     *  locally cached to avoid re-querying the data store and the deserialization costs.
+     *  The object will be retrieved in DO form, and mapped to a DTO.
+     *  The DO version will be cached to avoid re-querying the data store, but the DTO
+     *  will not be cached to avoid mutations poisoning the cache.
      *
      * @param id the content object ID.
      * @param failQuietly whether to log a warning if the content cannot be found.
@@ -185,15 +182,7 @@ public class GitContentManager {
      * @throws ContentManagerException on failure to return the object or null.
      */
     public final ContentDTO getContentById(final String id, final boolean failQuietly) throws ContentManagerException {
-        String k = "getContentById~" + getCurrentContentSHA() + "~" + id;
-        if (!cache.asMap().containsKey(k)) {
-            ContentDTO c = this.mapper.getDTOByDO(this.getContentDOById(id, failQuietly));
-            if (c != null) {
-                cache.put(k, c);
-            }
-        }
-
-        return (ContentDTO) cache.getIfPresent(k);
+        return this.mapper.getDTOByDO(this.getContentDOById(id, failQuietly));
     }
 
     /**


### PR DESCRIPTION
DTO objects exist to be transferred to the client, and we were caching them because it is expensive to load them from ElasticSearch and also expensive (but less so) to map them from DO to DTO form.

However, despite the warnings in the JavaDoc, we keep mutating the DTOs returned by the GCM without cloning them. This is understandable; they exist to contain user data for transfer.
Rather than ditch the cache entirely, we remove the cache for DTOs but continue to cache DOs, since the latter are actually supposed to be unchanging anyway and we do not mutate them anywhere at present.
This adds ~1-3ms onto a cache hit, but it prevents all sorts of data leaking from being possible. Since a cache miss is ~10ms, hopefully this extra time will be okay.

---

There are two methods that load objects in bulk. The results from these methods are currently not modified, and the performance penalty from removing the DTO cache is large enough to warrant keeping the methods. Instead of removing them, name them in a way that makes things unambiguous.