### PR TITLE
Use ES to filter schools so that limit is correct

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -485,6 +485,7 @@ public final class Constants {
     public static final String SCHOOL_URN_FIELDNAME_POJO = "urn";
     public static final String SCHOOL_ESTABLISHMENT_NAME_FIELDNAME_POJO = "name";
     public static final String SCHOOL_POSTCODE_FIELDNAME_POJO = "postcode";
+    public static final String SCHOOL_CLOSED_FIELDNAME_POJO = "closed";
 
     // User School Reporting
 


### PR DESCRIPTION
Undo a [temporary commit](https://github.com/isaacphysics/isaac-api/commit/17369ea2e857efad483e33d9f772473a56aa02ca) so that ElasticSearch does the filtering of closed schools meaning that the endpoint's limit query param works correctly.

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- ~Added enough Logging to monitor expected behaviour change~
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- ~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~
- [ ] Peer-Reviewed
