### PR TITLE
Improved page loading

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -920,40 +920,6 @@ public class PagesFacade extends AbstractIsaacFacade {
     }
 
     /**
-     * For use when we expect to only find a single result.
-     * 
-     * @param fieldsToMatch
-     *            - expects a map of the form fieldname -> list of queries to match
-     * @return A Response containing a single conceptPage or containing a SegueErrorResponse.
-     */
-    private Response findSingleResult(final Map<String, List<String>> fieldsToMatch) {
-        try {
-            ResultsWrapper<ContentDTO> resultList = api.findMatchingContent(this.contentIndex,
-                    ContentService.generateDefaultFieldToMatch(fieldsToMatch), null, null); // includes
-            // type
-            // checking.
-            ContentDTO c = null;
-            if (resultList.getResults().size() > 1) {
-                return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Multiple results ("
-                        + resultList.getResults().size() + ") returned error. For search query: " + fieldsToMatch.values())
-                        .toResponse();
-            } else if (resultList.getResults().isEmpty()) {
-                return new SegueErrorResponse(Status.NOT_FOUND, "No content found that matches the query with parameters: "
-                        + fieldsToMatch.values()).toResponse();
-            } else {
-                c = resultList.getResults().get(0);
-            }
-
-            return Response.ok(this.augmentContentWithRelatedContent(c, Maps.newHashMap())).build();
-        } catch (ContentManagerException e1) {
-            SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error locating the content requested",
-                    e1);
-            log.error(error.getErrorMessage(), e1);
-            return error.toResponse();
-        }
-    }
-
-    /**
      * Helper method to query segue for a list of content objects.
      * 
      * This method will only use the latest version of the content.


### PR DESCRIPTION
None of these methods used question attempts, and locally there is not much difference between the speed of the old method and the new one. Sometimes it could be 75% faster, sometimes the same time; it was never worse which is good enough for me. I expect better results on the server (where the cache is helpful and other things are happening in the API).

We now consistently used `getContentById` for loading pages and fragments of all kinds, and so `findSingleResult` can and has been removed. The code is easier to read since all the methods are very similar to one another. A later improvement might be to reduce the code duplication.