### PR TITLE
Remove credentials of deleted users

### DIFF
--- a/src/main/resources/db_scripts/migrations/2023-07-remove-deleted-user-credentials.sql
+++ b/src/main/resources/db_scripts/migrations/2023-07-remove-deleted-user-credentials.sql
@@ -1,0 +1,2 @@
+UPDATE user_credentials SET reset_token=NULL, reset_expiry=NULL, password=concat('DELETED@', gen_random_uuid())
+WHERE user_id IN (SELECT id FROM users WHERE deleted);


### PR DESCRIPTION
After we moved to soft-deletion of users, the rows of this table stopped being removed by the ON DELETE CASCADE. But we have no cause for keeping old credentials and so should remove them.
For existing deleted users we can remove the credentials with an SQL script.
This forms important groundwork for archiving of user accounts.