### PR TITLE
Randomise previewed quiz/test choices

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -346,6 +346,8 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             IsaacQuizDTO quiz = this.quizManager.findQuiz(quizId);
 
+            quiz = quizQuestionManager.augmentQuestionsForPreview(quiz);
+
             // Check this user is actually allowed to preview this quiz. A tutor counts as both a student and teacher
             // in this check
             if (null != quiz.getHiddenFromRoles() && (quiz.getHiddenFromRoles().contains(user.getRole().name())

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
@@ -142,6 +142,20 @@ public class QuizQuestionManager {
     }
 
     /**
+     * This method will shuffle choices for questions in the quiz.
+     * @param quiz
+     *            - to augment - this object may be mutated as a result of this method. i.e choices may be shuffled.
+     * @return The quiz object augmented (generally a modified parameter).
+     */
+    public IsaacQuizDTO augmentQuestionsForPreview(IsaacQuizDTO quiz) {
+        List<QuestionDTO> questionsToAugment = GameManager.getAllMarkableQuestionPartsDFSOrder(quiz);
+
+        questionManager.shuffleChoiceQuestionsChoices("PREVIEW", questionsToAugment);
+
+        return quiz;
+    }
+
+    /**
      * Modify the quiz to contain feedback for the specified mode, and possibly the users answers and the correct answers.
      *  @param quizAttempt
      *            - which attempt at the quiz to get attempts for.

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -426,8 +426,11 @@ public class QuizFacadeTest extends AbstractFacadeTest {
     public void previewQuiz() {
         forEndpoint(() -> quizFacade.previewQuiz(requestForCaching, httpServletRequest, studentQuiz.getId()),
             requiresLogin(),
-            as(student, failsWith(SegueErrorResponse.getIncorrectRoleResponse())),
-            as(teacher, respondsWith(studentQuiz))
+            as(student,
+                failsWith(SegueErrorResponse.getIncorrectRoleResponse())),
+            as(teacher,
+                prepare(quizQuestionManager, m -> expect(m.augmentQuestionsForPreview(studentQuiz)).andReturn(studentQuiz)),
+                respondsWith(studentQuiz))
         );
     }
 


### PR DESCRIPTION
This branch adds a method which prepares questions in a test/quiz to be previewed. It is a subset of the tasks that are needed to `augmentQuestionsForUser(...)`. Currently the only task is to randomise choices in Choice questions but, if there are future features that make use of it (such as initialising parametric questions), we should pull out the common code at that point into a separate private method.

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- ~Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)~
- [ ] Peer-Reviewed
