### PR TITLE
Use DOs for assignment and gameboard calculations

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -33,13 +33,13 @@ import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.api.services.AssignmentService;
 import uk.ac.cam.cl.dtg.isaac.dos.LightweightQuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 import uk.ac.cam.cl.dtg.isaac.dto.AssignmentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.AssignmentStatusDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardItem;
 import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.isaac.dto.UserGroupDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.content.QuestionDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.GroupManager;
@@ -536,7 +536,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
             for (GameboardItem questionPage : gameboard.getContents()) {
                 int index = 0;
 
-                for (QuestionDTO question : gameManager.getAllMarkableQuestionPartsDFSOrder(questionPage.getId())) {
+                for (Question question : gameManager.getAllMarkableDOQuestionPartsDFSOrder(questionPage.getId())) {
                     //int newCharIndex = 'A' + index; // decided not to try and match the front end.
                     int newCharIndex = index + 1;
                     if (question.getTitle() != null) {
@@ -816,7 +816,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                 GameboardDTO gameboard = assignmentGameboards.get(assignment);
                 for (GameboardItem questionPage : gameboard.getContents()) {
                     int b = 1;
-                    for (QuestionDTO question : gameManager.getAllMarkableQuestionPartsDFSOrder(questionPage.getId())) {
+                    for (Question question : gameManager.getAllMarkableDOQuestionPartsDFSOrder(questionPage.getId())) {
                         List<String> questionIds = gameboardQuestionIds.get(gameboard);
                         if (null == questionIds) {
                             questionIds = Lists.newArrayList();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -727,6 +727,9 @@ public class GameManager {
      * Get all questions in a piece of content. This method will conduct a DFS traversal and
      * ensure the collection is ordered as per the DFS. Quick questions will be filtered out.
      *
+     * See also {@link QuestionManager#extractQuestionObjectsRecursively(ContentDTO, List)}
+     * which does basically the same thing.
+     *
      * @param content
      *            - results depend on each question having an id prefixed with the question page id.
      * @return collection of markable question parts (questions).

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -505,7 +505,10 @@ public class QuestionManager {
 
     /**
      * Extract all of the questionObjectsRecursively.
-     * 
+     *
+     * See also {@link uk.ac.cam.cl.dtg.isaac.api.managers.GameManager#getAllMarkableQuestionPartsDFSOrder(ContentDTO)}
+     * which does basically the same thing.
+     *
      * @param toExtract
      *            - The contentDTO which may have question objects as children.
      * @param result


### PR DESCRIPTION
In these cases we were not using the question DTOs for transfer, but as reference for what parts a question contains. We can use DOs for this since they are the authoritative version of questions, and we do not plan to use the objects for anything which is transferred to the client. This avoids the need to create new DTO objects every time, and can use the DO cache.
