### PR TITLE
Stop using token owner for group join permissions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssociationToken.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssociationToken.java
@@ -72,6 +72,7 @@ public class AssociationToken {
      * 
      * @return the ownerUserId
      */
+    @Deprecated
     public Long getOwnerUserId() {
         return ownerUserId;
     }
@@ -82,6 +83,7 @@ public class AssociationToken {
      * @param ownerUserId
      *            the ownerUserId to set
      */
+    @Deprecated
     public void setOwnerUserId(final Long ownerUserId) {
         this.ownerUserId = ownerUserId;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
@@ -465,10 +465,9 @@ public class AuthorisationFacade extends AbstractSegueFacade {
             misuseMonitor.notifyEvent(currentRegisteredUser.getId().toString(),
                     TokenOwnerLookupMisuseHandler.class.getSimpleName());
 
-            // add owner
             List<UserSummaryWithEmailAddressDTO> usersLinkedToToken = Lists.newArrayList();
-            usersLinkedToToken.add(userManager.convertToDetailedUserSummaryObject(userManager.getUserDTOById(associationToken.getOwnerUserId()), UserSummaryWithEmailAddressDTO.class));
-
+            // add owner
+            usersLinkedToToken.add(group.getOwnerSummary());
             // add additional managers
             usersLinkedToToken.addAll(group.getAdditionalManagers());
 
@@ -485,8 +484,6 @@ public class AuthorisationFacade extends AbstractSegueFacade {
         } catch (SegueDatabaseException e) {
             log.error("Database error while trying to get association token. ", e);
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Database error", e).toResponse();
-        } catch (NoUserException e) {
-            return new SegueErrorResponse(Status.BAD_REQUEST, "Unable to locate user to verify identity").toResponse();
         } catch (SegueResourceMisuseException e) {
             String message = "You have exceeded the number of requests allowed for this endpoint. "
                     + "Please try again later.";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
@@ -234,15 +234,11 @@ public class UserAssociationManager {
 
         AssociationToken lookedupToken = associationDatabase.lookupAssociationToken(token);
 
-        if (null == lookedupToken) {
+        if (null == lookedupToken || lookedupToken.getGroupId() == null) {
             throw new InvalidUserAssociationTokenException("The group token provided does not exist or is invalid.");
         }
 
         UserGroupDTO group = userGroupManager.getGroupById(lookedupToken.getGroupId());
-
-        if (lookedupToken.getGroupId() == null) {
-            throw new InvalidUserAssociationTokenException("The group token provided does not exist or is invalid.");
-        }
 
         userGroupManager.addUserToGroup(group, userGrantingPermission);
         log.debug(String.format("Adding User: %s to Group: %s", userGrantingPermission.getId(),

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
@@ -238,25 +238,24 @@ public class UserAssociationManager {
             throw new InvalidUserAssociationTokenException("The group token provided does not exist or is invalid.");
         }
 
-        // add owner association
-        if (!associationDatabase
-                .hasValidAssociation(lookedupToken.getOwnerUserId(), userGrantingPermission.getId())) {
-            associationDatabase.createAssociation(lookedupToken, userGrantingPermission.getId());
-        }
-
         UserGroupDTO group = userGroupManager.getGroupById(lookedupToken.getGroupId());
 
-        if (lookedupToken.getGroupId() != null) {
-            userGroupManager.addUserToGroup(group, userGrantingPermission);
-            log.debug(String.format("Adding User: %s to Group: %s", userGrantingPermission.getId(),
-                    lookedupToken.getGroupId()));
+        if (lookedupToken.getGroupId() == null) {
+            throw new InvalidUserAssociationTokenException("The group token provided does not exist or is invalid.");
+        }
 
-            // add additional manager associations
-            for (Long additionalManagerId : group.getAdditionalManagersUserIds()) {
-                if (!associationDatabase
-                        .hasValidAssociation(additionalManagerId, userGrantingPermission.getId())) {
-                    associationDatabase.createAssociation(additionalManagerId, userGrantingPermission.getId());
-                }
+        userGroupManager.addUserToGroup(group, userGrantingPermission);
+        log.debug(String.format("Adding User: %s to Group: %s", userGrantingPermission.getId(),
+                lookedupToken.getGroupId()));
+
+        // add owner association
+        if (!associationDatabase.hasValidAssociation(group.getOwnerId(), userGrantingPermission.getId())) {
+            associationDatabase.createAssociation(group.getOwnerId(), userGrantingPermission.getId());
+        }
+        // add additional manager associations
+        for (Long additionalManagerId : group.getAdditionalManagersUserIds()) {
+            if (!associationDatabase.hasValidAssociation(additionalManagerId, userGrantingPermission.getId())) {
+                associationDatabase.createAssociation(additionalManagerId, userGrantingPermission.getId());
             }
         }
         return lookedupToken;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/IAssociationDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/IAssociationDataManager.java
@@ -72,19 +72,6 @@ public interface IAssociationDataManager {
 
     /**
      * Creates an association based on a token.
-     * 
-     * @param token
-     *            - containing information about the user to grant access to and the group the userIdGrantingAccess
-     *            should go into.
-     * @param userIdGrantingAccess
-     *            - This user is the user granting access to their data.
-     * @throws SegueDatabaseException
-     *             - if there is a database error.
-     */
-    void createAssociation(AssociationToken token, Long userIdGrantingAccess) throws SegueDatabaseException;
-
-    /**
-     * Creates an association based on a token.
      *
      * @param userIdReceivingAccess
      *            - the user to grant access to.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/PgAssociationDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/PgAssociationDataManager.java
@@ -95,15 +95,6 @@ public class PgAssociationDataManager implements IAssociationDataManager {
     }
 
     @Override
-    public void createAssociation(final AssociationToken token, final Long userIdGrantingAccess)
-            throws SegueDatabaseException {
-        Validate.notNull(token);
-        Long userIdReceivingAccess = token.getOwnerUserId();
-
-        createAssociation(userIdReceivingAccess, userIdGrantingAccess);
-    }
-
-    @Override
     public void createAssociation(final Long userIdReceivingAccess, final Long userIdGrantingAccess)
             throws SegueDatabaseException {
         Validate.notNull(userIdReceivingAccess);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManagerTest.java
@@ -117,14 +117,13 @@ public class UserAssociationManagerTest {
 		
 		expect(dummyAssociationDataManager.lookupAssociationToken(someToken.getToken())).andReturn(someToken);
 		
-		expect(
-				dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId,
-						someUserIdGrantingAccess)).andReturn(false);
+		expect(dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId, someUserIdGrantingAccess)).andReturn(false);
 		
-		dummyAssociationDataManager.createAssociation(someToken, someUserIdGrantingAccess);
+		dummyAssociationDataManager.createAssociation(someGroupOwnerUserId, someUserIdGrantingAccess);
 		expectLastCall().once();
 		
 		UserGroupDTO groupToAddUserTo = createMock(UserGroupDTO.class);
+        expect(groupToAddUserTo.getOwnerId()).andReturn(someGroupOwnerUserId).atLeastOnce();
 		expect(groupToAddUserTo.getAdditionalManagersUserIds()).andReturn(Sets.newHashSet()).atLeastOnce();
 
 		expect(dummyGroupDataManager.getGroupById(someAssociatedGroupId)).andReturn(groupToAddUserTo).once();
@@ -166,11 +165,10 @@ public class UserAssociationManagerTest {
 		
 		expect(dummyAssociationDataManager.lookupAssociationToken(someToken.getToken())).andReturn(someToken);
 		
-		expect(
-				dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId,
-						someUserIdGrantingAccess)).andReturn(true);
+		expect(dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId, someUserIdGrantingAccess)).andReturn(true);
 		
 		UserGroupDTO groupToAddUserTo = createMock(UserGroupDTO.class);
+        expect(groupToAddUserTo.getOwnerId()).andReturn(someGroupOwnerUserId).atLeastOnce();
 		expect(groupToAddUserTo.getAdditionalManagersUserIds()).andReturn(Sets.newHashSet()).atLeastOnce();
 		expect(dummyGroupDataManager.getGroupById(someAssociatedGroupId)).andReturn(groupToAddUserTo).once();
 		
@@ -187,48 +185,7 @@ public class UserAssociationManagerTest {
 		}
 
 		verify(someRegisteredUserGrantingAccess, dummyAssociationDataManager);
-	}	
-	
-	@Test
-	public final void userAssociationManager_createAssociationWithTokenNoGroup_associationShouldBeCreated()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
-
-		Long someUserIdGrantingAccess = 89745531132231213L;
-		Long someGroupOwnerUserId = 17659214141L;
-
-		RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
-		RegisteredUserDTO someRegisteredUserReceivingAccess = createMock(RegisteredUserDTO.class);
-		Long someAssociatedGroupId = null; // no group
-
-		expect(someRegisteredUserGrantingAccess.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
-		
-		expect(someRegisteredUserReceivingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		replay(someRegisteredUserGrantingAccess);
-
-		AssociationToken someToken = new AssociationToken("someToken", someGroupOwnerUserId, someAssociatedGroupId);
-		
-		expect(dummyAssociationDataManager.lookupAssociationToken(someToken.getToken())).andReturn(someToken);
-		
-		expect(
-				dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId,
-						someUserIdGrantingAccess)).andReturn(false);
-		
-		dummyAssociationDataManager.createAssociation(someToken, someUserIdGrantingAccess);
-		expectLastCall().once();
-		
-		replay(dummyAssociationDataManager);
-
-		try {
-			managerUnderTest.createAssociationWithToken(someToken.getToken(), someRegisteredUserGrantingAccess);
-		} catch (InvalidUserAssociationTokenException e) {
-			e.printStackTrace();
-			fail("InvalidUserAssociationTokenException is unexpected");
-		}
-
-		verify(someRegisteredUserGrantingAccess, dummyAssociationDataManager);
-	}	
+	}
 	
 	@Test
 	public final void userAssociationManager_createAssociationWithBadToken_exceptionShouldBeThrown()


### PR DESCRIPTION
For some reason both groups and group join tokens have ownership information. We added support for altering the owner of a group, but this did not alter the owner of the token.
When users tried to join a group with a changed owner, the new owner was not listed amongst the users to approve, but the old token owner was. This meant that the group owner was not given permission.

This commit stops using the token ownership information for anything; tokens really belong to groups, not to users, and the old approach of tokens belonging to users has not been correct in some time. As such, the test that group tokens could work without a group is not useful; they cannot work that way since the introduction of additional managers.

This commit also purges methods for creating an association based on a token, since that method did not include group managers; it was misleading and required group managers to be dealt with separately.