### PR TITLE
Checkstyle cleanup

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AbstractIsaacFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AbstractIsaacFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AbstractIsaacFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AbstractIsaacFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,19 +24,6 @@ import com.google.inject.name.Named;
 import com.opencsv.CSVWriter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
 import ma.glasnost.orika.MapperFacade;
 import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
@@ -82,6 +69,19 @@ import uk.ac.cam.cl.dtg.segue.search.AbstractFilterInstruction;
 import uk.ac.cam.cl.dtg.segue.search.DateRangeFilterInstruction;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;
@@ -125,15 +125,12 @@ public class EventsFacade extends AbstractIsaacFacade {
 
     /**
      * EventsFacade.
-     *  @param properties
-     *            - global properties map
-     * @param logManager
-     *            - for managing logs.
-     * @param bookingManager
- *            - Instance of Booking Manager
+     *
+     * @param properties     - global properties map
+     * @param logManager     - for managing logs.
+     * @param bookingManager - Instance of Booking Manager
      * @param userManager
-     * @param contentManager
-*            - for retrieving event content.
+     * @param contentManager - for retrieving event content.
      * @param mapper
      */
     @Inject
@@ -161,23 +158,15 @@ public class EventsFacade extends AbstractIsaacFacade {
 
     /**
      * REST end point to provide a list of events.
-     * 
-     * @param request
-     *            - this allows us to check to see if a user is currently loggedin.
-     * @param tags
-     *            - a comma separated list of tags to include in the search.
-     * @param startIndex
-     *            - the initial index for the first result.
-     * @param limit
-     *            - the maximums number of results to return
-     * @param sortOrder
-     *            - flag to indicate preferred sort order.
-     * @param showActiveOnly
-     *            - true will impose filtering on the results. False will not. Defaults to false.
-     * @param showInactiveOnly
-     *            - true will impose filtering on the results. False will not. Defaults to false.
-     * @param showStageOnly
-     *            - if present, only events with an audience matching this string will be shown
+     *
+     * @param request          - this allows us to check to see if a user is currently loggedin.
+     * @param tags             - a comma separated list of tags to include in the search.
+     * @param startIndex       - the initial index for the first result.
+     * @param limit            - the maximums number of results to return
+     * @param sortOrder        - flag to indicate preferred sort order.
+     * @param showActiveOnly   - true will impose filtering on the results. False will not. Defaults to false.
+     * @param showInactiveOnly - true will impose filtering on the results. False will not. Defaults to false.
+     * @param showStageOnly    - if present, only events with an audience matching this string will be shown
      * @return a Response containing a list of events objects or containing a SegueErrorResponse.
      */
     @GET
@@ -186,15 +175,15 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GZIP
     @Operation(summary = "List events matching the provided criteria.")
     public final Response getEvents(@Context final HttpServletRequest request,
-            @QueryParam("tags") final String tags,
-            @DefaultValue(DEFAULT_START_INDEX_AS_STRING) @QueryParam("start_index") final Integer startIndex,
-            @DefaultValue(DEFAULT_RESULTS_LIMIT_AS_STRING) @QueryParam("limit") final Integer limit,
-            @QueryParam("sort_by") final String sortOrder,
-            @QueryParam("show_active_only") final Boolean showActiveOnly,
-            @QueryParam("show_inactive_only") final Boolean showInactiveOnly,
-            @QueryParam("show_booked_only") final Boolean showMyBookingsOnly,
-            @QueryParam("show_reservations_only") final Boolean showReservationsOnly,
-            @QueryParam("show_stage_only") final String showStageOnly) {
+                                    @QueryParam("tags") final String tags,
+                                    @DefaultValue(DEFAULT_START_INDEX_AS_STRING) @QueryParam("start_index") final Integer startIndex,
+                                    @DefaultValue(DEFAULT_RESULTS_LIMIT_AS_STRING) @QueryParam("limit") final Integer limit,
+                                    @QueryParam("sort_by") final String sortOrder,
+                                    @QueryParam("show_active_only") final Boolean showActiveOnly,
+                                    @QueryParam("show_inactive_only") final Boolean showInactiveOnly,
+                                    @QueryParam("show_booked_only") final Boolean showMyBookingsOnly,
+                                    @QueryParam("show_reservations_only") final Boolean showReservationsOnly,
+                                    @QueryParam("show_stage_only") final String showStageOnly) {
         Map<String, List<String>> fieldsToMatch = Maps.newHashMap();
 
         Integer newLimit = null;
@@ -223,7 +212,7 @@ public class EventsFacade extends AbstractIsaacFacade {
             sortInstructions.put(DATE_FIELDNAME, SortOrder.DESC);
         }
 
-        fieldsToMatch.put(TYPE_FIELDNAME, Arrays.asList(EVENT_TYPE));
+        fieldsToMatch.put(TYPE_FIELDNAME, List.of(EVENT_TYPE));
 
         Map<String, AbstractFilterInstruction> filterInstructions = null;
         if (null != showActiveOnly && showActiveOnly) {
@@ -290,15 +279,15 @@ public class EventsFacade extends AbstractIsaacFacade {
                     .toResponse();
         } catch (SegueDatabaseException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error accessing your bookings.")
-                .toResponse();
+                    .toResponse();
         }
     }
 
-	/**
+    /**
      * Get Events Booked by user.
      *
-     * @param request - the http request so we can resolve booking information
-     * @param tags - the tags we want to filter on
+     * @param request     - the http request so we can resolve booking information
+     * @param tags        - the tags we want to filter on
      * @param currentUser - the currently logged on user.
      * @return a list of event pages that the user has been booked
      * @throws SegueDatabaseException
@@ -312,30 +301,30 @@ public class EventsFacade extends AbstractIsaacFacade {
         Map<String, BookingStatus> userBookingMap = this.bookingManager.getAllEventStatesForUser(currentUser.getId());
 
         for (String eventId : userBookingMap.keySet()) {
-			if (BookingStatus.CANCELLED.equals(userBookingMap.get(eventId))) {
-				continue;
-			}
+            if (BookingStatus.CANCELLED.equals(userBookingMap.get(eventId))) {
+                continue;
+            }
 
-			final IsaacEventPageDTO eventDTOById = this.getAugmentedEventDTOById(request, eventId);
+            final IsaacEventPageDTO eventDTOById = this.getAugmentedEventDTOById(request, eventId);
 
-			if (tags != null) {
-				Set<String> tagsList = Sets.newHashSet(tags);
-				tagsList.retainAll(eventDTOById.getTags()); // get intersection
-				if (tagsList.size() == 0) {
-					// if the intersection is empty then we can continue
-					continue;
-				}
-			}
+            if (tags != null) {
+                Set<String> tagsList = Sets.newHashSet(tags);
+                tagsList.retainAll(eventDTOById.getTags()); // get intersection
+                if (tagsList.size() == 0) {
+                    // if the intersection is empty then we can continue
+                    continue;
+                }
+            }
 
-			filteredResults.add(eventDTOById);
-		}
+            filteredResults.add(eventDTOById);
+        }
         return new ResultsWrapper<>(filteredResults, (long) filteredResults.size());
     }
 
     /**
      * Get Events Reserved by user.
      *
-     * @param request - the http request so we can resolve booking information
+     * @param request     - the http request so we can resolve booking information
      * @param currentUser - the currently logged on user.
      * @return a list of event pages that the user has been booked
      * @throws SegueDatabaseException
@@ -359,11 +348,9 @@ public class EventsFacade extends AbstractIsaacFacade {
 
     /**
      * REST end point to retrieve an event by id..
-     * 
-     * @param request
-     *            - this allows us to check to see if a user is currently logged-in.
-     * @param eventId
-     *            - Id of the event of interest.
+     *
+     * @param request - this allows us to check to see if a user is currently logged-in.
+     * @param eventId - Id of the event of interest.
      * @return a Response containing a list of events objects or containing a SegueErrorResponse.
      */
     @GET
@@ -371,7 +358,7 @@ public class EventsFacade extends AbstractIsaacFacade {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get details about a specific event.")
     public final Response getEvent(@Context final HttpServletRequest request,
-            @PathParam("event_id") final String eventId) {
+                                   @PathParam("event_id") final String eventId) {
         try {
             IsaacEventPageDTO page = getAugmentedEventDTOById(request, eventId);
             return Response.ok(page)
@@ -385,15 +372,14 @@ public class EventsFacade extends AbstractIsaacFacade {
         } catch (SegueDatabaseException e) {
             log.error("Error during event request", e);
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error resolving event bookings.")
-                .toResponse();
+                    .toResponse();
         }
     }
 
     /**
      * Count all event bookings.
-     * 
-     * @param request
-     *            - so we can determine if the user is logged in
+     *
+     * @param request - so we can determine if the user is logged in
      * @return a list of booking objects
      */
     @GET
@@ -419,11 +405,9 @@ public class EventsFacade extends AbstractIsaacFacade {
 
     /**
      * Find a booking by id.
-     * 
-     * @param request
-     *            - for authentication
-     * @param bookingId
-     *            - the booking of interest.
+     *
+     * @param request   - for authentication
+     * @param bookingId - the booking of interest.
      * @return The booking information.
      */
     @GET
@@ -455,14 +439,10 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * Allow a staff user to promote a existing bookings to confirmed bookings.
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event booking containing updates, must contain primary id.
-     * @param userId
-     *            - the user to be promoted.
-     * @param additionalInformation
-     *            - additional information to be stored with this booking e.g. dietary requirements.
+     * @param request               - so we can determine if the user is logged in
+     * @param eventId               - event booking containing updates, must contain primary id.
+     * @param userId                - the user to be promoted.
+     * @param additionalInformation - additional information to be stored with this booking e.g. dietary requirements.
      * @return the updated booking.
      */
     @POST
@@ -487,7 +467,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             this.getLogManager().logEvent(currentUser, request,
                     SegueServerLogType.ADMIN_EVENT_WAITING_LIST_PROMOTION, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, event.getId(),
-                                                                         USER_ID_FKEY_FIELDNAME, userId));
+                            USER_ID_FKEY_FIELDNAME, userId));
             return Response.ok(eventBookingDTO).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
@@ -497,20 +477,20 @@ public class EventsFacade extends AbstractIsaacFacade {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, errorMsg).toResponse();
         } catch (ContentManagerException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
-                "Content Database error occurred while trying to retrieve event booking information.")
-                .toResponse();
+                    "Content Database error occurred while trying to retrieve event booking information.")
+                    .toResponse();
         } catch (EventIsFullException e) {
             return new SegueErrorResponse(Status.CONFLICT,
-                "This event is already full. Unable to book the user on to it.")
-                .toResponse();
+                    "This event is already full. Unable to book the user on to it.")
+                    .toResponse();
         } catch (EventBookingUpdateException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "Unable to modify the booking", e)
-                .toResponse();
+                    "Unable to modify the booking", e)
+                    .toResponse();
         } catch (NoUserException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "The user doesn't exist, so unable to book them onto an event", e)
-                .toResponse();
+                    "The user doesn't exist, so unable to book them onto an event", e)
+                    .toResponse();
         } catch (EventIsCancelledException e) {
             return SegueErrorResponse.getBadRequestResponse("The event is cancelled, so no bookings are being accepted.");
         }
@@ -518,11 +498,9 @@ public class EventsFacade extends AbstractIsaacFacade {
 
     /**
      * gets an admin and selected staff only list of event bookings based on a given event id.
-     * 
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
      *
+     * @param request - so we can determine if the user is logged in
+     * @param eventId
      * @return list of bookings.
      */
     @GET
@@ -530,7 +508,7 @@ public class EventsFacade extends AbstractIsaacFacade {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "List event bookings for a specific event.")
     public final Response adminGetEventBookingByEventId(@Context final HttpServletRequest request,
-            @PathParam("event_id") final String eventId) {
+                                                        @PathParam("event_id") final String eventId) {
         try {
             RegisteredUserDTO currentUser = userManager.getCurrentRegisteredUser(request);
             IsaacEventPageDTO event = getRawEventDTOById(eventId);
@@ -541,7 +519,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             List<DetailedEventBookingDTO> eventBookings = bookingManager.adminGetBookingsByEventId(eventId);
 
-            if (Arrays.asList(Role.EVENT_LEADER).contains(currentUser.getRole())) {
+            if (List.of(Role.EVENT_LEADER).contains(currentUser.getRole())) {
                 eventBookings = userAssociationManager.filterUnassociatedRecords(currentUser, eventBookings, booking -> booking.getUserBooked().getId());
             }
 
@@ -556,8 +534,8 @@ public class EventsFacade extends AbstractIsaacFacade {
         }
     }
 
-    /** gets a list of event bookings based on a given group id.
-     *
+    /**
+     * gets a list of event bookings based on a given group id.
      */
     @GET
     @Path("{event_id}/bookings/for_group/{group_id}")
@@ -593,7 +571,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             // Event leaders are only allowed to see the bookings of connected users
             eventBookings = userAssociationManager.filterUnassociatedRecords(currentUser, eventBookings,
-                booking -> booking.getUserBooked().getId());
+                    booking -> booking.getUserBooked().getId());
 
             return Response.ok(this.mapper.mapAsList(eventBookings, EventBookingDTO.class)).build();
         } catch (SegueDatabaseException e) {
@@ -611,15 +589,15 @@ public class EventsFacade extends AbstractIsaacFacade {
         }
     }
 
-    /** gets a list of event bookings for all groups owned.
-     *
+    /**
+     * gets a list of event bookings for all groups owned.
      */
     @GET
     @Path("{event_id}/groups_bookings")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "List event bookings for a specific event")
     public final Response getEventBookingForAllGroups(@Context final HttpServletRequest request,
-                                                       @PathParam("event_id") final String eventId) {
+                                                      @PathParam("event_id") final String eventId) {
         try {
             RegisteredUserDTO currentUser = userManager.getCurrentRegisteredUser(request);
 
@@ -632,7 +610,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             // Only allowed to see the bookings of connected users
             eventBookings = userAssociationManager.filterUnassociatedRecords(
-                        currentUser, eventBookings, booking -> booking.getUserBooked().getId());
+                    currentUser, eventBookings, booking -> booking.getUserBooked().getId());
 
             return Response.ok(eventBookings).build();
         } catch (NoUserLoggedInException e) {
@@ -649,10 +627,8 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * Allows authorised users to view a csv of event attendees
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - the event of interest.
+     * @param request - so we can determine if the user is logged in
+     * @param eventId - the event of interest.
      * @return list of bookings csv.
      */
     @GET
@@ -660,7 +636,7 @@ public class EventsFacade extends AbstractIsaacFacade {
     @Produces("text/csv")
     @Operation(summary = "Download event attendance csv.")
     public Response getEventBookingCSV(@Context final HttpServletRequest request,
-                                                   @PathParam("event_id") final String eventId) {
+                                       @PathParam("event_id") final String eventId) {
         try {
             RegisteredUserDTO currentUser = userManager.getCurrentRegisteredUser(request);
             IsaacEventPageDTO event = this.getRawEventDTOById(eventId);
@@ -744,7 +720,7 @@ public class EventsFacade extends AbstractIsaacFacade {
             csvWriter.writeAll(rows);
             csvWriter.close();
 
-            headerBuilder.append(stringWriter.toString());
+            headerBuilder.append(stringWriter);
             return Response.ok(headerBuilder.toString())
                     .header("Content-Disposition", String.format("attachment; filename=event_attendees_%s.csv", eventId))
                     .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
@@ -757,29 +733,25 @@ public class EventsFacade extends AbstractIsaacFacade {
             String message = "Database error occurred while trying to retrieve all event booking information.";
             log.error(message, e);
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, message).toResponse();
-        }   catch (ContentManagerException e) {
+        } catch (ContentManagerException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
                     "Content Database error occurred while trying to retrieve event booking information.")
                     .toResponse();
         } catch (UnableToIndexSchoolsException e) {
-        return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Database error while looking up schools", e)
-                .toResponse();
-    }
+            return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Database error while looking up schools", e)
+                    .toResponse();
+        }
     }
 
     /**
      * createBooking for a specific isaac user.
      * - Will attempt to create a waiting list booking if the event is already full.
      * - Must be a Staff user.
-     * 
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event id
-     * @param userId
-     *            - user id
-     * @param additionalInformation
-     *            - additional information to be stored with this booking e.g. dietary requirements.
+     *
+     * @param request               - so we can determine if the user is logged in
+     * @param eventId               - event id
+     * @param userId                - user id
+     * @param additionalInformation - additional information to be stored with this booking e.g. dietary requirements.
      * @return the new booking
      */
     @POST
@@ -808,10 +780,10 @@ public class EventsFacade extends AbstractIsaacFacade {
             this.getLogManager().logEvent(currentUser, request,
                     SegueServerLogType.ADMIN_EVENT_BOOKING_CREATED,
                     ImmutableMap.of(
-                        EVENT_ID_FKEY_FIELDNAME, event.getId(),
-                        USER_ID_FKEY_FIELDNAME, userId,
-                        BOOKING_STATUS_FIELDNAME, booking.getBookingStatus().toString(),
-                        ADMIN_BOOKING_REASON_FIELDNAME, additionalInformation.get("authorisation") == null ? "NOT_PROVIDED" : additionalInformation.get("authorisation")
+                            EVENT_ID_FKEY_FIELDNAME, event.getId(),
+                            USER_ID_FKEY_FIELDNAME, userId,
+                            BOOKING_STATUS_FIELDNAME, booking.getBookingStatus().toString(),
+                            ADMIN_BOOKING_REASON_FIELDNAME, additionalInformation.get("authorisation") == null ? "NOT_PROVIDED" : additionalInformation.get("authorisation")
                     ));
 
             return Response.ok(this.mapper.map(booking, EventBookingDTO.class)).build();
@@ -829,8 +801,8 @@ public class EventsFacade extends AbstractIsaacFacade {
                     .toResponse();
         } catch (DuplicateBookingException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "User already booked on this event. Unable to create a duplicate booking.")
-                .toResponse();
+                    "User already booked on this event. Unable to create a duplicate booking.")
+                    .toResponse();
         } catch (EventIsCancelledException e) {
             return SegueErrorResponse.getBadRequestResponse("The event is cancelled, so no bookings are being accepted.");
         }
@@ -839,12 +811,9 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * Add event reservations for the given users.
      *
-     * @param request
-     *            - so we can determine who is making the request
-     * @param eventId
-     *            - event id
-     * @param userIds
-     *            - the users to reserve spaces for
+     * @param request - so we can determine who is making the request
+     * @param eventId - event id
+     * @param userIds - the users to reserve spaces for
      * @return the list of bookings/reservations
      */
     @POST
@@ -932,20 +901,17 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * This function allows cancellation of the reservations for the given users
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event id
-     * @param userIds
-     *            - user ids
+     * @param request - so we can determine if the user is logged in
+     * @param eventId - event id
+     * @param userIds - user ids
      */
     @POST
     @Path("{event_id}/reservations/cancel")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Cancel a reservations on an event for a set of users.")
     public final Response cancelReservations(@Context final HttpServletRequest request,
-                                        @PathParam("event_id") final String eventId,
-                                        final List<Long> userIds) {
+                                             @PathParam("event_id") final String eventId,
+                                             final List<Long> userIds) {
         try {
             IsaacEventPageDTO event = getRawEventDTOById(eventId);
             RegisteredUserDTO userLoggedIn = this.userManager.getCurrentRegisteredUser(request);
@@ -1008,10 +974,8 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * createBooking for the current user.
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event id
+     * @param request - so we can determine if the user is logged in
+     * @param eventId - event id
      * @return the new booking if allowed to book.
      */
     @POST
@@ -1027,7 +991,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             if (EventStatus.CLOSED.equals(event.getEventStatus())) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "Sorry booking for this event is closed. Please try again later.")
-                    .toResponse();
+                        .toResponse();
             }
 
             if (EventStatus.CANCELLED.equals(event.getEventStatus())) {
@@ -1042,7 +1006,7 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             if (bookingManager.isUserBooked(eventId, user.getId())) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "You are already booked on this event.")
-                    .toResponse();
+                        .toResponse();
             }
 
             // Reservation-only events can only be booked by teachers, reserved by the group manager (teacher), or
@@ -1070,24 +1034,24 @@ public class EventsFacade extends AbstractIsaacFacade {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, errorMsg).toResponse();
         } catch (ContentManagerException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
-                "Content Database error occurred while trying to retrieve all event booking information.")
-                .toResponse();
+                    "Content Database error occurred while trying to retrieve all event booking information.")
+                    .toResponse();
         } catch (EmailMustBeVerifiedException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "In order to book on this event your user account must have a verified email address. Please verify your address to make a booking.")
-                .toResponse();
+                    "In order to book on this event your user account must have a verified email address. Please verify your address to make a booking.")
+                    .toResponse();
         } catch (DuplicateBookingException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "You have already been booked on this event. Unable to create a duplicate booking.")
-                .toResponse();
+                    "You have already been booked on this event. Unable to create a duplicate booking.")
+                    .toResponse();
         } catch (EventIsFullException e) {
             return new SegueErrorResponse(Status.CONFLICT,
-                "This event is already full. Unable to book you on to it.")
-                .toResponse();
+                    "This event is already full. Unable to book you on to it.")
+                    .toResponse();
         } catch (EventDeadlineException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "The booking deadline for this event has passed. No more bookings are being accepted.")
-                .toResponse();
+                    "The booking deadline for this event has passed. No more bookings are being accepted.")
+                    .toResponse();
         } catch (EventIsCancelledException e) {
             return SegueErrorResponse.getBadRequestResponse("The event is cancelled, so no bookings are being accepted.");
         }
@@ -1096,10 +1060,8 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * Add current user to waiting list for the given event.
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event id
+     * @param request - so we can determine if the user is logged in
+     * @param eventId - event id
      * @return the new booking
      */
     @POST
@@ -1127,24 +1089,24 @@ public class EventsFacade extends AbstractIsaacFacade {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, errorMsg).toResponse();
         } catch (ContentManagerException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
-                "Content Database error occurred while trying to retrieve all event booking information.")
-                .toResponse();
+                    "Content Database error occurred while trying to retrieve all event booking information.")
+                    .toResponse();
         } catch (EmailMustBeVerifiedException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "In order to book on this event your user account must have a verified email address. Please verify your address to make a booking.")
-                .toResponse();
+                    "In order to book on this event your user account must have a verified email address. Please verify your address to make a booking.")
+                    .toResponse();
         } catch (DuplicateBookingException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "You have already been booked on this event. Unable to create a duplicate booking.")
-                .toResponse();
+                    "You have already been booked on this event. Unable to create a duplicate booking.")
+                    .toResponse();
         } catch (EventDeadlineException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST,
-                "The booking deadline for this event has passed. No more bookings are being accepted.")
-                .toResponse();
+                    "The booking deadline for this event has passed. No more bookings are being accepted.")
+                    .toResponse();
         } catch (EventIsNotFullException e) {
             return new SegueErrorResponse(Status.CONFLICT,
-                "There are spaces on this event and the deadline has not passed. Please use the request booking endpoint to book you on to it.")
-                .toResponse();
+                    "There are spaces on this event and the deadline has not passed. Please use the request booking endpoint to book you on to it.")
+                    .toResponse();
         } catch (EventIsCancelledException e) {
             return SegueErrorResponse.getBadRequestResponse("The event is cancelled, so no bookings are being accepted.");
         }
@@ -1153,10 +1115,8 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * This function allows a user who has booked onto an event to cancel their booking.
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event id
+     * @param request - so we can determine if the user is logged in
+     * @param eventId - event id
      * @return the new booking
      */
     @DELETE
@@ -1171,12 +1131,9 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * This function allows cancellation of a booking.
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event id
-     * @param userId
-     *            - user id
+     * @param request - so we can determine if the user is logged in
+     * @param eventId - event id
+     * @param userId  - user id
      * @return the new booking
      */
     @DELETE
@@ -1200,13 +1157,13 @@ public class EventsFacade extends AbstractIsaacFacade {
 
             if (event.getDate() != null && new Date().after(event.getDate())) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "You cannot cancel a booking on an event that has already started.")
-                    .toResponse();
+                        .toResponse();
             }
 
             // if the user id is null then it means they are changing their own booking.
             if (userId != null) {
                 if (!(bookingManager.isUserAbleToManageEvent(userLoggedIn, event) ||
-                      bookingManager.isReservationMadeByRequestingUser(userLoggedIn, userOwningBooking, event))) {
+                        bookingManager.isReservationMadeByRequestingUser(userLoggedIn, userOwningBooking, event))) {
                     return SegueErrorResponse.getIncorrectRoleResponse();
                 }
             }
@@ -1237,7 +1194,7 @@ public class EventsFacade extends AbstractIsaacFacade {
         } catch (ContentManagerException e) {
             log.error("Error during event request", e);
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error locating the content you requested.")
-                .toResponse();
+                    .toResponse();
         } catch (NoUserException e) {
             return SegueErrorResponse.getResourceNotFoundResponse("Unable to locate user specified.");
         }
@@ -1246,12 +1203,9 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * This function allows an administrator to attempt to resend the last confirmation email send for a given booking.
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event id
-     * @param userId
-     *            - user id
+     * @param request - so we can determine if the user is logged in
+     * @param eventId - event id
+     * @param userId  - user id
      * @return the new booking
      */
     @POST
@@ -1295,22 +1249,19 @@ public class EventsFacade extends AbstractIsaacFacade {
 
     /**
      * Delete a booking.
-     *
+     * <p>
      * This is an admin function to allow staff to delete a booking permanently.
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event id
-     * @param userId
-     *            - user id
+     * @param request - so we can determine if the user is logged in
+     * @param eventId - event id
+     * @param userId  - user id
      * @return the new booking
      */
     @DELETE
     @Path("{event_id}/bookings/{user_id}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Erase a user's booking on an event.",
-                  description = "This method removes the booking entirely, rather than recording the booking as cancelled.")
+            description = "This method removes the booking entirely, rather than recording the booking as cancelled.")
     public final Response deleteBooking(@Context final HttpServletRequest request,
                                         @PathParam("event_id") final String eventId,
                                         @PathParam("user_id") final Long userId) {
@@ -1353,14 +1304,10 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * Allow a staff user to record event attendance.
      *
-     * @param request
-     *            - so we can determine if the user is logged in
-     * @param eventId
-     *            - event booking containing updates, must contain primary id.
-     * @param userId
-     *            - the user to be promoted.
-     * @param attended
-     *            - boolean value representing whether the user was present, true, or absent, false.
+     * @param request  - so we can determine if the user is logged in
+     * @param eventId  - event booking containing updates, must contain primary id.
+     * @param userId   - the user to be promoted.
+     * @param attended - boolean value representing whether the user was present, true, or absent, false.
      * @return the updated booking.
      */
     @POST
@@ -1384,11 +1331,11 @@ public class EventsFacade extends AbstractIsaacFacade {
             this.getLogManager().logEvent(currentUser, request,
                     SegueServerLogType.ADMIN_EVENT_ATTENDANCE_RECORDED,
                     ImmutableMap.of(
-                        EVENT_ID_FKEY_FIELDNAME, event.getId(),
-                        USER_ID_FKEY_FIELDNAME, userId,
-                        ATTENDED_FIELDNAME, attended,
-                        EVENT_DATE_FIELDNAME, event.getDate(),
-                        EVENT_TAGS_FIELDNAME, event.getTags()
+                            EVENT_ID_FKEY_FIELDNAME, event.getId(),
+                            USER_ID_FKEY_FIELDNAME, userId,
+                            ATTENDED_FIELDNAME, attended,
+                            EVENT_DATE_FIELDNAME, event.getDate(),
+                            EVENT_TAGS_FIELDNAME, event.getTags()
                     ));
 
             if (event.getTags().contains("teacher")) {
@@ -1424,14 +1371,10 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * REST end point to provide a list of events.
      *
-     * @param request
-     *            - this allows us to check to see if a user is currently loggedin.
-     * @param startIndex
-     *            - the initial index for the first result.
-     * @param limit
-     *            - the maximums number of results to return
-     * @param filter
-     *            - in which way should the results be filtered from a choice defined in the EventFilterOption enum.
+     * @param request    - this allows us to check to see if a user is currently loggedin.
+     * @param startIndex - the initial index for the first result.
+     * @param limit      - the maximums number of results to return
+     * @param filter     - in which way should the results be filtered from a choice defined in the EventFilterOption enum.
      * @return a Response containing a list of events objects or containing a SegueErrorResponse.
      */
     @GET
@@ -1495,7 +1438,7 @@ public class EventsFacade extends AbstractIsaacFacade {
             List<Map<String, Object>> resultList = Lists.newArrayList();
 
             for (ContentDTO c : findByFieldNames.getResults()) {
-                if (!(c instanceof  IsaacEventPageDTO)) {
+                if (!(c instanceof IsaacEventPageDTO)) {
                     continue;
                 }
                 IsaacEventPageDTO event = (IsaacEventPageDTO) c;
@@ -1553,16 +1496,11 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * REST end point to provide a summary of events suitable for mapping.
      *
-     * @param request
-     *            - this allows us to check to see if a user is currently logged in.
-     * @param startIndex
-     *            - the initial index for the first result.
-     * @param limit
-     *            - the maximums number of results to return
-     * @param showActiveOnly
-     *            - true will impose filtering on the results. False will not. Defaults to false.
-     * @param showStageOnly
-     *            - if present, only events with an audience matching this string will be shown
+     * @param request        - this allows us to check to see if a user is currently logged in.
+     * @param startIndex     - the initial index for the first result.
+     * @param limit          - the maximums number of results to return
+     * @param showActiveOnly - true will impose filtering on the results. False will not. Defaults to false.
+     * @param showStageOnly  - if present, only events with an audience matching this string will be shown
      * @return a Response containing a list of event map summaries or containing a SegueErrorResponse.
      */
     @GET
@@ -1571,10 +1509,10 @@ public class EventsFacade extends AbstractIsaacFacade {
     @GZIP
     @Operation(summary = "List summary details suitable for mapping for events matching the provided criteria.")
     public final Response getEventMapData(@Context final HttpServletRequest request, @QueryParam("tags") final String tags,
-                                            @DefaultValue(DEFAULT_START_INDEX_AS_STRING) @QueryParam("start_index") final Integer startIndex,
-                                            @DefaultValue(DEFAULT_RESULTS_LIMIT_AS_STRING) @QueryParam("limit") final Integer limit,
-                                            @QueryParam("show_active_only") final Boolean showActiveOnly,
-                                            @QueryParam("show_stage_only") final String showStageOnly) {
+                                          @DefaultValue(DEFAULT_START_INDEX_AS_STRING) @QueryParam("start_index") final Integer startIndex,
+                                          @DefaultValue(DEFAULT_RESULTS_LIMIT_AS_STRING) @QueryParam("limit") final Integer limit,
+                                          @QueryParam("show_active_only") final Boolean showActiveOnly,
+                                          @QueryParam("show_stage_only") final String showStageOnly) {
         Map<String, List<String>> fieldsToMatch = Maps.newHashMap();
 
         Integer newLimit = null;
@@ -1618,7 +1556,7 @@ public class EventsFacade extends AbstractIsaacFacade {
             List<Map<String, Object>> resultList = Lists.newArrayList();
 
             for (ContentDTO c : findByFieldNames.getResults()) {
-                if (!(c instanceof  IsaacEventPageDTO)) {
+                if (!(c instanceof IsaacEventPageDTO)) {
                     continue;
                 }
 
@@ -1667,7 +1605,7 @@ public class EventsFacade extends AbstractIsaacFacade {
      * @param eventId the id of the event of interest
      * @return the fully populated event dto with user context information.
      * @throws ContentManagerException - if there is a problem finding the event information
-     * @throws SegueDatabaseException if there is a database error.
+     * @throws SegueDatabaseException  if there is a database error.
      */
     private IsaacEventPageDTO getRawEventDTOById(final String eventId)
             throws ContentManagerException, SegueDatabaseException {
@@ -1690,23 +1628,22 @@ public class EventsFacade extends AbstractIsaacFacade {
     /**
      * A helper method for retrieving an event and the number of places available and if the user is booked or not.
      *
-     *
      * @param request so we can determine if the user is logged in
      * @param eventId the id of the event of interest
      * @return the fully populated event dto with user context information.
      * @throws ContentManagerException - if there is a problem finding the event information
-     * @throws SegueDatabaseException if there is a database error.
-	 */
+     * @throws SegueDatabaseException  if there is a database error.
+     */
     private IsaacEventPageDTO getAugmentedEventDTOById(final HttpServletRequest request, final String eventId)
             throws ContentManagerException, SegueDatabaseException {
         IsaacEventPageDTO event = getRawEventDTOById(eventId);
         return augmentEventWithBookingInformation(request, event);
     }
 
-	/**
+    /**
      * Augment a single event with booking information before we send it out.
      *
-     * @param request - for user look up
+     * @param request       - for user look up
      * @param possibleEvent - a ContentDTO that should hopefully be an IsaacEventPageDTO.
      * @return an augmented IsaacEventPageDTO.
      * @throws SegueDatabaseException

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -105,7 +105,7 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager.extractPageIdFromQuestionId;
 
 /**
- * Quiz Facade
+ * Quiz Facade.
  */
 @Path("/quiz")
 @Tag(name = "/quiz")
@@ -124,28 +124,18 @@ public class QuizFacade extends AbstractIsaacFacade {
 
     /**
      * QuizFacade. For management of quizzes
-     * @param properties
-     *            - global properties map
-     * @param logManager
-     *            - for managing logs.
-     * @param contentManager
-     *            - for the content etag
-     * @param quizManager
-     *            - for quiz interaction.
-     * @param userManager
-     *            - for user information.
-     * @param associationManager
-     *            - So that we can determine what information is allowed to be seen by other users.
-     * @param groupManager
-     *            - for group information.
-     * @param quizAssignmentManager
-     *            - for managing the assignment of quizzes.
-     * @param assignmentService
-     *            - for general assignment-related services.
-     * @param quizAttemptManager
-     *            - for managing attempts at quizzes.
-     * @param quizQuestionManager
-     *            - for parsing, validating, and persisting quiz question answers.
+     *
+     * @param properties            - global properties map
+     * @param logManager            - for managing logs.
+     * @param contentManager        - for the content etag
+     * @param quizManager           - for quiz interaction.
+     * @param userManager           - for user information.
+     * @param associationManager    - So that we can determine what information is allowed to be seen by other users.
+     * @param groupManager          - for group information.
+     * @param quizAssignmentManager - for managing the assignment of quizzes.
+     * @param assignmentService     - for general assignment-related services.
+     * @param quizAttemptManager    - for managing attempts at quizzes.
+     * @param quizQuestionManager   - for parsing, validating, and persisting quiz question answers.
      */
     @Inject
     public QuizFacade(final AbstractConfigLoader properties, final ILogManager logManager,
@@ -187,9 +177,9 @@ public class QuizFacade extends AbstractIsaacFacade {
      *
      * Anonymous users can't see quizzes.
      *
-     * @param request the Request needed for ETag checking.
+     * @param request            the Request needed for ETag checking.
      * @param httpServletRequest the Request needed for Cookies for the current user.
-     * @param startIndex for pagination.
+     * @param startIndex         for pagination.
      * @return a Response containing a list of ContentSummaryDTO for the visible quizzes.
      */
     @GET
@@ -212,7 +202,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             if (null != startIndex) {
                 etagValue += startIndex;
             }
-            EntityTag etag = new EntityTag(etagValue + "");
+            EntityTag etag = new EntityTag(String.valueOf(etagValue));
             Response cachedResponse = generateCachedResponse(request, etag, NEVER_CACHE_WITHOUT_ETAG_CHECK);
 
             if (cachedResponse != null) {
@@ -225,8 +215,8 @@ public class QuizFacade extends AbstractIsaacFacade {
             ResultsWrapper<ContentSummaryDTO> summary = this.quizManager.getAvailableQuizzes(showOnlyStudentVisibleQuizzes, userRoleString, startIndex, 9000);
 
             return ok(summary).tag(etag)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
-                .build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
+                    .build();
         } catch (ContentManagerException e) {
             String message = "ContentManagerException whilst getting available tests";
             log.error(message, e);
@@ -265,7 +255,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             this.quizAttemptManager.augmentAssignmentsFor(user, assignments);
 
             return Response.ok(assignments)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (SegueDatabaseException e) {
             String message = "SegueDatabaseException whilst getting available tests";
             log.error(message, e);
@@ -296,7 +286,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             quizManager.augmentWithQuizSummary(attempts);
 
             return Response.ok(attempts)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (SegueDatabaseException e) {
             String message = "SegueDatabaseException whilst getting available tests";
             log.error(message, e);
@@ -309,12 +299,9 @@ public class QuizFacade extends AbstractIsaacFacade {
     /**
      * Preview a quiz. Only available to tutors and above.
      *
-     * @param request
-     *            - so we can deal with caching.
-     * @param httpServletRequest
-     *            - so that we can extract user information.
-     * @param quizId
-     *            as a string
+     * @param request            - so we can deal with caching.
+     * @param httpServletRequest - so that we can extract user information.
+     * @param quizId             as a string
      * @return a Response containing a list of ContentSummaryDTO for the visible quizzes.
      */
     @GET
@@ -337,7 +324,7 @@ public class QuizFacade extends AbstractIsaacFacade {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "You must provide a valid test id.").toResponse();
             }
 
-            EntityTag etag = new EntityTag(this.contentManager.getCurrentContentSHA().hashCode() + quizId.hashCode() + "");
+            EntityTag etag = new EntityTag(String.valueOf(this.contentManager.getCurrentContentSHA().hashCode() + quizId.hashCode()));
 
             Response cachedResponse = generateCachedResponse(request, etag);
             if (cachedResponse != null) {
@@ -358,7 +345,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             }
 
             return ok(quiz)
-                .cacheControl(getCacheControl(NUMBER_SECONDS_IN_ONE_HOUR, false)).tag(etag).build();
+                    .cacheControl(getCacheControl(NUMBER_SECONDS_IN_ONE_HOUR, false)).tag(etag).build();
         } catch (ContentManagerException e) {
             log.error("Content error whilst previewing a test", e);
             return SegueErrorResponse.getResourceNotFoundResponse("This test has become unavailable.");
@@ -374,13 +361,10 @@ public class QuizFacade extends AbstractIsaacFacade {
      * if they are a member of the group for the assignment.
      * If an attempt has already begun, return the already begun attempt.
      *
-     * @see #startFreeQuizAttempt An endpoint to allow a quiz that is visibleToStudents to be taken by students.
-     *
-     * @param httpServletRequest
-     *            - so that we can extract user information.
-     * @param quizAssignmentId
-     *            - the ID of the quiz assignment for this user.
+     * @param httpServletRequest - so that we can extract user information.
+     * @param quizAssignmentId   - the ID of the quiz assignment for this user.
      * @return a QuizAttemptDTO
+     * @see #startFreeQuizAttempt An endpoint to allow a quiz that is visibleToStudents to be taken by students.
      */
     @POST
     @Path("/assignment/{quizAssignmentId}/attempt")
@@ -421,8 +405,8 @@ public class QuizFacade extends AbstractIsaacFacade {
             quizAttempt = augmentAttempt(quizAttempt, quizAssignment, false);
 
             return Response.ok(quizAttempt)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
-                .build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
+                    .build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (SegueDatabaseException e) {
@@ -446,10 +430,8 @@ public class QuizFacade extends AbstractIsaacFacade {
      * they are locked out of all previous feedback for that quiz and prevented from starting the
      * quiz freely in order to prevent some ways of cheating.)
      *
-     * @param httpServletRequest
-     *            - so that we can extract user information.
-     * @param quizId
-     *            - the ID of the quiz the user wishes to attempt.
+     * @param httpServletRequest - so that we can extract user information.
+     * @param quizId             - the ID of the quiz the user wishes to attempt.
      * @return a QuizAttemptDTO
      */
     @POST
@@ -494,8 +476,8 @@ public class QuizFacade extends AbstractIsaacFacade {
             quizAttempt = augmentAttempt(quizAttempt, null, false);
 
             return Response.ok(quizAttempt)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
-                .build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
+                    .build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (SegueDatabaseException e) {
@@ -511,10 +493,8 @@ public class QuizFacade extends AbstractIsaacFacade {
     /**
      * Get the QuizDTO for a quiz attempt.
      *
-     * @param httpServletRequest
-     *            - so that we can extract user information.
-     * @param quizAttemptId
-     *            - the ID of the quiz the user wishes to attempt.
+     * @param httpServletRequest - so that we can extract user information.
+     * @param quizAttemptId      - the ID of the quiz the user wishes to attempt.
      * @return The QuizDTO augmented with the user answers so far.
      */
     @GET
@@ -534,8 +514,8 @@ public class QuizFacade extends AbstractIsaacFacade {
             quizAttempt = augmentAttempt(quizAttempt, quizAssignment, false);
 
             return Response.ok(quizAttempt)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
-                .build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
+                    .build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (SegueDatabaseException e) {
@@ -557,10 +537,8 @@ public class QuizFacade extends AbstractIsaacFacade {
      *
      * The attempt must be completed.
      *
-     * @param httpServletRequest
-     *            - so that we can extract user information.
-     * @param quizAttemptId
-     *            - the ID of the quiz the user wishes to see feedback for.
+     * @param httpServletRequest - so that we can extract user information.
+     * @param quizAttemptId      - the ID of the quiz the user wishes to see feedback for.
      * @return The feedback if this user is allowed to see it.
      */
     @GET
@@ -595,8 +573,8 @@ public class QuizFacade extends AbstractIsaacFacade {
             augmentAttempt(quizAttempt, quizAssignment);
 
             return Response.ok(quizAttempt)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
-                .build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
+                    .build();
 
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
@@ -619,10 +597,8 @@ public class QuizFacade extends AbstractIsaacFacade {
      *
      * Only the user taking the quiz can mark it complete.
      *
-     * @param httpServletRequest
-     *            - so that we can extract user information.
-     * @param quizAttemptId
-     *            - the ID of the quiz the user wishes to attempt.
+     * @param httpServletRequest - so that we can extract user information.
+     * @param quizAttemptId      - the ID of the quiz the user wishes to attempt.
      * @return The updated quiz attempt or an error.
      */
     @POST
@@ -666,12 +642,9 @@ public class QuizFacade extends AbstractIsaacFacade {
      * If it is a self-taken quiz, you cannot mark it incomplete, as that would make it easier to tweak individual
      * questions to find the right answers (also there is no assignment so you can't construct the URL anyway).
      *
-     * @param httpServletRequest
-     *            - so that we can extract user information.
-     * @param quizAssignmentId
-     *            - the ID of the assignment you want to mark an attempt incomplete from.
-     * @param userId
-     *            - the ID of the user whose attempt you want to mark incomplete.
+     * @param httpServletRequest - so that we can extract user information.
+     * @param quizAssignmentId   - the ID of the assignment you want to mark an attempt incomplete from.
+     * @param userId             - the ID of the user whose attempt you want to mark incomplete.
      * @return The updated attempt or an error.
      */
     @POST
@@ -698,7 +671,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             if (assignment == null || !canManageGroup(user, group)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
-                    "You can only mark assignments incomplete for groups you own or manage.").toResponse();
+                        "You can only mark assignments incomplete for groups you own or manage.").toResponse();
             }
 
             if (assignment.getDueDate() != null && !assignment.dueDateIsAfter(new Date())) {
@@ -720,10 +693,10 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             QuizUserFeedbackDTO feedback;
             UserSummaryDTO userSummary = associationManager.enforceAuthorisationPrivacy(user,
-                userManager.convertToUserSummaryObject(student));
+                    userManager.convertToUserSummaryObject(student));
 
             feedback = new QuizUserFeedbackDTO(userSummary,
-                userSummary.isAuthorisedFullAccess() ? new QuizFeedbackDTO() : null);
+                    userSummary.isAuthorisedFullAccess() ? new QuizFeedbackDTO() : null);
 
             return Response.ok(feedback).build();
         } catch (NoUserLoggedInException e) {
@@ -769,11 +742,11 @@ public class QuizFacade extends AbstractIsaacFacade {
             QuizAssignmentDTO assignment = checkQuizAssignmentNotCancelledOrOverdue(quizAttempt);
 
             Map<String, Object> eventDetails = ImmutableMap.of(
-                QUIZ_ID_FKEY, quizAttempt.getQuizId(),
-                QUIZ_ATTEMPT_FK, quizAttempt.getId(),
-                QUIZ_ASSIGNMENT_FK, assignment != null ? assignment.getId().toString() : "FREE_ATTEMPT",
-                ASSIGNMENT_DUEDATE, assignment == null || assignment.getDueDate() == null ? "NO_DUE_DATE" : assignment.getDueDate(),
-                QUIZ_SECTION, sectionNumber
+                    QUIZ_ID_FKEY, quizAttempt.getQuizId(),
+                    QUIZ_ATTEMPT_FK, quizAttempt.getId(),
+                    QUIZ_ASSIGNMENT_FK, assignment != null ? assignment.getId().toString() : "FREE_ATTEMPT",
+                    ASSIGNMENT_DUEDATE, assignment == null || assignment.getDueDate() == null ? "NO_DUE_DATE" : assignment.getDueDate(),
+                    QUIZ_SECTION, sectionNumber
             );
 
             getLogManager().logEvent(user, httpServletRequest, Constants.IsaacServerLogType.VIEW_QUIZ_SECTION, eventDetails);
@@ -795,12 +768,9 @@ public class QuizFacade extends AbstractIsaacFacade {
     /**
      * Record that a user has answered a question.
      *
-     * @param request
-     *            - the servlet request so we can find out if it is a known user.
-     * @param questionId
-     *            that you are attempting to answer.
-     * @param jsonAnswer
-     *            - answer body which will be parsed as a Choice and then converted to a ChoiceDTO.
+     * @param request    - the servlet request so we can find out if it is a known user.
+     * @param questionId that you are attempting to answer.
+     * @param jsonAnswer - answer body which will be parsed as a Choice and then converted to a ChoiceDTO.
      * @return Response containing a QuestionValidationResponse object or containing a SegueErrorResponse .
      */
     @POST
@@ -809,7 +779,7 @@ public class QuizFacade extends AbstractIsaacFacade {
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
     @Operation(summary = "Submit an answer to a question.",
-        description = "The answer must be the correct Choice subclass for the question with the provided ID.")
+            description = "The answer must be the correct Choice subclass for the question with the provided ID.")
     public Response answerQuestion(@Context final HttpServletRequest request,
                                    @PathParam("quizAttemptId") final Long quizAttemptId,
                                    @PathParam("question_id") final String questionId,
@@ -833,7 +803,7 @@ public class QuizFacade extends AbstractIsaacFacade {
                 contentBasedOnId = this.contentManager.getContentDOById(questionId);
             } catch (ContentManagerException e1) {
                 SegueErrorResponse error = new SegueErrorResponse(Status.NOT_FOUND, "Error locating the version requested",
-                    e1);
+                        e1);
                 log.error(error.getErrorMessage(), e1);
                 return error.toResponse();
             }
@@ -843,7 +813,7 @@ public class QuizFacade extends AbstractIsaacFacade {
                 question = (Question) contentBasedOnId;
             } else {
                 SegueErrorResponse error = new SegueErrorResponse(Status.NOT_FOUND,
-                    "No question object found for given id: " + questionId);
+                        "No question object found for given id: " + questionId);
                 log.warn(error.getErrorMessage());
                 return error.toResponse();
             }
@@ -882,10 +852,8 @@ public class QuizFacade extends AbstractIsaacFacade {
      *
      * This can only be done on free quiz attempts, as we don't want any startDate shenanigans on assigned quizzes.
      *
-     * @param httpServletRequest
-     *            - so that we can extract user information.
-     * @param quizAttemptId
-     *            - the ID of the quiz the user wishes to attempt.
+     * @param httpServletRequest - so that we can extract user information.
+     * @param quizAttemptId      - the ID of the quiz the user wishes to attempt.
      * @return Confirmation or an error.
      */
     @DELETE
@@ -932,9 +900,8 @@ public class QuizFacade extends AbstractIsaacFacade {
      * Sends emails to the members of the group informing them of the quiz.
      * Takes a quiz id, a group id, an optional end datetime for completion, and the feedbackMode.
      *
-     * @param request so that we can extract user information.
+     * @param request              so that we can extract user information.
      * @param clientQuizAssignment the partially constructed quiz assignment
-     *
      * @return the quiz assignment that has been created, or an error.
      */
     @POST
@@ -946,9 +913,9 @@ public class QuizFacade extends AbstractIsaacFacade {
     public final Response createQuizAssignment(@Context final HttpServletRequest request,
                                                final QuizAssignmentDTO clientQuizAssignment) {
 
-        if (   clientQuizAssignment.getQuizId() == null
-            || clientQuizAssignment.getGroupId() == null
-            || clientQuizAssignment.getQuizFeedbackMode() == null) {
+        if (clientQuizAssignment.getQuizId() == null
+                || clientQuizAssignment.getGroupId() == null
+                || clientQuizAssignment.getQuizFeedbackMode() == null) {
             return new SegueErrorResponse(Status.BAD_REQUEST, "A required field was missing. Must provide group and test ids and a test feedback mode.").toResponse();
         }
 
@@ -961,13 +928,13 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             if (!canManageAssignment(clientQuizAssignment, currentlyLoggedInUser)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
-                    "You can only set assignments to groups you own or manage.").toResponse();
+                        "You can only set assignments to groups you own or manage.").toResponse();
             }
 
             IsaacQuizDTO quiz = this.quizManager.findQuiz(clientQuizAssignment.getQuizId());
             if (null == quiz) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "The test id specified does not exist.")
-                    .toResponse();
+                        .toResponse();
             }
 
             if (null != clientQuizAssignment.getScheduledStartDate()) {
@@ -1050,7 +1017,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
                 if (null == group) {
                     return new SegueErrorResponse(Status.NOT_FOUND, "The group specified cannot be located.")
-                        .toResponse();
+                            .toResponse();
                 }
 
                 if (!canManageGroup(user, group)) {
@@ -1066,7 +1033,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             quizManager.augmentWithQuizSummary(assignments);
 
             return Response.ok(assignments)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (SegueDatabaseException e) {
@@ -1077,11 +1044,10 @@ public class QuizFacade extends AbstractIsaacFacade {
     }
 
     /**
-     * Allows a teacher to see results of an assignment
+     * Allows a teacher to see results of an assignment.
      *
      * @param httpServletRequest so that we can extract user information.
-     * @param quizAssignmentId the id of the assignment to view.
-     *
+     * @param quizAssignmentId   the id of the assignment to view.
      * @return Details about the assignment.
      */
     @GET
@@ -1109,7 +1075,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             if (!canManageGroup(user, group)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
-                    "You can only view assignments to groups you own or manage.").toResponse();
+                        "You can only view assignments to groups you own or manage.").toResponse();
             }
 
             this.assignmentService.augmentAssignerSummaries(Collections.singletonList(assignment));
@@ -1123,19 +1089,19 @@ public class QuizFacade extends AbstractIsaacFacade {
             List<QuizUserFeedbackDTO> userFeedback = new ArrayList<>();
 
             for (RegisteredUserDTO groupMember : groupMembers) {
-                QuizFeedbackDTO feedback  = feedbackMap.get(groupMember);
+                QuizFeedbackDTO feedback = feedbackMap.get(groupMember);
                 UserSummaryDTO userSummary = associationManager.enforceAuthorisationPrivacy(user,
-                    userManager.convertToUserSummaryObject(groupMember));
+                        userManager.convertToUserSummaryObject(groupMember));
 
                 userFeedback.add(new QuizUserFeedbackDTO(userSummary,
-                    userSummary.isAuthorisedFullAccess() ? feedback : null));
+                        userSummary.isAuthorisedFullAccess() ? feedback : null));
             }
 
             assignment.setUserFeedback(userFeedback);
             assignment.setQuiz(quiz);
 
             return Response.ok(assignment)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (AssignmentCancelledException e) {
@@ -1151,12 +1117,11 @@ public class QuizFacade extends AbstractIsaacFacade {
     }
 
     /**
-     * Allows a teacher to download the results of an assignment as a CSV
+     * Allows a teacher to download the results of an assignment as a CSV.
      *
      * @param httpServletRequest so that we can extract user information.
-     * @param quizAssignmentId the id of the assignment to view.
-     * @param formatMode set to "excel" for some MS Excel magic
-     *
+     * @param quizAssignmentId   the id of the assignment to view.
+     * @param formatMode         set to "excel" for some MS Excel magic
      * @return Details about the assignment.
      */
     @GET
@@ -1192,7 +1157,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             StringWriter stringWriter = new StringWriter();
             CSVWriter csvWriter = new CSVWriter(stringWriter);
             StringBuilder headerBuilder = new StringBuilder();
-            if (null != formatMode && formatMode.toLowerCase().equals("excel")) {
+            if (null != formatMode && formatMode.equalsIgnoreCase("excel")) {
                 headerBuilder.append("\uFEFF");  // UTF-8 Byte Order Marker
             }
             headerBuilder.append(String.format("Test (%s) Results: Downloaded on %s \nGenerated by: %s %s \n\n",
@@ -1205,7 +1170,7 @@ public class QuizFacade extends AbstractIsaacFacade {
                     IsaacQuizSectionDTO quizSection = (IsaacQuizSectionDTO) section;
                     List<ContentBaseDTO> quizQuestions = quizSection.getChildren().stream().filter(c -> c instanceof IsaacQuestionBaseDTO).collect(Collectors.toList());
                     for (int i = 0; i < quizQuestions.size(); ++i) {
-                        questionTitles.add(String.format("\"%s - %s - Q%d\"", quiz.getTitle(), quizSection.getTitle(), i+1));
+                        questionTitles.add(String.format("\"%s - %s - Q%d\"", quiz.getTitle(), quizSection.getTitle(), i + 1));
                         questionIds.add(quizQuestions.get(i).getId());
                     }
                 }
@@ -1255,7 +1220,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             csvWriter.writeAll(rows);
             csvWriter.close();
 
-            headerBuilder.append(stringWriter.toString());
+            headerBuilder.append(stringWriter);
             // get game manager completion information for this assignment.
             return Response.ok(headerBuilder.toString())
                     .header("Content-Disposition", "attachment; filename=test_results.csv")
@@ -1309,7 +1274,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             StringWriter stringWriter = new StringWriter();
             CSVWriter csvWriter = new CSVWriter(stringWriter);
             StringBuilder headerBuilder = new StringBuilder();
-            if (null != formatMode && formatMode.toLowerCase().equals("excel")) {
+            if (null != formatMode && formatMode.equalsIgnoreCase("excel")) {
                 headerBuilder.append("\uFEFF");  // UTF-8 Byte Order Marker
             }
             headerBuilder.append(String.format("Quiz results for group (%s): Downloaded on %s \nGenerated by: %s %s \n\n",
@@ -1416,7 +1381,7 @@ public class QuizFacade extends AbstractIsaacFacade {
             }
             csvWriter.close();
 
-            headerBuilder.append(stringWriter.toString());
+            headerBuilder.append(stringWriter);
             return Response.ok(headerBuilder.toString())
                     .header("Content-Disposition", "attachment; filename=group_test_results.csv")
                     .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
@@ -1444,7 +1409,7 @@ public class QuizFacade extends AbstractIsaacFacade {
                 IsaacQuizSectionDTO quizSection = (IsaacQuizSectionDTO) section;
                 List<ContentBaseDTO> quizQuestions = quizSection.getChildren().stream().filter(c -> c instanceof IsaacQuestionBaseDTO).collect(Collectors.toList());
                 for (int i = 0; i < quizQuestions.size(); ++i) {
-                    questionTitles.add(String.format("\"%s - %s - Q%d\"", quiz.getTitle(), quizSection.getTitle(), i+1));
+                    questionTitles.add(String.format("\"%s - %s - Q%d\"", quiz.getTitle(), quizSection.getTitle(), i + 1));
                 }
             }
         }
@@ -1470,9 +1435,8 @@ public class QuizFacade extends AbstractIsaacFacade {
      * Allows a teacher to see a specific user's attempt to an assignment.
      *
      * @param httpServletRequest so that we can extract user information.
-     * @param quizAssignmentId the id of the assignment.
-     * @param userId the id of the user to get the answers for.
-     *
+     * @param quizAssignmentId   the id of the assignment.
+     * @param userId             the id of the user to get the answers for.
      * @return Details about the user's attempt.
      */
     @GET
@@ -1501,26 +1465,26 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             if (!canManageGroup(user, group)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
-                    "You can only view assignments to groups you own or manage.").toResponse();
+                        "You can only view assignments to groups you own or manage.").toResponse();
             }
 
             RegisteredUserDTO student = this.userManager.getUserDTOById(userId);
 
             if (!groupManager.isUserInGroup(student, group)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
-                    "That student is not in the group that was assigned this test.").toResponse();
+                        "That student is not in the group that was assigned this test.").toResponse();
             }
 
             if (!associationManager.hasPermission(user, student)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
-                    "You do not have access to that student's data.").toResponse();
+                        "You do not have access to that student's data.").toResponse();
             }
 
             QuizAttemptDTO quizAttempt = quizAttemptManager.getByQuizAssignmentAndUser(assignment, student);
 
             if (quizAttempt == null || quizAttempt.getCompletedDate() == null) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
-                    "That student has not completed this test assignment.").toResponse();
+                        "That student has not completed this test assignment.").toResponse();
             }
 
             if (!isUserAnAdmin(userManager, user) && !user.getId().equals(student.getId()) && assignment.getCreationDate().getTime() < QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP) {
@@ -1536,8 +1500,8 @@ public class QuizFacade extends AbstractIsaacFacade {
             QuizAttemptFeedbackDTO quizAttemptFeedback = new QuizAttemptFeedbackDTO(userManager.convertToUserSummaryObject(student), quizAttempt);
 
             return Response.ok(quizAttemptFeedback)
-                .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
-                .build();
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
+                    .build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (AssignmentCancelledException e) {
@@ -1559,10 +1523,9 @@ public class QuizFacade extends AbstractIsaacFacade {
      *
      * Only changes to the feedbackMode and dueDate fields are accepted. A bad request error will be thrown if any other fields are set.
      *
-     * @param httpServletRequest so that we can extract user information.
-     * @param quizAssignmentId the id of the assignment to update.
+     * @param httpServletRequest   so that we can extract user information.
+     * @param quizAssignmentId     the id of the assignment to update.
      * @param clientQuizAssignment a partial object with new values for the quiz assignment (only feedbackMode and dueDate may be set.)
-     *
      * @return Confirmation or error.
      */
     @POST
@@ -1577,13 +1540,12 @@ public class QuizFacade extends AbstractIsaacFacade {
             return new SegueErrorResponse(Status.BAD_REQUEST, "You must provide a valid test assignment id.").toResponse();
         }
 
-        if (   clientQuizAssignment.getId() != null
-            || clientQuizAssignment.getQuizId() != null
-            || clientQuizAssignment.getGroupId() != null
-            || clientQuizAssignment.getOwnerUserId() != null
-            || clientQuizAssignment.getCreationDate() != null
-            || clientQuizAssignment.getScheduledStartDate() != null)
-        {
+        if (clientQuizAssignment.getId() != null
+                || clientQuizAssignment.getQuizId() != null
+                || clientQuizAssignment.getGroupId() != null
+                || clientQuizAssignment.getOwnerUserId() != null
+                || clientQuizAssignment.getCreationDate() != null
+                || clientQuizAssignment.getScheduledStartDate() != null) {
             log.warn("Attempt to change fields for test assignment id {} that aren't feedbackMode or dueDate: {}", quizAssignmentId, clientQuizAssignment);
             return new SegueErrorResponse(Status.BAD_REQUEST, "Those fields are not editable.").toResponse();
         }
@@ -1597,8 +1559,10 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             QuizAssignmentDTO assignment = quizAssignmentManager.getById(quizAssignmentId);
 
-            if (!canManageAssignment(assignment, user)) return new SegueErrorResponse(Status.FORBIDDEN,
-                "You can only updates assignments to groups you own or manage.").toResponse();
+            if (!canManageAssignment(assignment, user)) {
+                return new SegueErrorResponse(Status.FORBIDDEN,
+                        "You can only updates assignments to groups you own or manage.").toResponse();
+            }
 
             if (assignment.getDueDate() != null && clientQuizAssignment.getDueDate() != null && clientQuizAssignment.getDueDate().compareTo(assignment.getDueDate()) <= 0) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
@@ -1607,8 +1571,8 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             quizAssignmentManager.updateAssignment(assignment, clientQuizAssignment);
 
-            if (assignment.getDueDate() != null && clientQuizAssignment.getDueDate() != null &&
-                assignment.getDueDate().compareTo(clientQuizAssignment.getDueDate()) != 0) {
+            if (assignment.getDueDate() != null && clientQuizAssignment.getDueDate() != null
+                    && assignment.getDueDate().compareTo(clientQuizAssignment.getDueDate()) != 0) {
                 Map<String, Object> eventDetails = ImmutableMap.of(
                         QUIZ_ID_FKEY, assignment.getQuizId(),
                         GROUP_FK, assignment.getGroupId(),
@@ -1628,8 +1592,8 @@ public class QuizFacade extends AbstractIsaacFacade {
                 this.getLogManager().logEvent(user, httpServletRequest, IsaacServerLogType.UPDATE_QUIZ_DEADLINE, eventDetails);
             }
 
-            if (assignment.getQuizFeedbackMode() != null && clientQuizAssignment.getQuizFeedbackMode() != null &&
-                assignment.getQuizFeedbackMode().compareTo(clientQuizAssignment.getQuizFeedbackMode()) != 0) {
+            if (assignment.getQuizFeedbackMode() != null && clientQuizAssignment.getQuizFeedbackMode() != null
+                    && assignment.getQuizFeedbackMode().compareTo(clientQuizAssignment.getQuizFeedbackMode()) != 0) {
                 Map<String, Object> eventDetails = ImmutableMap.of(
                         QUIZ_ID_FKEY, assignment.getQuizId(),
                         GROUP_FK, assignment.getGroupId(),
@@ -1656,8 +1620,7 @@ public class QuizFacade extends AbstractIsaacFacade {
      * Allows a teacher to cancel a quiz they have set.
      *
      * @param httpServletRequest so that we can extract user information.
-     * @param quizAssignmentId the id of the assignment to cancel.
-     *
+     * @param quizAssignmentId   the id of the assignment to cancel.
      * @return Confirmation or error.
      */
     @DELETE
@@ -1679,8 +1642,10 @@ public class QuizFacade extends AbstractIsaacFacade {
 
             QuizAssignmentDTO assignment = quizAssignmentManager.getById(quizAssignmentId);
 
-            if (!canManageAssignment(assignment, user)) return new SegueErrorResponse(Status.FORBIDDEN,
-                "You can only cancel assignments to groups you own or manage.").toResponse();
+            if (!canManageAssignment(assignment, user)) {
+                return new SegueErrorResponse(Status.FORBIDDEN,
+                        "You can only cancel assignments to groups you own or manage.").toResponse();
+            }
 
             quizAssignmentManager.cancelAssignment(assignment);
 
@@ -1723,7 +1688,7 @@ public class QuizFacade extends AbstractIsaacFacade {
         return null;
     }
 
-    @SuppressWarnings( "deprecation" )
+    @SuppressWarnings("deprecation")
     private QuizAttemptDTO getIncompleteQuizAttemptForUser(Long quizAttemptId, RegisteredUserDTO user) throws SegueDatabaseException, ErrorResponseWrapper {
         QuizAttemptDTO quizAttempt = getQuizAttemptForUser(quizAttemptId, user);
 
@@ -1733,7 +1698,7 @@ public class QuizFacade extends AbstractIsaacFacade {
         return quizAttempt;
     }
 
-    @SuppressWarnings( "deprecation" )
+    @SuppressWarnings("deprecation")
     private QuizAttemptDTO getCompleteQuizAttemptForUser(Long quizAttemptId, RegisteredUserDTO user) throws SegueDatabaseException, ErrorResponseWrapper {
         QuizAttemptDTO quizAttempt = getQuizAttemptForUser(quizAttemptId, user);
 
@@ -1770,7 +1735,7 @@ public class QuizFacade extends AbstractIsaacFacade {
 
     private boolean canManageGroup(RegisteredUserDTO currentlyLoggedInUser, UserGroupDTO assigneeGroup) throws NoUserLoggedInException {
         return GroupManager.isOwnerOrAdditionalManager(assigneeGroup, currentlyLoggedInUser.getId())
-            || isUserAnAdmin(userManager, currentlyLoggedInUser);
+                || isUserAnAdmin(userManager, currentlyLoggedInUser);
     }
 
     private QuizAttemptDTO augmentAttempt(QuizAttemptDTO quizAttempt, @Nullable QuizAssignmentDTO quizAssignment, boolean includeCorrect) throws ContentManagerException, SegueDatabaseException {
@@ -1785,7 +1750,7 @@ public class QuizFacade extends AbstractIsaacFacade {
         Map<RegisteredUserDTO, QuizFeedbackDTO> feedbackMap = quizQuestionManager.getAssignmentTeacherFeedback(quiz, assignment, groupMembers);
         List<QuizUserFeedbackDTO> userFeedback = new ArrayList<>();
         for (RegisteredUserDTO groupMember : groupMembers) {
-            QuizFeedbackDTO feedback  = feedbackMap.get(groupMember);
+            QuizFeedbackDTO feedback = feedbackMap.get(groupMember);
             UserSummaryDTO userSummary = associationManager.enforceAuthorisationPrivacy(user,
                     userManager.convertToUserSummaryObject(groupMember));
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AttemptCompletedException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AttemptCompletedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/DueBeforeNowException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/DueBeforeNowException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Raspberry Pi Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/DueBeforeNowException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/DueBeforeNowException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/DuplicateAssignmentException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/DuplicateAssignmentException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/DuplicateAssignmentException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/DuplicateAssignmentException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/NoWildcardException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/NoWildcardException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAttemptManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/URIManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/URIManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/URIManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/URIManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/monitors/IsaacMetrics.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/monitors/IsaacMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/monitors/IsaacMetrics.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/monitors/IsaacMetrics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/AssignmentService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/AssignmentService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/ContentSummarizerService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/ContentSummarizerService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/EmailService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/EmailService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Raspberry Pi Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/EmailService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/EmailService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/GroupChangedService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/GroupChangedService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacApplicationRegister.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacHttpServletDispatcher.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacHttpServletDispatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacHttpServletDispatcher.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/IsaacHttpServletDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Andrew Rice
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/RestEasyJacksonConfiguration.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/RestEasyJacksonConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/exceptionMappers/MethodNotAllowedExceptionMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/exceptionMappers/MethodNotAllowedExceptionMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/exceptionMappers/OptionsMethodExceptionMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/exceptionMappers/OptionsMethodExceptionMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/exceptionMappers/UnhandledExceptionMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/configuration/exceptionMappers/UnhandledExceptionMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/IQuizAssignmentPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/IQuizAssignmentPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/IQuizAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/IQuizAttemptPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/IQuizQuestionAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/IQuizQuestionAttemptPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgAssignmentPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgAssignmentPersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgAssignmentPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgAssignmentPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizAssignmentPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizAssignmentPersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Raspberry Pi Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizAssignmentPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizAssignmentPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizAttemptPersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizAttemptPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizQuestionAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgQuizQuestionAttemptPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AbstractUserPreferenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AbstractUserPreferenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssignmentDO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssignmentDO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssignmentDO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssignmentDO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,207 +21,213 @@ import java.util.Date;
  * This class is the Domain Object used to store Assignments in the isaac CMS.
  */
 public class AssignmentDO {
-	private Long id;
-	private String gameboardId;
-	private Long groupId;
-	private Long ownerUserId;
-	private String notes;
-	private Date creationDate;
-	private Date dueDate;
-	private Date scheduledStartDate;
+    private Long id;
+    private String gameboardId;
+    private Long groupId;
+    private Long ownerUserId;
+    private String notes;
+    private Date creationDate;
+    private Date dueDate;
+    private Date scheduledStartDate;
 
-	/**
-	 * Complete AssignmentDO constructor with all dependencies.
-	 *  @param id
-	 *            - unique id for the gameboard
-	 * @param gameboardId
-	 *            - The gameboard to assign as homework.
-	 * @param ownerUserId
-     *            - User id of the owner of the gameboard.
-	 * @param groupId
-     *            - Group id who should be assigned the game board.
-	 * @param notes
-	 * @param creationDate
-	 *            - the date the assignment was created.
-	 * @param dueDate
-	 * @param scheduledStartDate
-	 *        - the date and time the assignment should have notification emails sent to its group (using Quartz)
-	 */
+    /**
+     * Complete AssignmentDO constructor with all dependencies.
+     *
+     * @param id                 - unique id for the gameboard
+     * @param gameboardId        - The gameboard to assign as homework.
+     * @param ownerUserId        - User id of the owner of the gameboard.
+     * @param groupId            - Group id who should be assigned the game board.
+     * @param notes
+     * @param creationDate       - the date the assignment was created.
+     * @param dueDate
+     * @param scheduledStartDate - the date and time the assignment should appear to users and notifications be sent
+     */
     public AssignmentDO(final Long id, final String gameboardId, final Long ownerUserId, final Long groupId,
-						String notes, final Date creationDate, final Date dueDate, final Date scheduledStartDate) {
-		this.id = id;
-		this.gameboardId = gameboardId;
-		this.ownerUserId = ownerUserId;
-		this.groupId = groupId;
-		this.notes = notes;
-		this.creationDate = creationDate;
-		this.dueDate = dueDate;
-		this.scheduledStartDate = scheduledStartDate;
-	}
-	
-	/**
-	 * Default constructor required for AutoMapping.
-	 */
-	public AssignmentDO() {
-
-	}
-
-	/**
-	 * Gets the id.
-	 * @return the id
-	 */
-	public Long getId() {
-		return id;
-	}
-
-	/**
-	 * Sets the id.
-	 * @param id the id to set
-	 */
-	public void setId(final Long id) {
-		this.id = id;
-	}
-
-	/**
-	 * Gets the gameboardId.
-	 * @return the gameboardId
-	 */
-	public String getGameboardId() {
-		return gameboardId;
-	}
-
-	/**
-	 * Sets the gameboardId.
-	 * @param gameboardId the gameboardId to set
-	 */
-	public void setGameboardId(final String gameboardId) {
-		this.gameboardId = gameboardId;
-	}
-
-	/**
-	 * Gets the groupId.
-	 * @return the groupId
-	 */
-	public Long getGroupId() {
-		return groupId;
-	}
-
-	/**
-	 * Sets the groupId.
-	 * @param groupId the groupId to set
-	 */
-	public void setGroupId(final Long groupId) {
-		this.groupId = groupId;
-	}
-
-	/**
-	 * Gets the ownerUserId.
-	 * @return the ownerUserId
-	 */
-	public Long getOwnerUserId() {
-		return ownerUserId;
-	}
-
-	/**
-	 * Sets the ownerUserId.
-	 * @param ownerUserId the ownerUserId to set
-	 */
-	public void setOwnerUserId(final Long ownerUserId) {
-		this.ownerUserId = ownerUserId;
-	}
-
-	/**
-	 * get notes to an assignment.
-	 * @return notes - the notes
-	 */
-	public String getNotes() {
-		return notes;
-	}
-
-	/**
-	 * set notes to an assignment.
-	 * @param notes - the notes
-	 */
-	public void setNotes(String notes) {
-		this.notes = notes;
-	}
-
-	/**
-	 * Gets the creationDate.
-	 * @return the creationDate
-	 */
-	public Date getCreationDate() {
-		return creationDate;
-	}
-
-	/**
-	 * Sets the creationDate.
-	 * @param creationDate the creationDate to set
-	 */
-	public void setCreationDate(final Date creationDate) {
-		this.creationDate = creationDate;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(final Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (!(obj instanceof AssignmentDO)) {
-			return false;
-		}
-		AssignmentDO other = (AssignmentDO) obj;
-		if (id == null) {
-			if (other.id != null) {
-				return false;
-			}
-		} else if (!id.equals(other.id)) {
-			return false;
-		}
-        return true;
+                        String notes, final Date creationDate, final Date dueDate, final Date scheduledStartDate) {
+        this.id = id;
+        this.gameboardId = gameboardId;
+        this.ownerUserId = ownerUserId;
+        this.groupId = groupId;
+        this.notes = notes;
+        this.creationDate = creationDate;
+        this.dueDate = dueDate;
+        this.scheduledStartDate = scheduledStartDate;
     }
 
-	/**
-	 * get the due date of the assignment.
-	 * @return dueDate
-	 */
-	public Date getDueDate() {
-		return dueDate;
-	}
+    /**
+     * Default constructor required for AutoMapping.
+     */
+    public AssignmentDO() {
 
-	/**
-	 * set the due date of an assignment.
-	 * @param dueDate - date due
-	 */
-	public void setDueDate(Date dueDate) {
-		this.dueDate = dueDate;
-	}
+    }
+
+    /**
+     * Gets the id.
+     *
+     * @return the id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the id.
+     *
+     * @param id the id to set
+     */
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the gameboardId.
+     *
+     * @return the gameboardId
+     */
+    public String getGameboardId() {
+        return gameboardId;
+    }
+
+    /**
+     * Sets the gameboardId.
+     *
+     * @param gameboardId the gameboardId to set
+     */
+    public void setGameboardId(final String gameboardId) {
+        this.gameboardId = gameboardId;
+    }
+
+    /**
+     * Gets the groupId.
+     *
+     * @return the groupId
+     */
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * Sets the groupId.
+     *
+     * @param groupId the groupId to set
+     */
+    public void setGroupId(final Long groupId) {
+        this.groupId = groupId;
+    }
+
+    /**
+     * Gets the ownerUserId.
+     *
+     * @return the ownerUserId
+     */
+    public Long getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    /**
+     * Sets the ownerUserId.
+     *
+     * @param ownerUserId the ownerUserId to set
+     */
+    public void setOwnerUserId(final Long ownerUserId) {
+        this.ownerUserId = ownerUserId;
+    }
+
+    /**
+     * get notes to an assignment.
+     *
+     * @return notes - the notes
+     */
+    public String getNotes() {
+        return notes;
+    }
+
+    /**
+     * set notes to an assignment.
+     *
+     * @param notes - the notes
+     */
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    /**
+     * Gets the creationDate.
+     *
+     * @return the creationDate
+     */
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    /**
+     * Sets the creationDate.
+     *
+     * @param creationDate the creationDate to set
+     */
+    public void setCreationDate(final Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof AssignmentDO)) {
+            return false;
+        }
+        AssignmentDO other = (AssignmentDO) obj;
+        if (id == null) {
+            return other.id == null;
+        } else return id.equals(other.id);
+    }
+
+    /**
+     * get the due date of the assignment.
+     *
+     * @return dueDate
+     */
+    public Date getDueDate() {
+        return dueDate;
+    }
+
+    /**
+     * set the due date of an assignment.
+     *
+     * @param dueDate - date due
+     */
+    public void setDueDate(Date dueDate) {
+        this.dueDate = dueDate;
+    }
 
 
-	/**
-	 * get the date of when the assignment should be displayed to users.
-	 * @return scheduledStartDate
-	 */
-	public Date getScheduledStartDate() {
-		return scheduledStartDate;
-	}
+    /**
+     * get the date of when the assignment should be displayed to users.
+     *
+     * @return scheduledStartDate
+     */
+    public Date getScheduledStartDate() {
+        return scheduledStartDate;
+    }
 
-	/**
-	 * set the date of when the assignment should be displayed to users.
-	 * @param scheduledStartDate - the scheduled start date
-	 */
-	public void setScheduledStartDate(Date scheduledStartDate) {
-		this.scheduledStartDate = scheduledStartDate;
-	}
+    /**
+     * set the date of when the assignment should be displayed to users.
+     *
+     * @param scheduledStartDate - the scheduled start date
+     */
+    public void setScheduledStartDate(Date scheduledStartDate) {
+        this.scheduledStartDate = scheduledStartDate;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssociationToken.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssociationToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssociationToken.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssociationToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/FormulaValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/FormulaValidationResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ian Davies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/FormulaValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/FormulaValidationResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GameboardCreationMethod.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GameboardCreationMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GameboardCreationMethod.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GameboardCreationMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GameboardDO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GameboardDO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GameboardDO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GameboardDO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GroupMembership.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GroupMembership.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GroupMembershipStatus.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GroupMembershipStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GroupStatus.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/GroupStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IUserNotification.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IUserNotification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IUserNotification.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IUserNotification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IUserNotifications.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IUserNotifications.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IUserNotifications.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IUserNotifications.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacAnvilQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacAnvilQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacAnvilQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacAnvilQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCard.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCard.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCard.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCardDeck.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCardDeck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCardDeck.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCardDeck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacClozeQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacClozeQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacConceptPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacConceptPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacConceptPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacConceptPage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,24 +15,23 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dos;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ExternalReference;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Image;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
 import uk.ac.cam.cl.dtg.util.locations.Address;
 import uk.ac.cam.cl.dtg.util.locations.Location;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * DO for isaac Event.
@@ -40,187 +39,187 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.EVENT_GROUP_RESERVATION_DEFAU
 @DTOMapping(IsaacEventPageDTO.class)
 @JsonContentType("isaacEventPage")
 public class IsaacEventPage extends Content {
-	private Date date;
-	private Date end_date;
-	private Date bookingDeadline;
-	private Date prepWorkDeadline;
+    private Date date;
+    private Date end_date;
+    private Date bookingDeadline;
+    private Date prepWorkDeadline;
 
-	private Location location;
+    private Location location;
 
-	private List<ExternalReference> preResources;
-	private List<Content> preResourceContent;
+    private List<ExternalReference> preResources;
+    private List<Content> preResourceContent;
 
-	private String emailEventDetails;
+    private String emailEventDetails;
 
-	private String emailConfirmedBookingText;
-	private String emailWaitingListBookingText;
+    private String emailConfirmedBookingText;
+    private String emailWaitingListBookingText;
 
-	private List<ExternalReference> postResources;
-	private List<Content> postResourceContent;
+    private List<ExternalReference> postResources;
+    private List<Content> postResourceContent;
 
-	private Image eventThumbnail;
+    private Image eventThumbnail;
 
-	private Integer numberOfPlaces;
+    private Integer numberOfPlaces;
 
-	private EventStatus eventStatus;
+    private EventStatus eventStatus;
 
-	private String isaacGroupToken;
+    private String isaacGroupToken;
 
-	private Integer groupReservationLimit;
+    private Integer groupReservationLimit;
 
-	private Boolean allowGroupReservations;
+    private Boolean allowGroupReservations;
 
-	@JsonCreator
-	public IsaacEventPage(@JsonProperty("id") String id,
-						  @JsonProperty("title") String title,
-						  @JsonProperty("subtitle") String subtitle,
-						  @JsonProperty("type") String type,
-						  @JsonProperty("author") String author,
-						  @JsonProperty("encoding") String encoding,
-						  @JsonProperty("canonicalSourceFile") String canonicalSourceFile,
-						  @JsonProperty("layout") String layout,
-						  @JsonProperty("children") List<ContentBase> children,
-						  @JsonProperty("relatedContent") List<String> relatedContent,
-						  @JsonProperty("version") boolean published,
-						  @JsonProperty("deprecated") Boolean deprecated,
-						  @JsonProperty("tags") Set<String> tags,
-						  @JsonProperty("date") Date date, @JsonProperty("end_date") Date end_date,
-						  @JsonProperty("bookingDeadline") Date bookingDeadline,
-						  @JsonProperty("prepWorkDeadline") Date prepWorkDeadline,
-						  @JsonProperty("location") Location location,
-						  @JsonProperty("preResources") List<ExternalReference> preResources,
-						  @JsonProperty("postResources") List<ExternalReference> postResources,
-						  @JsonProperty("eventThumbnail") Image eventThumbnail,
-						  @JsonProperty("numberOfPlaces") Integer numberOfPlaces,
-						  @JsonProperty("EventStatus") EventStatus eventStatus,
-						  @JsonProperty("groupReservationLimit") Integer groupReservationLimit,
-						  @JsonProperty("allowGroupReservations") Boolean allowGroupReservations) {
-		super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null,
-			null, relatedContent, published, deprecated, tags, null);
+    @JsonCreator
+    public IsaacEventPage(@JsonProperty("id") String id,
+                          @JsonProperty("title") String title,
+                          @JsonProperty("subtitle") String subtitle,
+                          @JsonProperty("type") String type,
+                          @JsonProperty("author") String author,
+                          @JsonProperty("encoding") String encoding,
+                          @JsonProperty("canonicalSourceFile") String canonicalSourceFile,
+                          @JsonProperty("layout") String layout,
+                          @JsonProperty("children") List<ContentBase> children,
+                          @JsonProperty("relatedContent") List<String> relatedContent,
+                          @JsonProperty("version") boolean published,
+                          @JsonProperty("deprecated") Boolean deprecated,
+                          @JsonProperty("tags") Set<String> tags,
+                          @JsonProperty("date") Date date, @JsonProperty("end_date") Date end_date,
+                          @JsonProperty("bookingDeadline") Date bookingDeadline,
+                          @JsonProperty("prepWorkDeadline") Date prepWorkDeadline,
+                          @JsonProperty("location") Location location,
+                          @JsonProperty("preResources") List<ExternalReference> preResources,
+                          @JsonProperty("postResources") List<ExternalReference> postResources,
+                          @JsonProperty("eventThumbnail") Image eventThumbnail,
+                          @JsonProperty("numberOfPlaces") Integer numberOfPlaces,
+                          @JsonProperty("EventStatus") EventStatus eventStatus,
+                          @JsonProperty("groupReservationLimit") Integer groupReservationLimit,
+                          @JsonProperty("allowGroupReservations") Boolean allowGroupReservations) {
+        super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null,
+                null, relatedContent, published, deprecated, tags, null);
 
-		this.date = date;
-		this.end_date = end_date;
-		this.bookingDeadline = bookingDeadline;
-		this.prepWorkDeadline = prepWorkDeadline;
-		this.location = location;
-		this.preResources = preResources;
-		this.postResources = postResources;
-		this.eventThumbnail = eventThumbnail;
-		this.numberOfPlaces = numberOfPlaces;
-		this.eventStatus = eventStatus;
-		this.groupReservationLimit = groupReservationLimit != null ? groupReservationLimit : EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
-		this.allowGroupReservations = allowGroupReservations != null ? allowGroupReservations : false;
-	}
+        this.date = date;
+        this.end_date = end_date;
+        this.bookingDeadline = bookingDeadline;
+        this.prepWorkDeadline = prepWorkDeadline;
+        this.location = location;
+        this.preResources = preResources;
+        this.postResources = postResources;
+        this.eventThumbnail = eventThumbnail;
+        this.numberOfPlaces = numberOfPlaces;
+        this.eventStatus = eventStatus;
+        this.groupReservationLimit = groupReservationLimit != null ? groupReservationLimit : EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
+        this.allowGroupReservations = allowGroupReservations != null ? allowGroupReservations : false;
+    }
 
-	/**
-	 * Default constructor required for Jackson.
-	 */
-	public IsaacEventPage() {
+    /**
+     * Default constructor required for Jackson.
+     */
+    public IsaacEventPage() {
 
-	}
+    }
 
-	/**
-	 * Gets the date.
-	 *
-	 * @return the date
-	 */
-	public Date getDate() {
-		return date;
-	}
+    /**
+     * Gets the date.
+     *
+     * @return the date
+     */
+    public Date getDate() {
+        return date;
+    }
 
-	/**
-	 * Sets the date.
-	 *
-	 * @param date the date to set
-	 */
-	public void setDate(final Date date) {
-		this.date = date;
-	}
+    /**
+     * Sets the date.
+     *
+     * @param date the date to set
+     */
+    public void setDate(final Date date) {
+        this.date = date;
+    }
 
-	/**
-	 * Gets the end date.
-	 *
-	 * @return the end date
-	 */
-	public Date getEndDate() {
-		return end_date;
-	}
+    /**
+     * Gets the end date.
+     *
+     * @return the end date
+     */
+    public Date getEndDate() {
+        return end_date;
+    }
 
-	/**
-	 * getBookingDeadline.
-	 *
-	 * @return bookingDeadline.
-	 */
-	public Date getBookingDeadline() {
-		return bookingDeadline;
-	}
+    /**
+     * getBookingDeadline.
+     *
+     * @return bookingDeadline.
+     */
+    public Date getBookingDeadline() {
+        return bookingDeadline;
+    }
 
-	/**
-	 * setBookingDeadline.
-	 *
-	 * @param bookingDeadline the booking deadline.
-	 */
-	public void setBookingDeadline(final Date bookingDeadline) {
-		this.bookingDeadline = bookingDeadline;
-	}
+    /**
+     * setBookingDeadline.
+     *
+     * @param bookingDeadline the booking deadline.
+     */
+    public void setBookingDeadline(final Date bookingDeadline) {
+        this.bookingDeadline = bookingDeadline;
+    }
 
-	/**
-	 * getPrepWorkDeadline.
-	 *
-	 * @return bookingDeadline.
-	 */
-	public Date getPrepWorkDeadline() {
-		return prepWorkDeadline;
-	}
+    /**
+     * getPrepWorkDeadline.
+     *
+     * @return bookingDeadline.
+     */
+    public Date getPrepWorkDeadline() {
+        return prepWorkDeadline;
+    }
 
-	/**
-	 * setPrepWorkDeadline.
-	 *
-	 * @param prepWorkDeadline the booking deadline.
-	 */
-	public void setPrepWorkDeadline(final Date prepWorkDeadline) {
-		this.prepWorkDeadline = prepWorkDeadline;
-	}
+    /**
+     * setPrepWorkDeadline.
+     *
+     * @param prepWorkDeadline the booking deadline.
+     */
+    public void setPrepWorkDeadline(final Date prepWorkDeadline) {
+        this.prepWorkDeadline = prepWorkDeadline;
+    }
 
-	/**
-	 * Sets the end date.
-	 *
-	 * @param end_date the end date to set
-	 */
-	public void setEndDate(final Date end_date) {
-		// Don't want 'end_date' to be null ever; force it to 'date' for consistency if necessary.
-		if (null != end_date) {
-			this.end_date = end_date;
-		} else {
-			this.end_date = this.date;
-		}
-	}
+    /**
+     * Sets the end date.
+     *
+     * @param end_date the end date to set
+     */
+    public void setEndDate(final Date end_date) {
+        // Don't want 'end_date' to be null ever; force it to 'date' for consistency if necessary.
+        if (null != end_date) {
+            this.end_date = end_date;
+        } else {
+            this.end_date = this.date;
+        }
+    }
 
-	/**
-	 * Gets the address.
-	 *
-	 * @return the address
-	 */
-	public Address getAddress() {
-		if (location != null) {
-			return location.getAddress();
-		} else {
-			return null;
-		}
-	}
+    /**
+     * Gets the address.
+     *
+     * @return the address
+     */
+    public Address getAddress() {
+        if (location != null) {
+            return location.getAddress();
+        } else {
+            return null;
+        }
+    }
 
-	/**
-	 * Sets the address.
-	 *
-	 * @param address the location to set
-	 */
-	public void setAddress(final Address address) {
-		if (location != null) {
-			this.location.setAddress(address);
-		} else {
-			this.location = new Location(address, null, null);
-		}
-	}
+    /**
+     * Sets the address.
+     *
+     * @param address the location to set
+     */
+    public void setAddress(final Address address) {
+        if (location != null) {
+            this.location.setAddress(address);
+        } else {
+            this.location = new Location(address, null, null);
+        }
+    }
 
     /**
      * Gets the location.
@@ -240,233 +239,239 @@ public class IsaacEventPage extends Content {
         this.location = location;
     }
 
-	/**
-	 * Gets the preResources.
-	 *
-	 * @return the preResources
-	 */
-	public List<ExternalReference> getPreResources() {
-		return preResources;
-	}
+    /**
+     * Gets the preResources.
+     *
+     * @return the preResources
+     */
+    public List<ExternalReference> getPreResources() {
+        return preResources;
+    }
 
-	/**
-	 * Sets the preResources.
-	 *
-	 * @param preResources the preResources to set
-	 */
-	public void setPreResources(final List<ExternalReference> preResources) {
-		this.preResources = preResources;
-	}
+    /**
+     * Sets the preResources.
+     *
+     * @param preResources the preResources to set
+     */
+    public void setPreResources(final List<ExternalReference> preResources) {
+        this.preResources = preResources;
+    }
 
-	/**
-	 * Gets the postResources.
-	 *
-	 * @return the postResources
-	 */
-	public List<ExternalReference> getPostResources() {
-		return postResources;
-	}
+    /**
+     * Gets the postResources.
+     *
+     * @return the postResources
+     */
+    public List<ExternalReference> getPostResources() {
+        return postResources;
+    }
 
-	/**
-	 * Sets the postResources.
-	 *
-	 * @param postResources the postResources to set
-	 */
-	public void setPostResources(final List<ExternalReference> postResources) {
-		this.postResources = postResources;
-	}
+    /**
+     * Sets the postResources.
+     *
+     * @param postResources the postResources to set
+     */
+    public void setPostResources(final List<ExternalReference> postResources) {
+        this.postResources = postResources;
+    }
 
-	/**
-	 * Gets the eventThumbnail.
-	 *
-	 * @return the eventThumbnail
-	 */
-	public Image getEventThumbnail() {
-		return eventThumbnail;
-	}
+    /**
+     * Gets the eventThumbnail.
+     *
+     * @return the eventThumbnail
+     */
+    public Image getEventThumbnail() {
+        return eventThumbnail;
+    }
 
-	/**
-	 * Sets the eventThumbnail.
-	 *
-	 * @param eventThumbnail the eventThumbnail to set
-	 */
-	public void setEventThumbnail(final Image eventThumbnail) {
-		this.eventThumbnail = eventThumbnail;
-	}
+    /**
+     * Sets the eventThumbnail.
+     *
+     * @param eventThumbnail the eventThumbnail to set
+     */
+    public void setEventThumbnail(final Image eventThumbnail) {
+        this.eventThumbnail = eventThumbnail;
+    }
 
-	/**
-	 * Gets the numberOfPlaces.
-	 *
-	 * @return the numberOfPlaces
-	 */
-	public Integer getNumberOfPlaces() {
-		return numberOfPlaces;
-	}
+    /**
+     * Gets the numberOfPlaces.
+     *
+     * @return the numberOfPlaces
+     */
+    public Integer getNumberOfPlaces() {
+        return numberOfPlaces;
+    }
 
-	/**
-	 * Sets the numberOfPlaces.
-	 *
-	 * @param numberOfPlaces the numberOfPlaces to set
-	 */
-	public void setNumberOfPlaces(final Integer numberOfPlaces) {
-		this.numberOfPlaces = numberOfPlaces;
-	}
+    /**
+     * Sets the numberOfPlaces.
+     *
+     * @param numberOfPlaces the numberOfPlaces to set
+     */
+    public void setNumberOfPlaces(final Integer numberOfPlaces) {
+        this.numberOfPlaces = numberOfPlaces;
+    }
 
-	/**
-	 * Gets the eventStatus.
-	 *
-	 * @return the eventStatus
-	 */
-	public EventStatus getEventStatus() {
-		return eventStatus;
-	}
+    /**
+     * Gets the eventStatus.
+     *
+     * @return the eventStatus
+     */
+    public EventStatus getEventStatus() {
+        return eventStatus;
+    }
 
-	/**
-	 * Sets the eventStatus.
-	 *
-	 * @param eventStatus the eventStatus to set
-	 */
-	public void setEventStatus(final EventStatus eventStatus) {
-		this.eventStatus = eventStatus;
-	}
+    /**
+     * Sets the eventStatus.
+     *
+     * @param eventStatus the eventStatus to set
+     */
+    public void setEventStatus(final EventStatus eventStatus) {
+        this.eventStatus = eventStatus;
+    }
 
-	/**
-	 * Gets the isaacGroupToken.
-	 *
-	 * @return the group token.
-	 */
-	public String getIsaacGroupToken() {
-		return isaacGroupToken;
-	}
+    /**
+     * Gets the isaacGroupToken.
+     *
+     * @return the group token.
+     */
+    public String getIsaacGroupToken() {
+        return isaacGroupToken;
+    }
 
-	/**
-	 * Sets the isaac group token.
-	 *
-	 * @param isaacGroupToken the group token for the event.
-	 */
-	public void setIsaacGroupToken(final String isaacGroupToken) {
-		this.isaacGroupToken = isaacGroupToken;
-	}
+    /**
+     * Sets the isaac group token.
+     *
+     * @param isaacGroupToken the group token for the event.
+     */
+    public void setIsaacGroupToken(final String isaacGroupToken) {
+        this.isaacGroupToken = isaacGroupToken;
+    }
 
-	/**
-	 * setEnd_date.
-	 *
-	 * @param end_date the end date of the event.
-	 */
-	public void setEnd_date(final Date end_date) {
-		this.end_date = end_date;
-	}
+    /**
+     * setEnd_date.
+     *
+     * @param end_date the end date of the event.
+     */
+    public void setEnd_date(final Date end_date) {
+        this.end_date = end_date;
+    }
 
-	/**
-	 * getPreResourceContent.
-	 *
-	 * @return the preresource content.
-	 */
-	public List<Content> getPreResourceContent() {
-		return preResourceContent;
-	}
+    /**
+     * getPreResourceContent.
+     *
+     * @return the preresource content.
+     */
+    public List<Content> getPreResourceContent() {
+        return preResourceContent;
+    }
 
-	/**
-	 * setPreResourceContent.
-	 *
-	 * @param preResourceContent - the preresource content.
-	 */
-	public void setPreResourceContent(final List<Content> preResourceContent) {
-		this.preResourceContent = preResourceContent;
-	}
+    /**
+     * setPreResourceContent.
+     *
+     * @param preResourceContent - the preresource content.
+     */
+    public void setPreResourceContent(final List<Content> preResourceContent) {
+        this.preResourceContent = preResourceContent;
+    }
 
-	/**
-	 * getPostResourceContent.
-	 *
-	 * @return the resource content.
-	 */
-	public List<Content> getPostResourceContent() {
-		return postResourceContent;
-	}
+    /**
+     * getPostResourceContent.
+     *
+     * @return the resource content.
+     */
+    public List<Content> getPostResourceContent() {
+        return postResourceContent;
+    }
 
-	/**
-	 * setPostResourceContent.
-	 *
-	 * @param postResourceContent the content list.
-	 */
-	public void setPostResourceContent(final List<Content> postResourceContent) {
-		this.postResourceContent = postResourceContent;
-	}
+    /**
+     * setPostResourceContent.
+     *
+     * @param postResourceContent the content list.
+     */
+    public void setPostResourceContent(final List<Content> postResourceContent) {
+        this.postResourceContent = postResourceContent;
+    }
 
-	/**
-	 * Get information about the event that is common to all booking system emails
-	 * @return emailEventDetails
-	 */
-	public String getEmailEventDetails() {
-		return emailEventDetails;
-	}
+    /**
+     * Get information about the event that is common to all booking system emails
+     *
+     * @return emailEventDetails
+     */
+    public String getEmailEventDetails() {
+        return emailEventDetails;
+    }
 
-	/**
-	 * Set the email event details.
-	 * @param emailEventDetails - the text to show in the email token
-	 */
-	public void setEmailEventDetails(final String emailEventDetails) {
-		this.emailEventDetails = emailEventDetails;
-	}
+    /**
+     * Set the email event details.
+     *
+     * @param emailEventDetails - the text to show in the email token
+     */
+    public void setEmailEventDetails(final String emailEventDetails) {
+        this.emailEventDetails = emailEventDetails;
+    }
 
 
-	/**
-	 * Get text about the event for the confirmed emails
-	 *
-	 * @return emailEventDetails
-	 */
-	public String getEmailConfirmedBookingText() {
-		return emailConfirmedBookingText;
-	}
+    /**
+     * Get text about the event for the confirmed emails
+     *
+     * @return emailEventDetails
+     */
+    public String getEmailConfirmedBookingText() {
+        return emailConfirmedBookingText;
+    }
 
-	/**
-	 * Set the email confirmed booking text for emails.
-	 * @param emailConfirmedBookingText - text to show in emails
-	 */
-	public void setEmailConfirmedBookingText(String emailConfirmedBookingText) {
-		this.emailConfirmedBookingText = emailConfirmedBookingText;
-	}
+    /**
+     * Set the email confirmed booking text for emails.
+     *
+     * @param emailConfirmedBookingText - text to show in emails
+     */
+    public void setEmailConfirmedBookingText(String emailConfirmedBookingText) {
+        this.emailConfirmedBookingText = emailConfirmedBookingText;
+    }
 
-	/**
-	 * Get text about the event for the waiting list emails
-	 *
-	 * @return emailEventDetails
-	 */
-	public String getEmailWaitingListBookingText() {
-		return emailWaitingListBookingText;
-	}
+    /**
+     * Get text about the event for the waiting list emails
+     *
+     * @return emailEventDetails
+     */
+    public String getEmailWaitingListBookingText() {
+        return emailWaitingListBookingText;
+    }
 
-	/**
-	 * Set the email waiting list text for emails.
-	 * @param emailWaitingListBookingText - text to show in email.
-	 */
-	public void setEmailWaitingListBookingText(String emailWaitingListBookingText) {
-		this.emailWaitingListBookingText = emailWaitingListBookingText;
-	}
+    /**
+     * Set the email waiting list text for emails.
+     *
+     * @param emailWaitingListBookingText - text to show in email.
+     */
+    public void setEmailWaitingListBookingText(String emailWaitingListBookingText) {
+        this.emailWaitingListBookingText = emailWaitingListBookingText;
+    }
 
-	/**
-	 * Get the maximum number of reservations per event that a teacher can request.
-	 * @return groupReservationLimit
-	 */
-	public Integer getGroupReservationLimit() {
-		return groupReservationLimit;
-	}
+    /**
+     * Get the maximum number of reservations per event that a teacher can request.
+     *
+     * @return groupReservationLimit
+     */
+    public Integer getGroupReservationLimit() {
+        return groupReservationLimit;
+    }
 
-	/**
-	 * Set the maximum number of reservations per event that a teacher can request.
-	 * @param groupReservationLimit
-	 */
-	public void setGroupReservationLimit(Integer groupReservationLimit) {
-		this.groupReservationLimit = groupReservationLimit;
-	}
+    /**
+     * Set the maximum number of reservations per event that a teacher can request.
+     *
+     * @param groupReservationLimit
+     */
+    public void setGroupReservationLimit(Integer groupReservationLimit) {
+        this.groupReservationLimit = groupReservationLimit;
+    }
 
-	public Boolean getAllowGroupReservations() {
-		return allowGroupReservations;
-	}
+    public Boolean getAllowGroupReservations() {
+        return allowGroupReservations;
+    }
 
-	public void setAllowGroupReservations(Boolean allowGroupReservations) {
-		this.allowGroupReservations = allowGroupReservations;
-	}
+    public void setAllowGroupReservations(Boolean allowGroupReservations) {
+        this.allowGroupReservations = allowGroupReservations;
+    }
 
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFastTrackQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFastTrackQuestionPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFastTrackQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFastTrackQuestionPage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFeaturedProfile.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFeaturedProfile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFeaturedProfile.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFeaturedProfile.java
@@ -1,11 +1,11 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,18 +15,17 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dos;
 
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacFeaturedProfileDTO;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Image;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacFeaturedProfileDTO;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * DO for isaac featured profiles.
@@ -36,91 +35,97 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 @JsonContentType("isaacFeaturedProfile")
 public class IsaacFeaturedProfile extends Content {
 
-	protected String emailAddress;
-	protected Image image;
-	protected String homepage;
+    protected String emailAddress;
+    protected Image image;
+    protected String homepage;
 
-	@JsonCreator
-	public IsaacFeaturedProfile(
-			@JsonProperty("id") String id, @JsonProperty("title") String title,
-			@JsonProperty("subtitle") String subtitle,
-			@JsonProperty("type") String type,
-			@JsonProperty("author") String author,
-			@JsonProperty("encoding") String encoding,
-			@JsonProperty("canonicalSourceFile") String canonicalSourceFile,
-			@JsonProperty("layout") String layout,
-			@JsonProperty("children") List<ContentBase> children,
-			@JsonProperty("value") String value,
-			@JsonProperty("attribution") String attribution,
-			@JsonProperty("relatedContent") List<String> relatedContent,
-			@JsonProperty("version") boolean published,
-			@JsonProperty("deprecated") Boolean deprecated,
-			@JsonProperty("tags") Set<String> tags,
-			@JsonProperty("level") Integer level,
-			@JsonProperty("emailAddress") String emailAddress,
-			@JsonProperty("image") Image image,
-			@JsonProperty("homepage") String homepage) {
-		super(id, title, subtitle, type, author, encoding,
-				canonicalSourceFile, layout, children, value, attribution,
-				relatedContent, published, deprecated, tags, level);
+    @JsonCreator
+    public IsaacFeaturedProfile(
+            @JsonProperty("id") String id, @JsonProperty("title") String title,
+            @JsonProperty("subtitle") String subtitle,
+            @JsonProperty("type") String type,
+            @JsonProperty("author") String author,
+            @JsonProperty("encoding") String encoding,
+            @JsonProperty("canonicalSourceFile") String canonicalSourceFile,
+            @JsonProperty("layout") String layout,
+            @JsonProperty("children") List<ContentBase> children,
+            @JsonProperty("value") String value,
+            @JsonProperty("attribution") String attribution,
+            @JsonProperty("relatedContent") List<String> relatedContent,
+            @JsonProperty("version") boolean published,
+            @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("level") Integer level,
+            @JsonProperty("emailAddress") String emailAddress,
+            @JsonProperty("image") Image image,
+            @JsonProperty("homepage") String homepage) {
+        super(id, title, subtitle, type, author, encoding,
+                canonicalSourceFile, layout, children, value, attribution,
+                relatedContent, published, deprecated, tags, level);
 
-		this.emailAddress = emailAddress;
-		this.image = image;
-		this.homepage = homepage;
-	}
+        this.emailAddress = emailAddress;
+        this.image = image;
+        this.homepage = homepage;
+    }
 
-	/**
-	 * Default constructor required for Jackson
-	 */
-	public IsaacFeaturedProfile() {
+    /**
+     * Default constructor required for Jackson.
+     */
+    public IsaacFeaturedProfile() {
 
-	}
+    }
 
-	/**
-	 * Gets the e-mail address.
-	 * @return the email
-	 */
-	public String getEmailAddress() {
-		return emailAddress;
-	}
-	
-	/**
-	 * Sets the email address.
-	 * @param emailAddress to set
-	 */
-	public void setEmailAddress(final String emailAddress) {
-		this.emailAddress = emailAddress;
-	}
+    /**
+     * Gets the e-mail address.
+     *
+     * @return the email
+     */
+    public String getEmailAddress() {
+        return emailAddress;
+    }
 
-	/**
-	 * Get the profile image.
-	 * @return the image
-	 */
-	public Image getImage() {
-		return image;
-	}
-	
-	/**
-	 * Set the image for the profile. 
-	 * @param image the image to set
-	 */
-	public void setImage(final Image image) {
-		this.image = image;
-	}
+    /**
+     * Sets the email address.
+     *
+     * @param emailAddress to set
+     */
+    public void setEmailAddress(final String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
 
-	/**
-	 * Gets the homepage.
-	 * @return the homepage
-	 */
-	public String getHomepage() {
-		return homepage;
-	}
+    /**
+     * Get the profile image.
+     *
+     * @return the image
+     */
+    public Image getImage() {
+        return image;
+    }
 
-	/**
-	 * Sets the homepage.
-	 * @param homepage the homepage to set
-	 */
-	public void setHomepage(final String homepage) {
-		this.homepage = homepage;
-	}
+    /**
+     * Set the image for the profile.
+     *
+     * @param image the image to set
+     */
+    public void setImage(final Image image) {
+        this.image = image;
+    }
+
+    /**
+     * Gets the homepage.
+     *
+     * @return the homepage
+     */
+    public String getHomepage() {
+        return homepage;
+    }
+
+    /**
+     * Sets the homepage.
+     *
+     * @param homepage the homepage to set
+     */
+    public void setHomepage(final String homepage) {
+        this.homepage = homepage;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFreeTextQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFreeTextQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFreeTextQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFreeTextQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacGraphSketcherQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacGraphSketcherQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacGraphSketcherQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacGraphSketcherQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ryan Lau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacItemQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacItemQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacMultiChoiceQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacMultiChoiceQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacMultiChoiceQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacMultiChoiceQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacNumericQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacNumericQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPageFragment.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPageFragment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacParsonsQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacParsonsQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPod.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPod.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPod.java
@@ -1,11 +1,11 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,18 +15,17 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dos;
 
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacPodDTO;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Image;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacPodDTO;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * DO for isaac featured profiles.
@@ -35,74 +34,74 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 @DTOMapping(IsaacPodDTO.class)
 @JsonContentType("isaacPod")
 public class IsaacPod extends Content {
-	private Image image;
-	private String url;
+    private Image image;
+    private String url;
 
-	@JsonCreator
-	public IsaacPod(
-			@JsonProperty("id") String id,
-			@JsonProperty("title") String title,
-			@JsonProperty("subtitle") String subtitle,
-			@JsonProperty("type") String type,
-			@JsonProperty("author") String author,
-			@JsonProperty("encoding") String encoding,
-			@JsonProperty("canonicalSourceFile") String canonicalSourceFile,
-			@JsonProperty("layout") String layout,
-			@JsonProperty("children") List<ContentBase> children,
-			@JsonProperty("value") String value,
-			@JsonProperty("attribution") String attribution,
-			@JsonProperty("relatedContent") List<String> relatedContent,
-			@JsonProperty("version") boolean published,
-			@JsonProperty("deprecated") Boolean deprecated,
-			@JsonProperty("tags") Set<String> tags,
-			@JsonProperty("level") Integer level,
-			@JsonProperty("emailAddress") String emailAddress,
-			@JsonProperty("image") Image image,
-			@JsonProperty("url") String url) {
-		super(id, title, subtitle, type, author, encoding,
-				canonicalSourceFile, layout, children, value, attribution,
-				relatedContent, published, deprecated, tags, level);
+    @JsonCreator
+    public IsaacPod(
+            @JsonProperty("id") String id,
+            @JsonProperty("title") String title,
+            @JsonProperty("subtitle") String subtitle,
+            @JsonProperty("type") String type,
+            @JsonProperty("author") String author,
+            @JsonProperty("encoding") String encoding,
+            @JsonProperty("canonicalSourceFile") String canonicalSourceFile,
+            @JsonProperty("layout") String layout,
+            @JsonProperty("children") List<ContentBase> children,
+            @JsonProperty("value") String value,
+            @JsonProperty("attribution") String attribution,
+            @JsonProperty("relatedContent") List<String> relatedContent,
+            @JsonProperty("version") boolean published,
+            @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("level") Integer level,
+            @JsonProperty("emailAddress") String emailAddress,
+            @JsonProperty("image") Image image,
+            @JsonProperty("url") String url) {
+        super(id, title, subtitle, type, author, encoding,
+                canonicalSourceFile, layout, children, value, attribution,
+                relatedContent, published, deprecated, tags, level);
 
-		this.url = url;
-		this.image = image;
-	}
+        this.url = url;
+        this.image = image;
+    }
 
-	/**
-	 * Default constructor required for Jackson.
-	 */
-	public IsaacPod() {
+    /**
+     * Default constructor required for Jackson.
+     */
+    public IsaacPod() {
 
-	}	
+    }
 
-	/**
-	 * Gets the image.
-	 * @return the image
-	 */
-	public Image getImage() {
-		return image;
-	}
+    /**
+     * Gets the image.
+     * @return the image
+     */
+    public Image getImage() {
+        return image;
+    }
 
-	/**
-	 * Sets the image.
-	 * @param image the image to set
-	 */
-	public void setImage(final Image image) {
-		this.image = image;
-	}
+    /**
+     * Sets the image.
+     * @param image the image to set
+     */
+    public void setImage(final Image image) {
+        this.image = image;
+    }
 
-	/**
-	 * Gets the url.
-	 * @return the url
-	 */
-	public String getUrl() {
-		return url;
-	}
+    /**
+     * Gets the url.
+     * @return the url
+     */
+    public String getUrl() {
+        return url;
+    }
 
-	/**
-	 * Sets the url.
-	 * @param url the url to set
-	 */
-	public void setUrl(final String url) {
-		this.url = url;
-	}
+    /**
+     * Sets the url.
+     * @param url the url to set
+     */
+    public void setUrl(final String url) {
+        this.url = url;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionBase.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionBase.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuickQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuickQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuickQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuickQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuizSection.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuizSection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Raspberry Pi Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuizSection.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuizSection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacRegexMatchQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacRegexMatchQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Chris Purdy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacRegexMatchQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacRegexMatchQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacReorderQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacReorderQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacStringMatchQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicChemistryQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicChemistryQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ian Davies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicChemistryQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicChemistryQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicLogicQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicLogicQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacSymbolicQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacTopicSummaryPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacTopicSummaryPage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacWildcard.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacWildcard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacWildcard.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacWildcard.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ItemValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ItemValidationResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LocationHistory.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LocationHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LocationHistory.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LocationHistory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LocationHistoryEvent.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LocationHistoryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LocationHistoryEvent.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LocationHistoryEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LogEvent.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/LogEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationEvent.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationEvent.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationHistory.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationHistory.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationHistory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserNotification.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserNotification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserNotification.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserNotification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserNotifications.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserNotifications.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserNotifications.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserNotifications.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserPreferenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgUserPreferenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuantityValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuantityValidationResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuantityValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuantityValidationResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuestionValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuestionValidationResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuestionValidationResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuestionValidationResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuizAssignmentDO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuizAssignmentDO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuizAttemptDO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuizAttemptDO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuizFeedbackMode.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/QuizFeedbackMode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/TestCase.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/TestCase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/TestQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/TestQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserAssociation.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserAssociation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserAssociation.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserAssociation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserGroup.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserPreference.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserPreference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/AnvilApp.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/AnvilApp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/AnvilApp.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/AnvilApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ChemicalFormula.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ChemicalFormula.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ian Davies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ChemicalFormula.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ChemicalFormula.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Choice.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Choice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Choice.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Choice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ChoiceQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ChoiceQuestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ChoiceQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ChoiceQuestion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CodeSnippet.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CodeSnippet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CodeSnippet.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CodeSnippet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Ben Hanson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Content.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Content.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Content.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Content.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ContentBase.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ContentBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/DTOMapping.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/DTOMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/DTOMapping.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/DTOMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/EmailTemplate.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/EmailTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ExternalReference.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ExternalReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ExternalReference.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ExternalReference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Figure.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Figure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Figure.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Figure.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Formula.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Formula.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Formula.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Formula.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/FreeTextRule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/FreeTextRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/FreeTextRule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/FreeTextRule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/GlossaryTerm.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/GlossaryTerm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Andrea Franceschini
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/GlossaryTerm.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/GlossaryTerm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Image.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Image.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Image.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Image.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Item.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Item.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ItemChoice.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ItemChoice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/JsonContentType.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/JsonContentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/JsonContentType.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/JsonContentType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LogicFormula.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LogicFormula.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Media.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Media.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Media.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Media.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Notification.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Notification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Notification.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Notification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ParsonsChoice.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ParsonsChoice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ParsonsItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/ParsonsItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Quantity.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Quantity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Quantity.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Quantity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Question.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Question.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/RegexPattern.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/RegexPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Chris Purdy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/RegexPattern.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/RegexPattern.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/StringChoice.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/StringChoice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/StringChoice.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/StringChoice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Video.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Video.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Video.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Video.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBooking.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBooking.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBooking.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBooking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/EventBookings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBooking.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBooking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/eventbookings/PgEventBookings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/AbstractSegueUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/AbstractSegueUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/AbstractSegueUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/AbstractSegueUser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/AnonymousUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/AnonymousUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/AnonymousUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/AnonymousUser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/EmailVerificationStatus.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/EmailVerificationStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/EmailVerificationStatus.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/EmailVerificationStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookTokenData.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookTokenData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookTokenData.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookTokenData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookTokenInfo.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookTokenInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookTokenInfo.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookTokenInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/FacebookUser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/Gender.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/Gender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/LinkedAccount.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/LinkedAccount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/LocalUserCredential.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/LocalUserCredential.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/RegisteredUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/RegisteredUser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/Role.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/Role.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/School.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/School.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/TOTPSharedSecret.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/TOTPSharedSecret.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserAuthenticationSettings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserAuthenticationSettings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserExternalAccountChanges.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserExternalAccountChanges.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserFromAuthProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserFromAuthProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserFromAuthProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserFromAuthProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserSettings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/users/UserSettings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentStatusDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentStatusDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/FormulaValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/FormulaValidationResponseDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ian Davies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/FormulaValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/FormulaValidationResponseDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameFilter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameFilter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardListDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardListDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardListDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardListDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacAnvilQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacAnvilQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacAnvilQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacAnvilQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCardDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCardDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCardDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCardDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCardDeckDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCardDeckDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCardDeckDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCardDeckDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacClozeQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacClozeQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacConceptPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacConceptPageDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacConceptPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacConceptPageDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFastTrackQuestionPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFastTrackQuestionPageDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFastTrackQuestionPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFastTrackQuestionPageDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFeaturedProfileDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFeaturedProfileDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFeaturedProfileDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFeaturedProfileDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFreeTextQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFreeTextQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFreeTextQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFreeTextQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ryan Lau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacItemQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacItemQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacMultiChoiceQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacNumericQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPageFragmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPageFragmentDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacParsonsQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacParsonsQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,90 +15,92 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto;
 
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ImageDTO;
 
+import java.util.List;
+import java.util.Set;
+
 /**
  * DO for isaac featured profiles.
- *
  */
 @JsonContentType("isaacPod")
 public class IsaacPodDTO extends ContentDTO {
-	private ImageDTO image;
-	private String url;
+    private ImageDTO image;
+    private String url;
 
-	@JsonCreator
-	public IsaacPodDTO(
-			@JsonProperty("id") String id, @JsonProperty("title") String title,
-			@JsonProperty("subtitle") String subtitle,
-			@JsonProperty("type") String type,
-			@JsonProperty("author") String author,
-			@JsonProperty("encoding") String encoding,
-			@JsonProperty("canonicalSourceFile") String canonicalSourceFile,
-			@JsonProperty("layout") String layout,
-			@JsonProperty("children") List<ContentBaseDTO> children,
-			@JsonProperty("value") String value,
-			@JsonProperty("attribution") String attribution,
-			@JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
-			@JsonProperty("version") boolean published,
-			@JsonProperty("deprecated") Boolean deprecated,
-			@JsonProperty("tags") Set<String> tags,
-			@JsonProperty("level") Integer level,
-			@JsonProperty("image") ImageDTO image,
-			@JsonProperty("url") String url) {
-		super(id, title, subtitle, type, author, encoding,
-				canonicalSourceFile, layout, children, value, attribution,
-				relatedContent, published, deprecated, tags, level);
+    @JsonCreator
+    public IsaacPodDTO(
+            @JsonProperty("id") String id, @JsonProperty("title") String title,
+            @JsonProperty("subtitle") String subtitle,
+            @JsonProperty("type") String type,
+            @JsonProperty("author") String author,
+            @JsonProperty("encoding") String encoding,
+            @JsonProperty("canonicalSourceFile") String canonicalSourceFile,
+            @JsonProperty("layout") String layout,
+            @JsonProperty("children") List<ContentBaseDTO> children,
+            @JsonProperty("value") String value,
+            @JsonProperty("attribution") String attribution,
+            @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
+            @JsonProperty("version") boolean published,
+            @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("level") Integer level,
+            @JsonProperty("image") ImageDTO image,
+            @JsonProperty("url") String url) {
+        super(id, title, subtitle, type, author, encoding,
+                canonicalSourceFile, layout, children, value, attribution,
+                relatedContent, published, deprecated, tags, level);
 
-		this.url = url;
-		this.image = image;
-	}
+        this.url = url;
+        this.image = image;
+    }
 
-	/**
-	 * Default constructor required for Jackson.
-	 */
-	public IsaacPodDTO() {
+    /**
+     * Default constructor required for Jackson.
+     */
+    public IsaacPodDTO() {
 
-	}	
+    }
 
-	/**
-	 * Gets the image.
-	 * @return the image
-	 */
-	public ImageDTO getImage() {
-		return image;
-	}
+    /**
+     * Gets the image.
+     *
+     * @return the image
+     */
+    public ImageDTO getImage() {
+        return image;
+    }
 
-	/**
-	 * Sets the image.
-	 * @param image the image to set
-	 */
-	public void setImage(final ImageDTO image) {
-		this.image = image;
-	}
+    /**
+     * Sets the image.
+     *
+     * @param image the image to set
+     */
+    public void setImage(final ImageDTO image) {
+        this.image = image;
+    }
 
-	/**
-	 * Gets the link.
-	 * @return the link
-	 */
-	public String getUrl() {
-		return url;
-	}
+    /**
+     * Gets the link.
+     *
+     * @return the link
+     */
+    public String getUrl() {
+        return url;
+    }
 
-	/**
-	 * Sets the link.
-	 * @param url the link to set
-	 */
-	public void setUrl(final String url) {
-		this.url = url;
-	}	
+    /**
+     * Sets the link.
+     *
+     * @param url the link to set
+     */
+    public void setUrl(final String url) {
+        this.url = url;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionBaseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionBaseDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionBaseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionBaseDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuickQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuickQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuickQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuickQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizSectionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizSectionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Raspberry Pi Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizSectionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizSectionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacRegexMatchQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacRegexMatchQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Chris Purdy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacRegexMatchQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacRegexMatchQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacReorderQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacReorderQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacStringMatchQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicChemistryQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicChemistryQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ian Davies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicChemistryQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicChemistryQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicLogicQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicLogicQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacSymbolicQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacTopicSummaryPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacTopicSummaryPageDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacWildcardDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacWildcardDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacWildcardDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacWildcardDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ItemValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ItemValidationResponseDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LocalAuthDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LocalAuthDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LocalAuthDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/LocalAuthDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/MFAResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/MFAResponseDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/MFAResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/MFAResponseDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/MisuseStatisticDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/MisuseStatisticDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuantityValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuantityValidationResponseDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuantityValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuantityValidationResponseDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionPartConceptDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionPartConceptDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionPartConceptDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionPartConceptDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionValidationResponseDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionValidationResponseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuestionValidationResponseDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAssignmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAssignmentDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAttemptDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAttemptDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizFeedbackDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizFeedbackDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizUserFeedbackDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizUserFeedbackDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ResultsWrapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ResultsWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ResultsWrapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/ResultsWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/SegueErrorResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/SegueErrorResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/SegueErrorResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/SegueErrorResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/UserGroupDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/UserGroupDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/AnvilAppDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/AnvilAppDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/AnvilAppDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/AnvilAppDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChemicalFormulaDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChemicalFormulaDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Ian Davies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChemicalFormulaDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChemicalFormulaDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChoiceDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChoiceDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChoiceQuestionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChoiceQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ChoiceQuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CodeSnippetDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CodeSnippetDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CodeSnippetDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CodeSnippetDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Ben Hanson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentBaseDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentBaseDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentSummaryDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentSummaryDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/EmailTemplateDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/EmailTemplateDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FigureDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FigureDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FigureDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FigureDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FormulaDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FormulaDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ian Davies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FormulaDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FormulaDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FreeTextRuleDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FreeTextRuleDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FreeTextRuleDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/FreeTextRuleDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/GlossaryTermDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/GlossaryTermDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Andrea Franceschini
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/GlossaryTermDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/GlossaryTermDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/GraphChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/GraphChoiceDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/GraphChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/GraphChoiceDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ImageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ImageDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ImageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ImageDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ItemChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ItemChoiceDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ItemDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ItemDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/LogicFormulaDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/LogicFormulaDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/MediaDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/MediaDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/MediaDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/MediaDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/NotificationDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/NotificationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/NotificationDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/NotificationDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ParsonsChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ParsonsChoiceDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ParsonsItemDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ParsonsItemDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/QuantityDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/QuantityDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/QuantityDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/QuantityDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/QuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/QuestionDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/RegexPatternDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/RegexPatternDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Chris Purdy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/RegexPatternDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/RegexPatternDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/SeguePageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/SeguePageDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/SeguePageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/SeguePageDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/StringChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/StringChoiceDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/StringChoiceDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/StringChoiceDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/VideoDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/VideoDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/VideoDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/VideoDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/eventbookings/EventBookingDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/eventbookings/EventBookingDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/eventbookings/EventBookingDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/eventbookings/EventBookingDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/AbstractSegueUserDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/AbstractSegueUserDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/AbstractSegueUserDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/AbstractSegueUserDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/AnonymousUserDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/AnonymousUserDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/AnonymousUserDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/AnonymousUserDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/GroupMembershipDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/GroupMembershipDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/RegisteredUserDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/RegisteredUserDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserAuthenticationSettingsDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserAuthenticationSettingsDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserIdMergeDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserIdMergeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserIdMergeDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserIdMergeDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserSummaryDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserSummaryForAdminUsersDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserSummaryForAdminUsersDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserSummaryWithEmailAddressDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserSummaryWithEmailAddressDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserSummaryWithGroupMembershipDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/users/UserSummaryWithGroupMembershipDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ChoiceQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ChoiceQuestionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ChoiceQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ChoiceQuestionValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISpecifier.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISpecifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 University of Cambridge
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISpecifier.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISpecifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacFreeTextValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherSettings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherSettings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacRegexMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacRegexMatchValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Chris Purdy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacRegexMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacRegexMatchValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacReorderValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacReorderValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/SpecifiesWith.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/SpecifiesWith.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/SpecifiesWith.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/SpecifiesWith.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/UnmarkedInputQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/UnmarkedInputQuestionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/UnmarkedInputQuestionValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/UnmarkedInputQuestionValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidatesWith.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidatesWith.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidatesWith.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidatesWith.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidatorUnavailableException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidatorUnavailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidatorUnavailableException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidatorUnavailableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/ContactFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/ContactFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/CountryLookupFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/CountryLookupFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *                 http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/ErrorResponseWrapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/ErrorResponseWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/InfoFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/InfoFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/LogEventFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/LogEventFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/NotificationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/NotificationFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/SchoolLookupServiceFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/SchoolLookupServiceFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueContentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueContentFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueDefaultFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueDefaultFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/CountryLookupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/CountryLookupManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/ExternalAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/ExternalAccountManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/ExternalAccountSynchronisationException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/ExternalAccountSynchronisationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/IGroupObserver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/IGroupObserver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/NotificationPicker.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/NotificationPicker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/NotificationPicker.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/NotificationPicker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/SegueResourceMisuseException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/SegueResourceMisuseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/SegueResourceMisuseException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/SegueResourceMisuseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StubExternalAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StubExternalAccountManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/AnonQuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/AnonQuestionAttemptMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/AnonQuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/AnonQuestionAttemptMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/EmailVerificationMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/EmailVerificationMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/EmailVerificationMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/EmailVerificationMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/EmailVerificationRequestMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/EmailVerificationRequestMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/EmailVerificationRequestMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/EmailVerificationRequestMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/GroupManagerLookupMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/GroupManagerLookupMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/GroupManagerLookupMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/GroupManagerLookupMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMetricsExporter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMetricsExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMetricsExporter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMetricsExporter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IMisuseMonitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IPQuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IPQuestionAttemptMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InMemoryMisuseMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InMemoryMisuseMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InMemoryMisuseMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/InMemoryMisuseMonitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/LogEventMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/LogEventMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/LogEventMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/LogEventMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PasswordResetByEmailMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PasswordResetByEmailMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PasswordResetByIPMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PasswordResetByIPMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PerformanceMonitor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PerformanceMonitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PrometheusMetricsExporter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PrometheusMetricsExporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PrometheusMetricsExporter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/PrometheusMetricsExporter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/QuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/QuestionAttemptMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/RegistrationMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/RegistrationMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/RegistrationMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/RegistrationMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueLoginMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueLoginMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueLoginMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueLoginMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Meurig Thomas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueMetrics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SendEmailMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SendEmailMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TeacherPasswordResetMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TeacherPasswordResetMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TeacherPasswordResetMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TeacherPasswordResetMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TokenOwnerLookupMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/TokenOwnerLookupMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/UserSearchMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/UserSearchMisuseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Connor Holloway
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/UserSearchMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/UserSearchMisuseHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Raspberry Pi Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/AuthenticationProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/AuthenticationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/AuthenticationProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/AuthenticationProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,31 +14,6 @@
  * limitations under the License.
  */
 package uk.ac.cam.cl.dtg.segue.auth;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.math.BigInteger;
-import java.security.SecureRandom;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.UUID;
-import java.util.WeakHashMap;
-
-import org.apache.commons.lang3.Validate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticatorSecurityException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.CodeExchangeException;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
-import uk.ac.cam.cl.dtg.segue.dao.JsonLoader;
-import uk.ac.cam.cl.dtg.isaac.dos.users.EmailVerificationStatus;
-import uk.ac.cam.cl.dtg.isaac.dos.users.FacebookTokenInfo;
-import uk.ac.cam.cl.dtg.isaac.dos.users.FacebookUser;
-import uk.ac.cam.cl.dtg.isaac.dos.users.UserFromAuthProvider;
 
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow.Builder;
@@ -58,50 +33,78 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.store.MemoryDataStoreFactory;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.dos.users.EmailVerificationStatus;
+import uk.ac.cam.cl.dtg.isaac.dos.users.FacebookTokenInfo;
+import uk.ac.cam.cl.dtg.isaac.dos.users.FacebookUser;
+import uk.ac.cam.cl.dtg.isaac.dos.users.UserFromAuthProvider;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticatorSecurityException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.CodeExchangeException;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
+import uk.ac.cam.cl.dtg.segue.dao.JsonLoader;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.WeakHashMap;
 
 /**
  * This class is derived from GoogleAuthenticator and provides 3rd party
  * authentication via the Facebook OAuth API.
- * 
+ *
  * @author Nick Rogers
  */
 public class FacebookAuthenticator implements IOAuth2Authenticator {
     private static final Logger log = LoggerFactory.getLogger(FacebookAuthenticator.class);
 
-	private final JsonFactory jsonFactory;
-	private final HttpTransport httpTransport;
+    private final JsonFactory jsonFactory;
+    private final HttpTransport httpTransport;
 
-	private final String clientId;
-	private final String clientSecret;
-	private final String callbackUri;
-	private final Collection<String> requestedScopes;
-	private final String requestedFields;
-	
-	private static final String FACEBOOK_API_VERSION = "2.12";
-	
+    private final String clientId;
+    private final String clientSecret;
+    private final String callbackUri;
+    private final Collection<String> requestedScopes;
+    private final String requestedFields;
+
+    private static final String FACEBOOK_API_VERSION = "2.12";
+
     private static final String AUTH_URL = "https://graph.facebook.com/v" + FACEBOOK_API_VERSION + "/oauth/authorize";
     private static final String TOKEN_EXCHANGE_URL = "https://graph.facebook.com/v" + FACEBOOK_API_VERSION
             + "/oauth/access_token";
-	private static final String USER_INFO_URL = "https://graph.facebook.com/v" + FACEBOOK_API_VERSION + "/me";
-	private static final String TOKEN_VERIFICATION_URL = "https://graph.facebook.com/debug_token";
+    private static final String USER_INFO_URL = "https://graph.facebook.com/v" + FACEBOOK_API_VERSION + "/me";
+    private static final String TOKEN_VERIFICATION_URL = "https://graph.facebook.com/debug_token";
 
-	// weak cache for mapping userInformation to credentials
-	private static WeakHashMap<String, Credential> credentialStore;
-	private static GoogleIdTokenVerifier tokenVerifier;
+    // weak cache for mapping userInformation to credentials
+    private static WeakHashMap<String, Credential> credentialStore;
+    private static GoogleIdTokenVerifier tokenVerifier;
 
     /**
-     * @param clientId The registered Facebook client ID
-     * @param clientSecret The client secret provided by the Facebook api (https://developers.facebook.com/apps/)
-     * @param callbackUri The callback url from the oauth process
-     * @param requestedScopes The facebook permissions requested by this application
-     * @param requestedFields The facebook user info fields requested by this application
+     * @param clientId
+     *         The registered Facebook client ID
+     * @param clientSecret
+     *         The client secret provided by the Facebook api (https://developers.facebook.com/apps/)
+     * @param callbackUri
+     *         The callback url from the oauth process
+     * @param requestedScopes
+     *         The facebook permissions requested by this application
+     * @param requestedFields
+     *         The facebook user info fields requested by this application
      */
     @Inject
     public FacebookAuthenticator(@Named(Constants.FACEBOOK_CLIENT_ID) final String clientId,
-            @Named(Constants.FACEBOOK_SECRET) final String clientSecret,
-            @Named(Constants.FACEBOOK_CALLBACK_URI) final String callbackUri,
-            @Named(Constants.FACEBOOK_OAUTH_SCOPES) final String requestedScopes,
-            @Named(Constants.FACEBOOK_USER_FIELDS) final String requestedFields) {
+                                 @Named(Constants.FACEBOOK_SECRET) final String clientSecret,
+                                 @Named(Constants.FACEBOOK_CALLBACK_URI) final String callbackUri,
+                                 @Named(Constants.FACEBOOK_OAUTH_SCOPES) final String requestedScopes,
+                                 @Named(Constants.FACEBOOK_USER_FIELDS) final String requestedFields) {
         this.jsonFactory = new JacksonFactory();
         this.httpTransport = new NetHttpTransport();
 
@@ -120,73 +123,73 @@ public class FacebookAuthenticator implements IOAuth2Authenticator {
         }
     }
 
-	@Override
-	public AuthenticationProvider getAuthenticationProvider() {
-		return AuthenticationProvider.FACEBOOK;
-	}
+    @Override
+    public AuthenticationProvider getAuthenticationProvider() {
+        return AuthenticationProvider.FACEBOOK;
+    }
 
-	@Override
-	public String getFriendlyName() {
-		return "Facebook";
-	}
+    @Override
+    public String getFriendlyName() {
+        return "Facebook";
+    }
 
-	@Override
-	public String getAuthorizationUrl(final String antiForgeryStateToken) {
+    @Override
+    public String getAuthorizationUrl(final String antiForgeryStateToken) {
         AuthorizationCodeRequestUrl urlBuilder = new AuthorizationCodeRequestUrl(AUTH_URL, clientId);
 
-		urlBuilder.set(Constants.STATE_PARAM_NAME, antiForgeryStateToken);
-		urlBuilder.set("redirect_uri", callbackUri);
+        urlBuilder.set(Constants.STATE_PARAM_NAME, antiForgeryStateToken);
+        urlBuilder.set("redirect_uri", callbackUri);
 
-		String scope = (null == requestedScopes || requestedScopes.size() == 0 ? null : String.join(",", requestedScopes));
-		urlBuilder.set("scope", scope);
+        String scope = (null == requestedScopes || requestedScopes.size() == 0 ? null : String.join(",", requestedScopes));
+        urlBuilder.set("scope", scope);
 
-		return urlBuilder.build();
-	}
+        return urlBuilder.build();
+    }
 
-	@Override
-	public String extractAuthCode(final String url) {
-		// Copied verbatim from GoogleAuthenticator.extractAuthCode
+    @Override
+    public String extractAuthCode(final String url) {
+        // Copied verbatim from GoogleAuthenticator.extractAuthCode
         AuthorizationCodeResponseUrl authResponse = new AuthorizationCodeResponseUrl(url);
 
-		if (authResponse.getError() == null) {
-			log.debug("User granted access to our app.");
-		} else {
-			log.info("User denied access to our app.");
-		}
+        if (authResponse.getError() == null) {
+            log.debug("User granted access to our app.");
+        } else {
+            log.info("User denied access to our app.");
+        }
 
-		return authResponse.getCode();
-	}
+        return authResponse.getCode();
+    }
 
-	@Override
-	public String exchangeCode(final String authorizationCode)
-		throws CodeExchangeException {
-		try {
+    @Override
+    public String exchangeCode(final String authorizationCode)
+            throws CodeExchangeException {
+        try {
             AuthorizationCodeTokenRequest request = new AuthorizationCodeTokenRequest(httpTransport, jsonFactory,
                     new GenericUrl(TOKEN_EXCHANGE_URL), authorizationCode);
 
             request.setClientAuthentication(new ClientParametersAuthentication(clientId, clientSecret));
-			request.setRedirectUri(callbackUri);
-			
-			TokenResponse response = request.execute();
+            request.setRedirectUri(callbackUri);
 
-			String accessToken;
-			Long expires;
-			if (response.get("error") != null) {
-				throw new CodeExchangeException("Server responded with the following error"
-						+ response.get("error") + " given the request" + request.toString());
-			}
-			
-			if (response.getAccessToken() != null && response.getExpiresInSeconds() != null) {
-				accessToken = response.getAccessToken();
-				expires = response.getExpiresInSeconds();
-			} else {
-				throw new IOException(
-						"access_token or expires_in values were not found");	
-			}
+            TokenResponse response = request.execute();
 
-			TokenResponse tokenResponse = new TokenResponse();
-			tokenResponse.setAccessToken(accessToken);
-			tokenResponse.setExpiresInSeconds(expires);
+            String accessToken;
+            Long expires;
+            if (response.get("error") != null) {
+                throw new CodeExchangeException("Server responded with the following error"
+                        + response.get("error") + " given the request" + request);
+            }
+
+            if (response.getAccessToken() != null && response.getExpiresInSeconds() != null) {
+                accessToken = response.getAccessToken();
+                expires = response.getExpiresInSeconds();
+            } else {
+                throw new IOException(
+                        "access_token or expires_in values were not found");
+            }
+
+            TokenResponse tokenResponse = new TokenResponse();
+            tokenResponse.setAccessToken(accessToken);
+            tokenResponse.setExpiresInSeconds(expires);
 
             // I don't really want to use the flow storage but it seems to be
             // easier to get credentials this way.
@@ -203,69 +206,69 @@ public class FacebookAuthenticator implements IOAuth2Authenticator {
             credentialStore.put(internalReferenceToken, credential);
             flow.getCredentialDataStore().clear();
 
-			return internalReferenceToken;
-		} catch (IOException e) {
-			String message = "An error occurred during code exchange";
-			throw new CodeExchangeException(message, e);
-		}
-	}
+            return internalReferenceToken;
+        } catch (IOException e) {
+            String message = "An error occurred during code exchange";
+            throw new CodeExchangeException(message, e);
+        }
+    }
 
-	@Override
-	public String getAntiForgeryStateToken() {
-		final int numberOfBits = 130;
-		final int radix = 130;
+    @Override
+    public String getAntiForgeryStateToken() {
+        final int numberOfBits = 130;
+        final int radix = 130;
 
         return "facebook" + new BigInteger(numberOfBits, new SecureRandom()).toString(radix);
     }
 
-	@Override
-	public synchronized UserFromAuthProvider getUserInfo(final String internalProviderReference)
-		throws NoUserException, AuthenticatorSecurityException {
-		Credential credentials = credentialStore.get(internalProviderReference);
+    @Override
+    public synchronized UserFromAuthProvider getUserInfo(final String internalProviderReference)
+            throws NoUserException, AuthenticatorSecurityException {
+        Credential credentials = credentialStore.get(internalProviderReference);
 
-		if (verifyAccessTokenIsValid(credentials)) {
-			log.debug("Successful Verification of access token with provider.");
-		} else {
-			log.error("Unable to verify access token - it could be an indication of fraud.");
-			throw new AuthenticatorSecurityException(
-					"Access token is invalid - the client id returned by the identity provider does not match ours.");
-		}
+        if (verifyAccessTokenIsValid(credentials)) {
+            log.debug("Successful Verification of access token with provider.");
+        } else {
+            log.error("Unable to verify access token - it could be an indication of fraud.");
+            throw new AuthenticatorSecurityException(
+                    "Access token is invalid - the client id returned by the identity provider does not match ours.");
+        }
 
-		FacebookUser userInfo = null;
+        FacebookUser userInfo = null;
 
-		try {
-			GenericUrl url = new GenericUrl(USER_INFO_URL + "?fields=" + requestedFields);
-			url.set("access_token", credentials.getAccessToken());
-			
-			userInfo = JsonLoader.load(inputStreamToString(url.toURL().openStream()),
-					FacebookUser.class, true);
+        try {
+            GenericUrl url = new GenericUrl(USER_INFO_URL + "?fields=" + requestedFields);
+            url.set("access_token", credentials.getAccessToken());
 
-			log.debug("Retrieved User info from Facebook");
-		} catch (IOException e) {
-			log.error("An IO error occurred while trying to retrieve user information: " + e);
-		}
+            userInfo = JsonLoader.load(inputStreamToString(url.toURL().openStream()),
+                    FacebookUser.class, true);
 
-		if (userInfo != null && userInfo.getId() != null) {
-			EmailVerificationStatus emailStatus = userInfo.isVerified() ? EmailVerificationStatus.VERIFIED : EmailVerificationStatus.NOT_VERIFIED;
-			String email = userInfo.getEmail();
-			if (null == email) {
-				email = userInfo.getId() + "-facebook";
-				emailStatus = EmailVerificationStatus.DELIVERY_FAILED;
-				log.warn("No email address provided by Facebook! Using (" + email + ") instead");
-			}
+            log.debug("Retrieved User info from Facebook");
+        } catch (IOException e) {
+            log.error("An IO error occurred while trying to retrieve user information: " + e);
+        }
 
-			return new UserFromAuthProvider(userInfo.getId(), userInfo.getFirstName(),
-					userInfo.getLastName(), email, emailStatus, null, null, null, null);
-		} else {
-			throw new NoUserException("No user could be created from provider details!");
-		}
-	}
+        if (userInfo != null && userInfo.getId() != null) {
+            EmailVerificationStatus emailStatus = userInfo.isVerified() ? EmailVerificationStatus.VERIFIED : EmailVerificationStatus.NOT_VERIFIED;
+            String email = userInfo.getEmail();
+            if (null == email) {
+                email = userInfo.getId() + "-facebook";
+                emailStatus = EmailVerificationStatus.DELIVERY_FAILED;
+                log.warn("No email address provided by Facebook! Using (" + email + ") instead");
+            }
+
+            return new UserFromAuthProvider(userInfo.getId(), userInfo.getFirstName(),
+                    userInfo.getLastName(), email, emailStatus, null, null, null, null);
+        } else {
+            throw new NoUserException("No user could be created from provider details!");
+        }
+    }
 
     /**
      * This method will contact the identity provider to verify that the token is valid for our application.
-     * 
+     *
      * @param credentials
-     *            to verify
+     *         to verify
      * @return true if the token passes our validation false if not.
      */
     private boolean verifyAccessTokenIsValid(final Credential credentials) {
@@ -286,27 +289,28 @@ public class FacebookAuthenticator implements IOAuth2Authenticator {
         return false;
     }
 
-	/**
-	 * Helper method to read an InputStream into a String.
-	 * 
-	 * @param is
-	 *            - The InputStream to be read
-	 * @return the contents of the InputStream
-	 * @throws IOException - if there is an error during reading the input stream.
-	 */
-	private String inputStreamToString(final InputStream is) throws IOException {
-		String line;
-		StringBuilder total = new StringBuilder();
+    /**
+     * Helper method to read an InputStream into a String.
+     *
+     * @param is
+     *         - The InputStream to be read
+     * @return the contents of the InputStream
+     * @throws IOException
+     *         - if there is an error during reading the input stream.
+     */
+    private String inputStreamToString(final InputStream is) throws IOException {
+        String line;
+        StringBuilder total = new StringBuilder();
 
-		// Wrap a BufferedReader around the InputStream
-		BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+        // Wrap a BufferedReader around the InputStream
+        BufferedReader rd = new BufferedReader(new InputStreamReader(is));
 
-		// Read response until the end
-		while ((line = rd.readLine()) != null) {
-			total.append(line);
-		}
+        // Read response until the end
+        while ((line = rd.readLine()) != null) {
+            total.append(line);
+        }
 
-		// Return full string
-		return total.toString();
-	}
+        // Return full string
+        return total.toString();
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IFederatedAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IFederatedAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IFederatedAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IFederatedAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth1Authenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth1Authenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth1Authenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth1Authenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth2Authenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth2Authenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth2Authenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth2Authenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers & Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IPasswordAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IPasswordAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IPasswordAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IPasswordAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/ISecondFactorAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/ISecondFactorAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/ISegueHashingAlgorithm.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/ISegueHashingAlgorithm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/OAuth1Token.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/OAuth1Token.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/OAuth1Token.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/OAuth1Token.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,50 +17,47 @@ package uk.ac.cam.cl.dtg.segue.auth;
 
 /**
  * @author Nick Rogers
- * 
  */
 public class OAuth1Token {
-	private String token;
-	private String tokenSecret;
+    private String token;
+    private String tokenSecret;
 
-	/**
-	 * Create an OAuth1Token.
-	 * 
-	 * @param token 
-	 * @param tokenSecret 
-	 */
-	public OAuth1Token(final String token, final String tokenSecret) {
-		this.token = token;
-		this.tokenSecret = tokenSecret;
-	}
+    /**
+     * Create an OAuth1Token.
+     *
+     * @param token
+     * @param tokenSecret
+     */
+    public OAuth1Token(final String token, final String tokenSecret) {
+        this.token = token;
+        this.tokenSecret = tokenSecret;
+    }
 
-	/**
-	 * @return the token
-	 */
-	public String getToken() {
-		return token;
-	}
+    /**
+     * @return the token
+     */
+    public String getToken() {
+        return token;
+    }
 
-	/**
-	 * @param token
-	 *            the token to set
-	 */
-	public void setToken(final String token) {
-		this.token = token;
-	}
+    /**
+     * @param token the token to set
+     */
+    public void setToken(final String token) {
+        this.token = token;
+    }
 
-	/**
-	 * @return the tokenSecret
-	 */
-	public String getTokenSecret() {
-		return tokenSecret;
-	}
+    /**
+     * @return the tokenSecret
+     */
+    public String getTokenSecret() {
+        return tokenSecret;
+    }
 
-	/**
-	 * @param tokenSecret
-	 *            the tokenSecret to set
-	 */
-	public void setTokenSecret(final String tokenSecret) {
-		this.tokenSecret = tokenSecret;
-	}
+    /**
+     * @param tokenSecret the tokenSecret to set
+     */
+    public void setTokenSecret(final String tokenSecret) {
+        this.tokenSecret = tokenSecret;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/OAuth1Token.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/OAuth1Token.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/OidcDiscoveryResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/OidcDiscoveryResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/RaspberryPiOidcAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/RaspberryPiOidcAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/RaspberryPiOidcIdToken.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/RaspberryPiOidcIdToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SecuredEndpoint.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SecuredEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SecuredEndpoint.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SecuredEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v1.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v1.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v2.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v2.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v3.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SeguePBKDF2v3.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueSCrypt.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueSCrypt.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueSCryptv1.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueSCryptv1.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueTOTPAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueTOTPAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AccountAlreadyLinkedException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AccountAlreadyLinkedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AccountAlreadyLinkedException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AccountAlreadyLinkedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AdditionalAuthenticationRequiredException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AdditionalAuthenticationRequiredException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticationCodeException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticationCodeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticationCodeException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticationCodeException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticationProviderMappingException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticationProviderMappingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticationProviderMappingException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticationProviderMappingException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticatorSecurityException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticatorSecurityException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticatorSecurityException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/AuthenticatorSecurityException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/CodeExchangeException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/CodeExchangeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/CodeExchangeException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/CodeExchangeException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/CrossSiteRequestForgeryException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/CrossSiteRequestForgeryException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/CrossSiteRequestForgeryException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/CrossSiteRequestForgeryException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/DuplicateAccountException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/DuplicateAccountException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/DuplicateAccountException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/DuplicateAccountException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/FailedToHashPasswordException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/FailedToHashPasswordException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/FailedToHashPasswordException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/FailedToHashPasswordException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/IncorrectCredentialsProvidedException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/IncorrectCredentialsProvidedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/IncorrectCredentialsProvidedException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/IncorrectCredentialsProvidedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidPasswordException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidPasswordException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidPasswordException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidPasswordException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidSessionException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidSessionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidSessionException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidSessionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidTokenException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidTokenException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidTokenException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidTokenException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/MFARequiredButNotConfiguredException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/MFARequiredButNotConfiguredException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/MissingRequiredFieldException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/MissingRequiredFieldException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/MissingRequiredFieldException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/MissingRequiredFieldException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoCredentialsAvailableException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoCredentialsAvailableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoCredentialsAvailableException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoCredentialsAvailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoUserException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoUserException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoUserException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoUserException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoUserLoggedInException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoUserLoggedInException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoUserLoggedInException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/NoUserLoggedInException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/UnknownCountryCodeException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/UnknownCountryCodeException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/AbstractCommunicationQueue.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/AbstractCommunicationQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/AbstractCommunicationQueue.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/AbstractCommunicationQueue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/CommunicationException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/CommunicationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/CommunicationException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/CommunicationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailAttachment.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailAttachment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailCommunicationMessage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailCommunicationMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailCommunicator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailCommunicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailType.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailType.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailType.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,57 +16,56 @@
 package uk.ac.cam.cl.dtg.segue.comm;
 
 /**
- * The types of email we can send. 
+ * The types of email we can send.
  *
  * @author Alistair Stead
- *
  */
 public enum EmailType {
-	ADMIN,
-	SYSTEM,
-	ASSIGNMENTS,
-	NEWS_AND_UPDATES,
-	EVENTS;
-	
-	/**
-	 * @return integer representation of priority
-	 */
-	public int getPriority() {
-		switch (this) {
-			case ADMIN:
-				return 0;
-			case SYSTEM:
-				return 1;
-			case ASSIGNMENTS:
-				return 2;
-			case NEWS_AND_UPDATES:
-				return 3;
-			case EVENTS:
-				return 4;
-			default:
-				return Integer.MAX_VALUE;
-		}
-	}
-	
-	/**
-	 * @return boolean giving the validity of email type as email preference
-	 */
-	public boolean isValidEmailPreference() {
-		switch (this) {
-			case ADMIN:
-				return false;
-			case SYSTEM:
-				return false;
-			case ASSIGNMENTS:
-				return true;
-			case NEWS_AND_UPDATES:
-				return true;
-			case EVENTS:
-				return true;
-			default:
-				return false;
-		}
-	}
+    ADMIN,
+    SYSTEM,
+    ASSIGNMENTS,
+    NEWS_AND_UPDATES,
+    EVENTS;
 
-	
+    /**
+     * @return integer representation of priority
+     */
+    public int getPriority() {
+        switch (this) {
+            case ADMIN:
+                return 0;
+            case SYSTEM:
+                return 1;
+            case ASSIGNMENTS:
+                return 2;
+            case NEWS_AND_UPDATES:
+                return 3;
+            case EVENTS:
+                return 4;
+            default:
+                return Integer.MAX_VALUE;
+        }
+    }
+
+    /**
+     * @return boolean giving the validity of email type as email preference
+     */
+    public boolean isValidEmailPreference() {
+        switch (this) {
+            case ADMIN:
+                return false;
+            case SYSTEM:
+                return false;
+            case ASSIGNMENTS:
+                return true;
+            case NEWS_AND_UPDATES:
+                return true;
+            case EVENTS:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/ICommunicationMessage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/ICommunicationMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/ICommunicationMessage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/ICommunicationMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/ICommunicator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/ICommunicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/ICommunicator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/ICommunicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/MailGunEmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/MailGunEmailManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/ISegueDTOConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/ISegueDTOConfigurationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/ISegueDTOConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/ISegueDTOConfigurationModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/exceptionMappers/JacksonInvalidFormatExceptionMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/exceptionMappers/JacksonInvalidFormatExceptionMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/AbstractPgDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/AbstractPgDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/FileAppDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/FileAppDataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/FileAppDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/FileAppDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/IAppDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/IAppDataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/IAppDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/IAppDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/IAppDatabaseManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/IAppDatabaseManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/IAppDatabaseManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/IAppDatabaseManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ILogManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ILogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ILogManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ILogManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/JsonLoader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/JsonLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Ian Davies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/JsonLoader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/JsonLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LogManagerEventPublisher.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LogManagerEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LoggingEventHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LoggingEventHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManagerEventListener.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManagerEventListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ResourceNotFoundException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ResourceNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ResourceNotFoundException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ResourceNotFoundException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/SegueDatabaseException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/SegueDatabaseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/SegueDatabaseException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/SegueDatabaseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/TrimWhitespaceDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/TrimWhitespaceDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/TrimWhitespaceDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/TrimWhitespaceDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/TrimWhitespaceListDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/TrimWhitespaceListDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/TrimWhitespaceListDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/TrimWhitespaceListDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/IAssociationDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/IAssociationDataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/IAssociationDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/IAssociationDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/InvalidUserAssociationTokenException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/InvalidUserAssociationTokenException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/InvalidUserAssociationTokenException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/InvalidUserAssociationTokenException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/PgAssociationDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/PgAssociationDataManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/PgAssociationDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/PgAssociationDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/UserGroupNotFoundException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/UserGroupNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/UserGroupNotFoundException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/associations/UserGroupNotFoundException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ChoiceOrikaConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentBaseOrikaConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentManagerException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentManagerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentManagerException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentManagerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentVersionUnavailableException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentVersionUnavailableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentVersionUnavailableException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentVersionUnavailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ItemDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ItemDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ItemOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ItemOrikaConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/SchoolListReader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/SchoolListReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/UnableToIndexSchoolsException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/UnableToIndexSchoolsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/UnableToIndexSchoolsException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/schools/UnableToIndexSchoolsException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/AnonymousUserQuestionAttemptsOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/AnonymousUserQuestionAttemptsOrikaConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IAnonymousUserDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IAnonymousUserDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IExternalAccountDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IExternalAccountDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IPasswordDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IPasswordDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/ITOTPDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/ITOTPDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserGroupPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserGroupPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgAnonymousUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgAnonymousUsers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgPasswordDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgPasswordDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgTOTPDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgTOTPDataManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/QuestionValidationResponseOrikaConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/database/GitDb.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/database/GitDb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/database/GitDb.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/database/GitDb.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/database/PostgresSqlDb.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/database/PostgresSqlDb.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/InteractiveCodeSnippet.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/InteractiveCodeSnippet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Chris Purdy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/InteractiveCodeSnippet.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/content/InteractiveCodeSnippet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/InteractiveCodeSnippetDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/InteractiveCodeSnippetDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Chris Purdy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/InteractiveCodeSnippetDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/content/InteractiveCodeSnippetDTO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SegueETLApplicationRegister.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/SegueETLApplicationRegister.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/DatabaseScriptExecutionJob.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/DatabaseScriptExecutionJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SchedulerClusterDataSource.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SchedulerClusterDataSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueJobService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueScheduledDatabaseScriptJob.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueScheduledDatabaseScriptJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueScheduledJob.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/SegueScheduledJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/jobs/SegueScheduledSyncMailjetUsersJob.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/jobs/SegueScheduledSyncMailjetUsersJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/jobs/SyncMailjetUsersJob.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/jobs/SyncMailjetUsersJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/AbstractFilterInstruction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/AbstractFilterInstruction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/DateRangeFilterInstruction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/DateRangeFilterInstruction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/DateRangeFilterInstruction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/DateRangeFilterInstruction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/NestedInstruction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/NestedInstruction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/SearchInField.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/SearchInField.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/SegueSearchException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/SegueSearchException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/SegueSearchException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/SegueSearchException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/SimpleExclusionInstruction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/SimpleExclusionInstruction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/SimpleFilterInstruction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/SimpleFilterInstruction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/TermsFilterInstruction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/TermsFilterInstruction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/AbstractConfigLoader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/AbstractConfigLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/Mailer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/Mailer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/Mailer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/Mailer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,57 +41,47 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Mailer Class Utility Class for sending e-mails such as contact us forms or
  * notifications.
- * 
+ *
  * @author Stephen Cummins
  */
 public class Mailer {
     private static final Logger log = LoggerFactory.getLogger(Mailer.class);
-	private String smtpAddress;
-	private String mailAddress;
-	private String smtpPort;
-	private final static ConcurrentMap<Integer, Session> sessionCache = new ConcurrentHashMap<>();
+    private String smtpAddress;
+    private String mailAddress;
+    private String smtpPort;
+    private static final ConcurrentMap<Integer, Session> sessionCache = new ConcurrentHashMap<>();
 
-	/**
-	 * Mailer Class.
-	 * 
-	 * @param smtpAddress
-	 *            The address of the smtp server - this implementation assumes
-	 *            that the port is the default (25)
-	 * @param mailAddress
-	 *            The Envelope-From address of the sending account - used for
-	 *            authentication sometimes, and will receive bounce emails.
-	 */
-	public Mailer(final String smtpAddress, final String mailAddress) {
-		this.smtpAddress = smtpAddress;
-		this.mailAddress = mailAddress;
-	}
+    /**
+     * Mailer Class.
+     *
+     * @param smtpAddress The address of the smtp server - this implementation assumes
+     *                    that the port is the default (25)
+     * @param mailAddress The Envelope-From address of the sending account - used for
+     *                    authentication sometimes, and will receive bounce emails.
+     */
+    public Mailer(final String smtpAddress, final String mailAddress) {
+        this.smtpAddress = smtpAddress;
+        this.mailAddress = mailAddress;
+    }
 
     /**
      * SendMail Utility Method Sends e-mail to a given recipient using the hard-coded MAIL_ADDRESS and SMTP details.
-     * 
-     * @param recipient
-     *            - string array of recipients that the message should be sent to
-     * @param fromAddress
-     *            - the e-mail address that should be used as the sending address
-     * @param overrideEnvelopeFrom
-     *            - (nullable) the e-mail address that should be used as the envelope from address, useful for routing
-     * @param replyTo
-     *            - (nullable) the e-mail address that should be used as the reply-to address
-     * @param subject
-     *            - The message subject
-     * @param contents
-     *            - The message body
-     * @throws MessagingException
-     *             - if we cannot send the message for some reason.
-     * @throws AddressException
-     *             - if the address is not valid.
+     *
+     * @param recipient            - string array of recipients that the message should be sent to
+     * @param fromAddress          - the e-mail address that should be used as the sending address
+     * @param overrideEnvelopeFrom - (nullable) e-mail address to use as envelope from address, useful for routing
+     * @param replyTo              - (nullable) the e-mail address to use as reply-to address
+     * @param subject              - The message subject
+     * @param contents             - The message body
+     * @throws MessagingException - if we cannot send the message for some reason.
+     * @throws AddressException   - if the address is not valid.
      */
     public void sendPlainTextMail(final String[] recipient, final InternetAddress fromAddress,
                                   @Nullable final String overrideEnvelopeFrom, @Nullable final InternetAddress replyTo,
                                   final String subject, final String contents)
-			throws MessagingException {
+            throws MessagingException {
         Message msg = this.setupMessage(recipient, fromAddress, overrideEnvelopeFrom, replyTo, subject);
-        
+
         msg.setText(contents);
 
         Transport.send(msg);
@@ -100,36 +90,25 @@ public class Mailer {
     /**
      * Utility method to allow us to send multipart messages using HTML and plain text.
      *
-     * 
-     * @param recipient
-     *            - string array of recipients that the message should be sent to
-     * @param fromAddress
-     *            - the e-mail address that should be used as the sending address
-     * @param overrideEnvelopeFrom
-     *            - (nullable) the e-mail address that should be used as the envelope from address, useful for routing
-     * @param replyTo
-     *            - (nullable) the e-mail address that should be used as the reply-to address
-     * @param subject
-     *            - The message subject
-     * @param plainText
-     *            - The message body
-     * @param html
-     *            - The message body in html
-	 * @param attachments
-	 * 			  - list of attachment objects
-     * @throws MessagingException
-     *             - if we cannot send the message for some reason.
-     * @throws AddressException
-     *             - if the address is not valid.
+     * @param recipient            - string array of recipients that the message should be sent to
+     * @param fromAddress          - the e-mail address that should be used as the sending address
+     * @param overrideEnvelopeFrom - (nullable) the e-mail address to use as envelope from address, useful for routing
+     * @param replyTo              - (nullable) the e-mail address to use as reply-to address
+     * @param subject              - The message subject
+     * @param plainText            - The message body
+     * @param html                 - The message body in html
+     * @param attachments          - list of attachment objects
+     * @throws MessagingException - if we cannot send the message for some reason.
+     * @throws AddressException   - if the address is not valid.
      */
     public void sendMultiPartMail(final String[] recipient, final InternetAddress fromAddress,
                                   @Nullable final String overrideEnvelopeFrom, @Nullable final InternetAddress replyTo,
                                   final String subject, final String plainText, final String html,
                                   final List<EmailAttachment> attachments)
-			throws MessagingException, AddressException {
+            throws MessagingException, AddressException {
 
-    	Message msg = this.setupMessage(recipient, fromAddress, overrideEnvelopeFrom, replyTo, subject);
-        
+        Message msg = this.setupMessage(recipient, fromAddress, overrideEnvelopeFrom, replyTo, subject);
+
         // Create the text part
         MimeBodyPart textPart = new MimeBodyPart();
         textPart.setText(plainText, "utf-8");
@@ -141,94 +120,96 @@ public class Mailer {
         multiPart.addBodyPart(textPart);
         multiPart.addBodyPart(htmlPart);
 
-		if (attachments != null) {
-			for (EmailAttachment attachment : attachments) {
-				if (null == attachment) {
-					continue;
-				}
+        if (attachments != null) {
+            for (EmailAttachment attachment : attachments) {
+                if (null == attachment) {
+                    continue;
+                }
 
-				MimeBodyPart attachmentBodyPart = new MimeBodyPart();
-				DataHandler dataHandler = new DataHandler(attachment.getAttachment(), attachment.getMimeType());
-				attachmentBodyPart.setDataHandler(dataHandler);
-				attachmentBodyPart.setFileName(attachment.getFileName());
-				multiPart.addBodyPart(attachmentBodyPart);
-			}
-		}
+                MimeBodyPart attachmentBodyPart = new MimeBodyPart();
+                DataHandler dataHandler = new DataHandler(attachment.getAttachment(), attachment.getMimeType());
+                attachmentBodyPart.setDataHandler(dataHandler);
+                attachmentBodyPart.setFileName(attachment.getFileName());
+                multiPart.addBodyPart(attachmentBodyPart);
+            }
+        }
 
         msg.setContent(multiPart);
-        
+
         Transport.send(msg);
     }
 
-	/**
-	 * Gets the smtpAddress.
-	 * @return the smtpAddress
-	 */
-	public String getSmtpAddress() {
-		return smtpAddress;
-	}
-
-	/**
-	 * Sets the smtpAddress.
-	 * @param smtpAddress the smtpAddress to set
-	 */
-	public void setSmtpAddress(final String smtpAddress) {
-		this.smtpAddress = smtpAddress;
-	}
-
-	/**
-	 * Gets the mailAddress.
-	 * @return the mailAddress
-	 */
-	public String getMailAddress() {
-		return mailAddress;
-	}
-
-	/**
-	 * Sets the mailAddress.
-	 * @param mailAddress the mailAddress to set
-	 */
-	public void setMailAddress(final String mailAddress) {
-		this.mailAddress = mailAddress;
-	}
-	/**
-	 * Gets the smtpPort.
-	 * @return the smtpPort
-	 */
-	public String getSmtpPort() {
-		return smtpPort;
-	}
-
-	/**
-	 * Sets the smtpPort.
-	 * @param smtpPort the smtpPort to set
-	 */
-	public void setSmtpPort(final String smtpPort) {
-		this.smtpPort = smtpPort;
-	}
-	
     /**
-     * @param recipient
-     *            - string array of recipients that the message should be sent to
-     * @param fromAddress
-     *            - the e-mail address that should be used as the sending address
-     * @param overrideEnvelopeFrom
-     *            - (nullable) the e-mail address that should be used as the envelope from address, useful for routing
-     * @param replyTo
-     *            - the e-mail address that should be used as the reply-to address
-     * @param subject
-     *            - The message subject
+     * Gets the smtpAddress.
+     *
+     * @return the smtpAddress
+     */
+    public String getSmtpAddress() {
+        return smtpAddress;
+    }
+
+    /**
+     * Sets the smtpAddress.
+     *
+     * @param smtpAddress the smtpAddress to set
+     */
+    public void setSmtpAddress(final String smtpAddress) {
+        this.smtpAddress = smtpAddress;
+    }
+
+    /**
+     * Gets the mailAddress.
+     *
+     * @return the mailAddress
+     */
+    public String getMailAddress() {
+        return mailAddress;
+    }
+
+    /**
+     * Sets the mailAddress.
+     *
+     * @param mailAddress the mailAddress to set
+     */
+    public void setMailAddress(final String mailAddress) {
+        this.mailAddress = mailAddress;
+    }
+
+    /**
+     * Gets the smtpPort.
+     *
+     * @return the smtpPort
+     */
+    public String getSmtpPort() {
+        return smtpPort;
+    }
+
+    /**
+     * Sets the smtpPort.
+     *
+     * @param smtpPort the smtpPort to set
+     */
+    public void setSmtpPort(final String smtpPort) {
+        this.smtpPort = smtpPort;
+    }
+
+    /**
+     * @param recipient            - string array of recipients that the message should be sent to
+     * @param fromAddress          - the e-mail address that should be used as the sending address
+     * @param overrideEnvelopeFrom - (nullable) the e-mail address to use as envelope from address, useful for routing
+     * @param replyTo              - the e-mail address to use as reply-to address
+     * @param subject              - The message subject
      * @return a newly created message with all of the headers populated.
      * @throws MessagingException - if there is an error in setting up the message
      */
     private Message setupMessage(final String[] recipient, final InternetAddress fromAddress,
                                  final String overrideEnvelopeFrom, @Nullable final InternetAddress replyTo,
                                  final String subject)
-			throws MessagingException {
+            throws MessagingException {
         Validate.notEmpty(recipient);
         Validate.notBlank(recipient[0]);
         Validate.notNull(fromAddress);
-        
+
         Properties p = new Properties();
 
         // Configure the SMTP server settings:
@@ -263,13 +244,13 @@ public class Mailer {
             receivers[i] = new InternetAddress(recipient[i]);
         }
 
-		msg.setFrom(fromAddress);
-		msg.setRecipients(RecipientType.TO, receivers);
-		msg.setSubject(subject);
+        msg.setFrom(fromAddress);
+        msg.setRecipients(RecipientType.TO, receivers);
+        msg.setSubject(subject);
 
-		if (null != replyTo) {
-			msg.setReplyTo(new InternetAddress[] { replyTo });
-		}
+        if (null != replyTo) {
+            msg.setReplyTo(new InternetAddress[]{replyTo});
+        }
 
         return msg;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/util/PropertiesLoader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/PropertiesLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/PropertiesLoader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/PropertiesLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/RequestIPExtractor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/RequestIPExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/RequestIPExtractor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/RequestIPExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/WriteablePropertiesLoader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/WriteablePropertiesLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/WriteablePropertiesLoader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/WriteablePropertiesLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/YamlLoader.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/YamlLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/email/MailJetApiClientWrapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/email/MailJetApiClientWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/email/MailJetSubscriptionAction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/email/MailJetSubscriptionAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/Address.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/Address.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/Address.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/IPLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/IPLocationResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/IPLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/IPLocationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/Location.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/Location.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/Location.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/Location.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/LocationServerException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/LocationServerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/LocationServerException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/LocationServerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCode.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCode.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeLocationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeLocationResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeRadius.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeRadius.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeRadius.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeRadius.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AbstractFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AbstractFacadeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacadeIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/GroupsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/GroupsFacadeIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ITConstants.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ITConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacControllerIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacControllerIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuestionFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuestionFacadeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAttemptManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAttemptManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizQuestionManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherValidatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacItemQuestionValidatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacReorderValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacReorderValidatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins and Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,375 +15,382 @@
  */
 package uk.ac.cam.cl.dtg.segue.api.managers;
 
-import static org.junit.Assert.*;
-import static org.easymock.EasyMock.*;
-
 import com.google.api.client.util.Sets;
 import org.easymock.Capture;
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
-
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.dao.associations.InvalidUserAssociationTokenException;
-import uk.ac.cam.cl.dtg.segue.dao.associations.UserGroupNotFoundException;
-import uk.ac.cam.cl.dtg.segue.dao.associations.IAssociationDataManager;
 import uk.ac.cam.cl.dtg.isaac.dos.AssociationToken;
 import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
 import uk.ac.cam.cl.dtg.isaac.dto.UserGroupDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.dao.associations.IAssociationDataManager;
+import uk.ac.cam.cl.dtg.segue.dao.associations.InvalidUserAssociationTokenException;
+import uk.ac.cam.cl.dtg.segue.dao.associations.UserGroupNotFoundException;
+
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * Test class for the user Association class.
- * 
  */
 @PowerMockIgnore({"jakarta.ws.*"})
 public class UserAssociationManagerTest {
-	private IAssociationDataManager dummyAssociationDataManager;
-	private GroupManager dummyGroupDataManager;
-	private UserAccountManager dummyUserManager;
+    private IAssociationDataManager dummyAssociationDataManager;
+    private GroupManager dummyGroupDataManager;
+    private UserAccountManager dummyUserManager;
 
-	/**
-	 * Initial configuration of tests.
-	 * 
-	 * @throws Exception
-	 *             - test exception
-	 */
-	@Before
-	public final void setUp() throws Exception {
-		dummyAssociationDataManager = createMock(IAssociationDataManager.class);
-		dummyGroupDataManager = createMock(GroupManager.class);
-	}
+    /**
+     * Initial configuration of tests.
+     *
+     * @throws Exception - test exception
+     */
+    @Before
+    public final void setUp() throws Exception {
+        dummyAssociationDataManager = createMock(IAssociationDataManager.class);
+        dummyGroupDataManager = createMock(GroupManager.class);
+    }
 
-	/**
-	 * Verify that the constructor responds correctly to bad input.
-	 * 
-	 * @throws SegueDatabaseException
-	 * @throws UserGroupNotFoundException
-	 */
-	@Test
-	public final void userAssociationManager_generateToken_tokenShouldBeCreatedAndPersisted()
-		throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+    /**
+     * Verify that the constructor responds correctly to bad input.
+     *
+     * @throws SegueDatabaseException
+     * @throws UserGroupNotFoundException
+     */
+    @Test
+    public final void userAssociationManager_generateToken_tokenShouldBeCreatedAndPersisted()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
 
-		Long someUserId = 89745531132231213L;
+        Long someUserId = 89745531132231213L;
 
-		RegisteredUserDTO someRegisteredUser = createMock(RegisteredUserDTO.class);
-		Long someAssociatedGroupId = 565481L;
+        RegisteredUserDTO someRegisteredUser = createMock(RegisteredUserDTO.class);
+        Long someAssociatedGroupId = 565481L;
 
-		expect(someRegisteredUser.getId()).andReturn(someUserId).anyTimes();
-		replay(someRegisteredUser);
+        expect(someRegisteredUser.getId()).andReturn(someUserId).anyTimes();
+        replay(someRegisteredUser);
 
-		AssociationToken someToken = new AssociationToken("someToken", someUserId, someAssociatedGroupId);
-		
-		expect(dummyGroupDataManager.isValidGroup(someAssociatedGroupId)).andReturn(true).once();
-		
-		expect(dummyAssociationDataManager.saveAssociationToken((AssociationToken) anyObject())).andReturn(
-				someToken).once();
-		
-		expect(dummyAssociationDataManager.getAssociationTokenByGroupId(anyLong())).andReturn(null);
-		
-		replay(dummyAssociationDataManager, dummyGroupDataManager);
+        AssociationToken someToken = new AssociationToken("someToken", someUserId, someAssociatedGroupId);
 
-		AssociationToken someGeneratedToken = managerUnderTest.generateAssociationToken(someRegisteredUser,
-				someAssociatedGroupId);
+        expect(dummyGroupDataManager.isValidGroup(someAssociatedGroupId)).andReturn(true).once();
 
-		assertTrue(someGeneratedToken != null);
+        expect(dummyAssociationDataManager.saveAssociationToken(anyObject())).andReturn(
+                someToken).once();
 
-		verify(someRegisteredUser, dummyAssociationDataManager);
-	}
-	
-	@Test
-	public final void userAssociationManager_createAssociationWithTokenAndAddToGroup_associationShouldBeCreatedAndUserAddedToGroup()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+        expect(dummyAssociationDataManager.getAssociationTokenByGroupId(anyLong())).andReturn(null);
 
-		Long someUserIdGrantingAccess = 89745531132231213L;
-		Long someGroupOwnerUserId = 17659214141L;
+        replay(dummyAssociationDataManager, dummyGroupDataManager);
 
-		RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
-		RegisteredUserDTO someRegisteredUserReceivingAccess = createMock(RegisteredUserDTO.class);
-		Long someAssociatedGroupId = 56548L;
+        AssociationToken someGeneratedToken = managerUnderTest.generateAssociationToken(someRegisteredUser,
+                someAssociatedGroupId);
 
-		expect(someRegisteredUserGrantingAccess.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
-		
-		expect(someRegisteredUserReceivingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		replay(someRegisteredUserGrantingAccess);
+        assertNotNull(someGeneratedToken);
 
-		AssociationToken someToken = new AssociationToken("someToken", someGroupOwnerUserId, someAssociatedGroupId);
-		
-		expect(dummyAssociationDataManager.lookupAssociationToken(someToken.getToken())).andReturn(someToken);
-		
-		expect(dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId, someUserIdGrantingAccess)).andReturn(false);
-		
-		dummyAssociationDataManager.createAssociation(someGroupOwnerUserId, someUserIdGrantingAccess);
-		expectLastCall().once();
-		
-		UserGroupDTO groupToAddUserTo = createMock(UserGroupDTO.class);
+        verify(someRegisteredUser, dummyAssociationDataManager);
+    }
+
+    @Test
+    public final void userAssociationManager_createAssociationWithTokenAndAddToGroup_associationShouldBeCreatedAndUserAddedToGroup()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+
+        Long someUserIdGrantingAccess = 89745531132231213L;
+        Long someGroupOwnerUserId = 17659214141L;
+
+        RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
+        RegisteredUserDTO someRegisteredUserReceivingAccess = createMock(RegisteredUserDTO.class);
+        Long someAssociatedGroupId = 56548L;
+
+        expect(someRegisteredUserGrantingAccess.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
+
+        expect(someRegisteredUserReceivingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
+        replay(someRegisteredUserGrantingAccess);
+
+        AssociationToken someToken = new AssociationToken("someToken", someGroupOwnerUserId, someAssociatedGroupId);
+
+        expect(dummyAssociationDataManager.lookupAssociationToken(someToken.getToken())).andReturn(someToken);
+
+        expect(dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId, someUserIdGrantingAccess)).andReturn(false);
+
+        dummyAssociationDataManager.createAssociation(someGroupOwnerUserId, someUserIdGrantingAccess);
+        expectLastCall().once();
+
+        UserGroupDTO groupToAddUserTo = createMock(UserGroupDTO.class);
         expect(groupToAddUserTo.getOwnerId()).andReturn(someGroupOwnerUserId).atLeastOnce();
-		expect(groupToAddUserTo.getAdditionalManagersUserIds()).andReturn(Sets.newHashSet()).atLeastOnce();
+        expect(groupToAddUserTo.getAdditionalManagersUserIds()).andReturn(Sets.newHashSet()).atLeastOnce();
 
-		expect(dummyGroupDataManager.getGroupById(someAssociatedGroupId)).andReturn(groupToAddUserTo).once();
-		
-		dummyGroupDataManager.addUserToGroup(groupToAddUserTo, someRegisteredUserGrantingAccess);
-		expectLastCall().once();
-		
-		replay(dummyAssociationDataManager, dummyGroupDataManager, groupToAddUserTo);
+        expect(dummyGroupDataManager.getGroupById(someAssociatedGroupId)).andReturn(groupToAddUserTo).once();
 
-		try {
-			managerUnderTest.createAssociationWithToken(someToken.getToken(), someRegisteredUserGrantingAccess);
-		} catch (InvalidUserAssociationTokenException e) {
-			e.printStackTrace();
-			fail("InvalidUserAssociationTokenException is unexpected");
-		}
+        dummyGroupDataManager.addUserToGroup(groupToAddUserTo, someRegisteredUserGrantingAccess);
+        expectLastCall().once();
 
-		verify(someRegisteredUserGrantingAccess, dummyAssociationDataManager);
-	}
-	
-	@Test
-	public final void userAssociationManager_DuplicateAssociationButAddToGroupAnyway_associationShouldNotBeCreatedButUserShouldBeAddedToGroup()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+        replay(dummyAssociationDataManager, dummyGroupDataManager, groupToAddUserTo);
 
-		Long someUserIdGrantingAccess = 89745531132231213L;
-		Long someGroupOwnerUserId = 17659214141L;
+        try {
+            managerUnderTest.createAssociationWithToken(someToken.getToken(), someRegisteredUserGrantingAccess);
+        } catch (InvalidUserAssociationTokenException e) {
+            e.printStackTrace();
+            fail("InvalidUserAssociationTokenException is unexpected");
+        }
 
-		RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
-		RegisteredUserDTO someRegisteredUserReceivingAccess = createMock(RegisteredUserDTO.class);
-		Long someAssociatedGroupId = 5654811L;
+        verify(someRegisteredUserGrantingAccess, dummyAssociationDataManager);
+    }
 
-		expect(someRegisteredUserGrantingAccess.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
-		
-		expect(someRegisteredUserReceivingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		replay(someRegisteredUserGrantingAccess);
+    @Test
+    public final void userAssociationManager_DuplicateAssociationButAddToGroupAnyway_associationShouldNotBeCreatedButUserShouldBeAddedToGroup()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
 
-		AssociationToken someToken = new AssociationToken("someToken", someGroupOwnerUserId, someAssociatedGroupId);
-		
-		expect(dummyAssociationDataManager.lookupAssociationToken(someToken.getToken())).andReturn(someToken);
-		
-		expect(dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId, someUserIdGrantingAccess)).andReturn(true);
-		
-		UserGroupDTO groupToAddUserTo = createMock(UserGroupDTO.class);
+        Long someUserIdGrantingAccess = 89745531132231213L;
+        Long someGroupOwnerUserId = 17659214141L;
+
+        RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
+        RegisteredUserDTO someRegisteredUserReceivingAccess = createMock(RegisteredUserDTO.class);
+        Long someAssociatedGroupId = 5654811L;
+
+        expect(someRegisteredUserGrantingAccess.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
+
+        expect(someRegisteredUserReceivingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
+        replay(someRegisteredUserGrantingAccess);
+
+        AssociationToken someToken = new AssociationToken("someToken", someGroupOwnerUserId, someAssociatedGroupId);
+
+        expect(dummyAssociationDataManager.lookupAssociationToken(someToken.getToken())).andReturn(someToken);
+
+        expect(dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId, someUserIdGrantingAccess)).andReturn(true);
+
+        UserGroupDTO groupToAddUserTo = createMock(UserGroupDTO.class);
         expect(groupToAddUserTo.getOwnerId()).andReturn(someGroupOwnerUserId).atLeastOnce();
-		expect(groupToAddUserTo.getAdditionalManagersUserIds()).andReturn(Sets.newHashSet()).atLeastOnce();
-		expect(dummyGroupDataManager.getGroupById(someAssociatedGroupId)).andReturn(groupToAddUserTo).once();
-		
-		dummyGroupDataManager.addUserToGroup(groupToAddUserTo, someRegisteredUserGrantingAccess);
-		expectLastCall().once();
-		
-		replay(dummyAssociationDataManager, dummyGroupDataManager, groupToAddUserTo);
+        expect(groupToAddUserTo.getAdditionalManagersUserIds()).andReturn(Sets.newHashSet()).atLeastOnce();
+        expect(dummyGroupDataManager.getGroupById(someAssociatedGroupId)).andReturn(groupToAddUserTo).once();
 
-		try {
-			managerUnderTest.createAssociationWithToken(someToken.getToken(), someRegisteredUserGrantingAccess);
-		} catch (InvalidUserAssociationTokenException e) {
-			e.printStackTrace();
-			fail("InvalidUserAssociationTokenException is unexpected");
-		}
+        dummyGroupDataManager.addUserToGroup(groupToAddUserTo, someRegisteredUserGrantingAccess);
+        expectLastCall().once();
 
-		verify(someRegisteredUserGrantingAccess, dummyAssociationDataManager);
-	}
-	
-	@Test
-	public final void userAssociationManager_createAssociationWithBadToken_exceptionShouldBeThrown()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+        replay(dummyAssociationDataManager, dummyGroupDataManager, groupToAddUserTo);
 
-		Long someUserIdGrantingAccess = 89745531132231213L;
-		Long someGroupOwnerUserId = 17659214141L;
+        try {
+            managerUnderTest.createAssociationWithToken(someToken.getToken(), someRegisteredUserGrantingAccess);
+        } catch (InvalidUserAssociationTokenException e) {
+            e.printStackTrace();
+            fail("InvalidUserAssociationTokenException is unexpected");
+        }
 
-		RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
-		RegisteredUserDTO someRegisteredUserReceivingAccess = createMock(RegisteredUserDTO.class);
+        verify(someRegisteredUserGrantingAccess, dummyAssociationDataManager);
+    }
 
-		expect(someRegisteredUserGrantingAccess.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
-		
-		expect(someRegisteredUserReceivingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		replay(someRegisteredUserGrantingAccess);
-		
-		String someBadToken = "bad token";
-		
-		expect(dummyAssociationDataManager.lookupAssociationToken(someBadToken)).andReturn(null);
-		
-		replay(dummyAssociationDataManager, dummyGroupDataManager);
+    @Test
+    public final void userAssociationManager_createAssociationWithBadToken_exceptionShouldBeThrown()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
 
-		try {
-			managerUnderTest.createAssociationWithToken(someBadToken, someRegisteredUserGrantingAccess);
-			fail("An exception was expected");
-		} catch (InvalidUserAssociationTokenException e) {
-			// this is a success as the exception was expected.
-		}
+        Long someUserIdGrantingAccess = 89745531132231213L;
+        Long someGroupOwnerUserId = 17659214141L;
 
-		verify(someRegisteredUserGrantingAccess, dummyAssociationDataManager);
-	}
-	
-	@Test
-	public final void userAssociationManager_hasPermissionUserIsTheOwner_trueShouldBeRetured()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+        RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
+        RegisteredUserDTO someRegisteredUserReceivingAccess = createMock(RegisteredUserDTO.class);
 
-		Long someGroupOwnerUserId = 17659214141L;
+        expect(someRegisteredUserGrantingAccess.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
 
-		RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
-		UserSummaryDTO someRegisteredUserGrantingAccessSummary = createMock(UserSummaryDTO.class);
+        expect(someRegisteredUserReceivingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
+        replay(someRegisteredUserGrantingAccess);
 
-		expect(someRegisteredUserGrantingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		expect(someRegisteredUserGrantingAccessSummary.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		
-		replay(someRegisteredUserGrantingAccess, someRegisteredUserGrantingAccessSummary);
-		
-		if (!managerUnderTest.hasPermission(someRegisteredUserGrantingAccess, someRegisteredUserGrantingAccessSummary)) {
-			fail("If the user id of the owner and the requester are the same always return true.");	
-		}
+        String someBadToken = "bad token";
 
-		verify(someRegisteredUserGrantingAccess, someRegisteredUserGrantingAccessSummary);
-	}
-	
-	@Test
-	public final void userAssociationManager_hasPermissionUserIsAdmin_trueShouldBeRetured()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+        expect(dummyAssociationDataManager.lookupAssociationToken(someBadToken)).andReturn(null);
 
-		Long someUserIdGrantingAccess = 89745531132231213L;
-		Long someGroupOwnerUserId = 17659214141L;
+        replay(dummyAssociationDataManager, dummyGroupDataManager);
 
-		RegisteredUserDTO someUserRequestingAccess = createMock(RegisteredUserDTO.class);
-		UserSummaryDTO someRegisteredUserGrantingAccessSummary = createMock(UserSummaryDTO.class);
+        try {
+            managerUnderTest.createAssociationWithToken(someBadToken, someRegisteredUserGrantingAccess);
+            fail("An exception was expected");
+        } catch (InvalidUserAssociationTokenException e) {
+            // this is a success as the exception was expected.
+        }
 
-		expect(someUserRequestingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		
-		expect(someUserRequestingAccess.getRole()).andReturn(Role.ADMIN).anyTimes();
-		
-		expect(someRegisteredUserGrantingAccessSummary.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
-		
-		replay(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary);
-		
-		if (!managerUnderTest.hasPermission(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary)) {
-			fail("If the user requesting access is an admin they should always have access.");	
-		}
+        verify(someRegisteredUserGrantingAccess, dummyAssociationDataManager);
+    }
 
-		verify(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary);
-	}
-	
-	@Test
-	public final void userAssociationManager_hasPermissionUserHasValidAssociation_trueShouldBeRetured()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+    @Test
+    public final void userAssociationManager_hasPermissionUserIsTheOwner_trueShouldBeRetured()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
 
-		Long someUserIdGrantingAccess = 89745531132231213L;
-		Long someGroupOwnerUserId = 17659214141L;
+        Long someGroupOwnerUserId = 17659214141L;
 
-		RegisteredUserDTO someUserRequestingAccess = createMock(RegisteredUserDTO.class);
-		UserSummaryDTO someRegisteredUserGrantingAccessSummary = createMock(UserSummaryDTO.class);
+        RegisteredUserDTO someRegisteredUserGrantingAccess = createMock(RegisteredUserDTO.class);
+        UserSummaryDTO someRegisteredUserGrantingAccessSummary = createMock(UserSummaryDTO.class);
 
-		expect(someUserRequestingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		
-		expect(someUserRequestingAccess.getRole()).andReturn(Role.TEACHER).anyTimes();
-		
-		expect(someRegisteredUserGrantingAccessSummary.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
-		
-		expect(
-				dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId,
-						someUserIdGrantingAccess)).andReturn(true).once();
-		
-		replay(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary, dummyAssociationDataManager);
-		
-		if (!managerUnderTest.hasPermission(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary)) {
-			fail("If the user requesting access has a valid association they should have permission");	
-		}
+        expect(someRegisteredUserGrantingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
+        expect(someRegisteredUserGrantingAccessSummary.getId()).andReturn(someGroupOwnerUserId).anyTimes();
 
-		verify(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary, dummyAssociationDataManager);
-	}
-	
-	@Test
-	public final void userAssociationManager_NoPermissionUserHasNoValidAssociation_falseShouldBeRetured()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+        replay(someRegisteredUserGrantingAccess, someRegisteredUserGrantingAccessSummary);
 
-		Long someUserIdNotGrantingAccess = 89745531132231213L;
-		Long someGroupOwnerUserId = 17659214141L;
+        if (!managerUnderTest.hasPermission(someRegisteredUserGrantingAccess, someRegisteredUserGrantingAccessSummary)) {
+            fail("If the user id of the owner and the requester are the same always return true.");
+        }
 
-		RegisteredUserDTO someUserRequestingAccess = createMock(RegisteredUserDTO.class);
-		UserSummaryDTO someRegisteredUserGrantingAccessSummary = createMock(UserSummaryDTO.class);
+        verify(someRegisteredUserGrantingAccess, someRegisteredUserGrantingAccessSummary);
+    }
 
-		
-		expect(someUserRequestingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
-		
-		expect(someUserRequestingAccess.getRole()).andReturn(Role.TEACHER).anyTimes();
-		
-		expect(someRegisteredUserGrantingAccessSummary.getId()).andReturn(someUserIdNotGrantingAccess).anyTimes();
-		
-		expect(
-				dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId,
-						someUserIdNotGrantingAccess)).andReturn(false).once();
-		
-		replay(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary, dummyAssociationDataManager);
-		
-		if (managerUnderTest.hasPermission(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary)) {
-			fail("This user should not have access as they are not an admin and do not have a valid association.");	
-		}
+    @Test
+    public final void userAssociationManager_hasPermissionUserIsAdmin_trueShouldBeRetured()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
 
-		verify(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary, dummyAssociationDataManager);
-	}
+        Long someUserIdGrantingAccess = 89745531132231213L;
+        Long someGroupOwnerUserId = 17659214141L;
 
-	@Test
-	public final void userAssociationManager_TokenMustBeSixCharactersAndRandom()
-			throws SegueDatabaseException, UserGroupNotFoundException {
-		UserAssociationManager managerUnderTest = new UserAssociationManager(
-				dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
-		Long someAssociatedGroupId = 5654811L;
+        RegisteredUserDTO someUserRequestingAccess = createMock(RegisteredUserDTO.class);
+        UserSummaryDTO someRegisteredUserGrantingAccessSummary = createMock(UserSummaryDTO.class);
 
-		RegisteredUserDTO someUserRequestingAccess = createMock(RegisteredUserDTO.class);
+        expect(someUserRequestingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
 
-		expect(someUserRequestingAccess.getId()).andReturn(0L).anyTimes();
-		expect(dummyGroupDataManager.isValidGroup(someAssociatedGroupId)).andReturn(true).anyTimes();
-		// This line means we'll get a new token each time we run generateAssociationToken:
-		expect(dummyAssociationDataManager.getAssociationTokenByGroupId(someAssociatedGroupId)).andReturn(null).anyTimes();
-		final Capture<AssociationToken> associationTokenCapture = Capture.newInstance();
-		// This was a lambda that overrode saveAssociationToken using andAnswer to return its only argument. IntelliJ
-		// simplified this to associationTokenCapture::getValue which apparently does the same thing . . .
-		expect(dummyAssociationDataManager.saveAssociationToken(capture(associationTokenCapture))).andAnswer(
-				associationTokenCapture::getValue).anyTimes();
-		replay(someUserRequestingAccess, dummyGroupDataManager, dummyAssociationDataManager);
+        expect(someUserRequestingAccess.getRole()).andReturn(Role.ADMIN).anyTimes();
 
-		// We want to test the randomness of tokens, which means sampling them lots:
-		int iterations = 100000;
-		int tokenLength = 6;
-		String charSpace = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        expect(someRegisteredUserGrantingAccessSummary.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
 
-		int[][] occurrences = new int[tokenLength][charSpace.length()];
+        replay(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary);
 
-		for (int i = 0; i < iterations; i++) {
+        if (!managerUnderTest.hasPermission(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary)) {
+            fail("If the user requesting access is an admin they should always have access.");
+        }
 
-			AssociationToken token = managerUnderTest.generateAssociationToken(someUserRequestingAccess, someAssociatedGroupId);
-			assertTrue(token.getToken().length() == tokenLength);
-			String t = token.getToken();
-			for (int j = 0; j < t.length(); j++) {
-				char c = t.charAt(j);
-				int chr = charSpace.indexOf(c);
-				occurrences[j][chr] += 1;
-			}
-		}
-		// If any letters appear too frequently, there's a problem. Before we were 500+% out!
-		int expectedAvg = (iterations / 30);  // There are 30 allowed characters after 0,O,1,I,5,S are removed.
-		int allowedDelta = expectedAvg / 5;  // Allow 20% leeway.
-		for (int x = 0; x < tokenLength; x++) {
-			for (int y = 0; y < charSpace.length(); y++) {
-				if (y == 8 || y == 14 || y == 18 || y == 26 || y == 27|| y == 31 ) {
-					// I=8, O=14, S=18, 0=26, 1=27, 5=31
-					// These characters are allowed to be blank!
-					continue;
-				}
-				assertFalse("Token letter distribution not random; expected " + expectedAvg + " occurrences, found " + occurrences[x][y] + "!",
-					(occurrences[x][y] > expectedAvg + allowedDelta) || (occurrences[x][y] < expectedAvg - allowedDelta));
-			}
-		}
-	}
+        verify(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary);
+    }
+
+    @Test
+    public final void userAssociationManager_hasPermissionUserHasValidAssociation_trueShouldBeRetured()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+
+        Long someUserIdGrantingAccess = 89745531132231213L;
+        Long someGroupOwnerUserId = 17659214141L;
+
+        RegisteredUserDTO someUserRequestingAccess = createMock(RegisteredUserDTO.class);
+        UserSummaryDTO someRegisteredUserGrantingAccessSummary = createMock(UserSummaryDTO.class);
+
+        expect(someUserRequestingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
+
+        expect(someUserRequestingAccess.getRole()).andReturn(Role.TEACHER).anyTimes();
+
+        expect(someRegisteredUserGrantingAccessSummary.getId()).andReturn(someUserIdGrantingAccess).anyTimes();
+
+        expect(
+                dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId,
+                        someUserIdGrantingAccess)).andReturn(true).once();
+
+        replay(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary, dummyAssociationDataManager);
+
+        if (!managerUnderTest.hasPermission(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary)) {
+            fail("If the user requesting access has a valid association they should have permission");
+        }
+
+        verify(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary, dummyAssociationDataManager);
+    }
+
+    @Test
+    public final void userAssociationManager_NoPermissionUserHasNoValidAssociation_falseShouldBeRetured()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+
+        Long someUserIdNotGrantingAccess = 89745531132231213L;
+        Long someGroupOwnerUserId = 17659214141L;
+
+        RegisteredUserDTO someUserRequestingAccess = createMock(RegisteredUserDTO.class);
+        UserSummaryDTO someRegisteredUserGrantingAccessSummary = createMock(UserSummaryDTO.class);
+
+
+        expect(someUserRequestingAccess.getId()).andReturn(someGroupOwnerUserId).anyTimes();
+
+        expect(someUserRequestingAccess.getRole()).andReturn(Role.TEACHER).anyTimes();
+
+        expect(someRegisteredUserGrantingAccessSummary.getId()).andReturn(someUserIdNotGrantingAccess).anyTimes();
+
+        expect(
+                dummyAssociationDataManager.hasValidAssociation(someGroupOwnerUserId,
+                        someUserIdNotGrantingAccess)).andReturn(false).once();
+
+        replay(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary, dummyAssociationDataManager);
+
+        if (managerUnderTest.hasPermission(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary)) {
+            fail("This user should not have access as they are not an admin and do not have a valid association.");
+        }
+
+        verify(someUserRequestingAccess, someRegisteredUserGrantingAccessSummary, dummyAssociationDataManager);
+    }
+
+    @Test
+    public final void userAssociationManager_TokenMustBeSixCharactersAndRandom()
+            throws SegueDatabaseException, UserGroupNotFoundException {
+        UserAssociationManager managerUnderTest = new UserAssociationManager(
+                dummyAssociationDataManager, dummyUserManager, dummyGroupDataManager);
+        Long someAssociatedGroupId = 5654811L;
+
+        RegisteredUserDTO someUserRequestingAccess = createMock(RegisteredUserDTO.class);
+
+        expect(someUserRequestingAccess.getId()).andReturn(0L).anyTimes();
+        expect(dummyGroupDataManager.isValidGroup(someAssociatedGroupId)).andReturn(true).anyTimes();
+        // This line means we'll get a new token each time we run generateAssociationToken:
+        expect(dummyAssociationDataManager.getAssociationTokenByGroupId(someAssociatedGroupId)).andReturn(null).anyTimes();
+        final Capture<AssociationToken> associationTokenCapture = Capture.newInstance();
+        // This was a lambda that overrode saveAssociationToken using andAnswer to return its only argument. IntelliJ
+        // simplified this to associationTokenCapture::getValue which apparently does the same thing . . .
+        expect(dummyAssociationDataManager.saveAssociationToken(capture(associationTokenCapture))).andAnswer(
+                associationTokenCapture::getValue).anyTimes();
+        replay(someUserRequestingAccess, dummyGroupDataManager, dummyAssociationDataManager);
+
+        // We want to test the randomness of tokens, which means sampling them lots:
+        int iterations = 100000;
+        int tokenLength = 6;
+        String charSpace = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        int[][] occurrences = new int[tokenLength][charSpace.length()];
+
+        for (int i = 0; i < iterations; i++) {
+
+            AssociationToken token = managerUnderTest.generateAssociationToken(someUserRequestingAccess, someAssociatedGroupId);
+            assertEquals(token.getToken().length(), tokenLength);
+            String t = token.getToken();
+            for (int j = 0; j < t.length(); j++) {
+                char c = t.charAt(j);
+                int chr = charSpace.indexOf(c);
+                occurrences[j][chr] += 1;
+            }
+        }
+        // If any letters appear too frequently, there's a problem. Before we were 500+% out!
+        int expectedAvg = (iterations / 30);  // There are 30 allowed characters after 0,O,1,I,5,S are removed.
+        int allowedDelta = expectedAvg / 5;  // Allow 20% leeway.
+        for (int x = 0; x < tokenLength; x++) {
+            for (int y = 0; y < charSpace.length(); y++) {
+                if (y == 8 || y == 14 || y == 18 || y == 26 || y == 27 || y == 31) {
+                    // I=8, O=14, S=18, 0=26, 1=27, 5=31
+                    // These characters are allowed to be blank!
+                    continue;
+                }
+                assertFalse("Token letter distribution not random; expected " + expectedAvg + " occurrences, found " + occurrences[x][y] + "!",
+                        (occurrences[x][y] > expectedAvg + allowedDelta) || (occurrences[x][y] < expectedAvg - allowedDelta));
+            }
+        }
+    }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins and Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins and Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/monitors/MisuseMonitorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/monitors/MisuseMonitorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/monitors/MisuseMonitorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/monitors/MisuseMonitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins and Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/FacebookAuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/GoogleAuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth1AuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth1AuthenticatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth1AuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth1AuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth2AuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth2AuthenticatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth2AuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuth2AuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/IOAuthAuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,70 +15,70 @@
  */
 package uk.ac.cam.cl.dtg.segue.auth;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-
 import org.junit.Test;
-
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.AuthenticatorSecurityException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.CodeExchangeException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
 
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 /**
  * Test class for the facebook authenticator class.
- * 
  */
 public abstract class IOAuthAuthenticatorTest {
-	protected final String clientId = "someClientId";
-	protected final String clientSecret = "someClientSecret";
-	protected final String callbackUri = "someCallbackUri";
-	protected final String requestedScopes = "requestedScopes";
-	protected final String someDomain = "http://www.somedomain.com/";
-	protected final String someAuthCode = "someAuthCode";
-	
-	protected IOAuthAuthenticator authenticator;
-	
-	
-	/**
-	 * Verify that the authenticator correctly identifies itself.
-	 */
-	@Test
-	public final void getAuthenticationProvider_returnsNonNullProvider() {
-		assertTrue(authenticator.getAuthenticationProvider() != null);
-	}
+    protected final String clientId = "someClientId";
+    protected final String clientSecret = "someClientSecret";
+    protected final String callbackUri = "someCallbackUri";
+    protected final String requestedScopes = "requestedScopes";
+    protected final String someDomain = "http://www.somedomain.com/";
+    protected final String someAuthCode = "someAuthCode";
+
+    protected IOAuthAuthenticator authenticator;
 
 
-	/**
-	 * Verify that the extractAuthCode method returns the correct value.
-	 * @throws NoUserException 
-	 * @throws IOException 
-	 */
-	@Test
-	public final void exchangeCode_invalidToken_throwsException() throws IOException, NoUserException {
-		try {
-			authenticator.exchangeCode(someAuthCode);
-			fail("Exception should have been thrown.");
-		} catch (CodeExchangeException e) {
-			// fine
-		}
-	}
-	
-	/**
-	 * Verify that the getAntiForgeryStateToken returns some non-null non-empty string.
-	 * @throws IOException 
-	 * @throws NoUserException 
-	 * @throws AuthenticatorSecurityException 
-	 */
-	@Test
-	public final void getUserInfo_nullReference_throwsException() throws NoUserException, IOException, AuthenticatorSecurityException {
-		try {
-			authenticator.getUserInfo(null);
-			fail("Exception should have been thrown.");
-		} catch (NullPointerException e) {
-			// fine
-		}
-	}
+    /**
+     * Verify that the authenticator correctly identifies itself.
+     */
+    @Test
+    public final void getAuthenticationProvider_returnsNonNullProvider() {
+        assertNotNull(authenticator.getAuthenticationProvider());
+    }
+
+
+    /**
+     * Verify that the extractAuthCode method returns the correct value.
+     *
+     * @throws NoUserException
+     * @throws IOException
+     */
+    @Test
+    public final void exchangeCode_invalidToken_throwsException() throws IOException, NoUserException {
+        try {
+            authenticator.exchangeCode(someAuthCode);
+            fail("Exception should have been thrown.");
+        } catch (CodeExchangeException e) {
+            // fine
+        }
+    }
+
+    /**
+     * Verify that the getAntiForgeryStateToken returns some non-null non-empty string.
+     *
+     * @throws IOException
+     * @throws NoUserException
+     * @throws AuthenticatorSecurityException
+     */
+    @Test
+    public final void getUserInfo_nullReference_throwsException() throws NoUserException, IOException, AuthenticatorSecurityException {
+        try {
+            authenticator.getUserInfo(null);
+            fail("Exception should have been thrown.");
+        } catch (NullPointerException e) {
+            // fine
+        }
+    }
 
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/RaspberryPiOidcAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/RaspberryPiOidcAuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,7 +42,6 @@ import static org.junit.Assert.fail;
 
 /**
  * Test class for the SegueLocalAuthenticator class.
- * 
  */
 public class SegueLocalAuthenticatorTest {
 
@@ -50,10 +49,10 @@ public class SegueLocalAuthenticatorTest {
     private IPasswordDataManager passwordDataManager;
     private AbstractConfigLoader propertiesLoader;
 
-    private ISegueHashingAlgorithm preferredAlgorithm = new SegueSCryptv1();
-    private ISegueHashingAlgorithm oldAlgorithm1 = new SeguePBKDF2v1();
-    private ISegueHashingAlgorithm oldAlgorithm2 = new SeguePBKDF2v2();
-    private ISegueHashingAlgorithm oldAlgorithm3 = new SeguePBKDF2v3();
+    private final ISegueHashingAlgorithm preferredAlgorithm = new SegueSCryptv1();
+    private final ISegueHashingAlgorithm oldAlgorithm1 = new SeguePBKDF2v1();
+    private final ISegueHashingAlgorithm oldAlgorithm2 = new SeguePBKDF2v2();
+    private final ISegueHashingAlgorithm oldAlgorithm3 = new SeguePBKDF2v3();
 
     Map<String, ISegueHashingAlgorithm> possibleAlgorithms = ImmutableMap.of(
             preferredAlgorithm.hashingAlgorithmName(), preferredAlgorithm,
@@ -62,209 +61,211 @@ public class SegueLocalAuthenticatorTest {
             oldAlgorithm3.hashingAlgorithmName(), oldAlgorithm3
     );
 
-	/**
-	 * Initial configuration of tests.
-	 *
-	 * @throws Exception
-	 *             - test exception
-	 */
-	@Before
-	public final void setUp() throws Exception {
-		this.userDataManager = createMock(IUserDataManager.class);
-		this.passwordDataManager = createMock(IPasswordDataManager.class);
-		this.propertiesLoader = createMock(AbstractConfigLoader.class);
-	}
+    /**
+     * Initial configuration of tests.
+     *
+     * @throws Exception - test exception
+     */
+    @Before
+    public final void setUp() throws Exception {
+        this.userDataManager = createMock(IUserDataManager.class);
+        this.passwordDataManager = createMock(IPasswordDataManager.class);
+        this.propertiesLoader = createMock(AbstractConfigLoader.class);
+    }
 
-	/**
-	 * Verify that setOrChangeUsersPassword fails with bad input.
-	 */
-	@Test
-	public final void segueLocalAuthenticator_setOrChangeUsersPasswordEmptyPassword_exceptionsShouldBeThrown() throws InvalidKeySpecException, NoSuchAlgorithmException {
-		RegisteredUser someUser = new RegisteredUser();
-		someUser.setEmail("test@test.com");
-		someUser.setId(533L);
-		
-		replay(userDataManager);
-		
-		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
-		        this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
-		
-		try {
-			segueAuthenticator.setOrChangeUsersPassword(someUser, null);
-			fail("Expected InvalidPasswordException to be thrown as a null password was given.");
-		} catch (InvalidPasswordException e) {
-			// this is a pass
-			
-		} catch (SegueDatabaseException e) {
-			e.printStackTrace();
-		}
+    /**
+     * Verify that setOrChangeUsersPassword fails with bad input.
+     */
+    @Test
+    public final void segueLocalAuthenticator_setOrChangeUsersPasswordEmptyPassword_exceptionsShouldBeThrown() throws InvalidKeySpecException, NoSuchAlgorithmException {
+        RegisteredUser someUser = new RegisteredUser();
+        someUser.setEmail("test@test.com");
+        someUser.setId(533L);
 
-		try {
-			segueAuthenticator.setOrChangeUsersPassword(someUser, "");
-			fail("Expected InvalidPasswordException to be thrown as a empty password was given.");
-		} catch (InvalidPasswordException e) {
-			// this is a pass
-			
-		} catch (SegueDatabaseException e) {
-			e.printStackTrace();
-		}
-	}
-	
-	/**
-	 * Verify that setOrChangeUsersPassword works with correct input and the
-	 * result is a user object with base64 encoded passwords and a secure salt.
-	 */
-	@Test
-	public final void segueLocalAuthenticator_setOrChangeUsersPasswordValidPassword_passwordAndHashShouldBePopulatedAsBase64() throws InvalidKeySpecException, NoSuchAlgorithmException {
-		RegisteredUser someUser = new RegisteredUser();
-		someUser.setEmail("test@test.com");
-		someUser.setId(533L);
-		String somePassword = "test5eguePassw0rd";
-		replay(userDataManager);
-		
-		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
-				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
-		
-		try {
-			segueAuthenticator.setOrChangeUsersPassword(someUser, somePassword);
-			
-			//TODO write test
-			
-		} catch (InvalidPasswordException e) {
-			fail("This should be a valid password");
-		} catch (SegueDatabaseException e) {
-			e.printStackTrace();
-		}
-	}
-	
-	/**
-	 * Verify that setOrChangeUsersPassword fails on a bad password.
-	 * @throws SegueDatabaseException 
-	 * @throws NoCredentialsAvailableException 
-	 * @throws NoUserException 
-	 */
-	@Test
-	public final void segueLocalAuthenticator_authenticate_correctEmailAndIncorrectPasswordProvided()
-			throws SegueDatabaseException, NoUserException, NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
-		String someCorrectPasswordPlainText = "test5eguePassw0rd";
-		String someCorrectPasswordHashFromDB = "NyACfIYjYUGK7EbtlMAV48+dgyXpa+DPUKHmR1IjY/nAI2xydZUuqtVYc/shQnJ9fhquDOu56C57NGUPsxJ52Q==";
-		String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
-		String usersEmailAddress = "test@test.com";
-		
-		RegisteredUser userFromDatabase = new RegisteredUser();
-		userFromDatabase.setId(533L);
-		userFromDatabase.setEmail(usersEmailAddress);
+        replay(userDataManager);
 
-		RegisteredUser someUser = new RegisteredUser();
-		someUser.setEmail("test@test.com");
-		someUser.setId(533L);
-		String someIncorrectPassword = "password";
+        SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
+                this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
+
+        try {
+            segueAuthenticator.setOrChangeUsersPassword(someUser, null);
+            fail("Expected InvalidPasswordException to be thrown as a null password was given.");
+        } catch (InvalidPasswordException e) {
+            // this is a pass
+
+        } catch (SegueDatabaseException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            segueAuthenticator.setOrChangeUsersPassword(someUser, "");
+            fail("Expected InvalidPasswordException to be thrown as a empty password was given.");
+        } catch (InvalidPasswordException e) {
+            // this is a pass
+
+        } catch (SegueDatabaseException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Verify that setOrChangeUsersPassword works with correct input and the
+     * result is a user object with base64 encoded passwords and a secure salt.
+     */
+    @Test
+    public final void segueLocalAuthenticator_setOrChangeUsersPasswordValidPassword_passwordAndHashShouldBePopulatedAsBase64() throws InvalidKeySpecException, NoSuchAlgorithmException {
+        RegisteredUser someUser = new RegisteredUser();
+        someUser.setEmail("test@test.com");
+        someUser.setId(533L);
+        String somePassword = "test5eguePassw0rd";
+        replay(userDataManager);
+
+        SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
+                this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
+
+        try {
+            segueAuthenticator.setOrChangeUsersPassword(someUser, somePassword);
+
+            //TODO write test
+
+        } catch (InvalidPasswordException e) {
+            fail("This should be a valid password");
+        } catch (SegueDatabaseException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Verify that setOrChangeUsersPassword fails on a bad password.
+     *
+     * @throws SegueDatabaseException
+     * @throws NoCredentialsAvailableException
+     * @throws NoUserException
+     */
+    @Test
+    public final void segueLocalAuthenticator_authenticate_correctEmailAndIncorrectPasswordProvided()
+            throws SegueDatabaseException, NoUserException, NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
+        String someCorrectPasswordPlainText = "test5eguePassw0rd";
+        String someCorrectPasswordHashFromDB = "NyACfIYjYUGK7EbtlMAV48+dgyXpa+DPUKHmR1IjY/nAI2xydZUuqtVYc/shQnJ9fhquDOu56C57NGUPsxJ52Q==";
+        String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
+        String usersEmailAddress = "test@test.com";
+
+        RegisteredUser userFromDatabase = new RegisteredUser();
+        userFromDatabase.setId(533L);
+        userFromDatabase.setEmail(usersEmailAddress);
+
+        RegisteredUser someUser = new RegisteredUser();
+        someUser.setEmail("test@test.com");
+        someUser.setId(533L);
+        String someIncorrectPassword = "password";
 
         LocalUserCredential luc = new LocalUserCredential();
         luc.setPassword(someCorrectPasswordHashFromDB);
         luc.setSecureSalt(someCorrectSecureSaltFromDB);
         luc.setSecurityScheme("SeguePBKDF2v1");
 
-		expect(userDataManager.getByEmail(usersEmailAddress)).andReturn(userFromDatabase).once();
+        expect(userDataManager.getByEmail(usersEmailAddress)).andReturn(userFromDatabase).once();
 
         expect(passwordDataManager.getLocalUserCredential(anyLong())).andReturn(luc).atLeastOnce();
 
-		replay(userDataManager, passwordDataManager);
-		
-		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
-				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
-		try {
-			RegisteredUser authenticatedUser = segueAuthenticator.authenticate(usersEmailAddress, someIncorrectPassword);
-			fail("This should fail as a bad password has been provided.");
-			
-		} catch (IncorrectCredentialsProvidedException e) {
-			// success
-			
-		}		
-	}
-	
-	/**
-	 * Verify that setOrChangeUsersPassword fails on a bad e-mail and password.
-	 * @throws SegueDatabaseException 
-	 * @throws IncorrectCredentialsProvidedException 
-	 * @throws NoCredentialsAvailableException 
-	 * @throws NoUserException 
-	 */
-	@Test
-	public final void segueLocalAuthenticator_authenticate_badEmailAndIncorrectPasswordProvided()
-			throws SegueDatabaseException, IncorrectCredentialsProvidedException,
-			NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
-		String someCorrectPasswordPlainText = "test5eguePassw0rd";
-		String someCorrectPasswordHashFromDB = "NyACfIYjYUGK7EbtlMAV48+dgyXpa+DPUKHmR1IjY/nAI2xydZUuqtVYc/shQnJ9fhquDOu56C57NGUPsxJ52Q==";
-		String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
-		String usersEmailAddress = "test@test.com";
-		
-		RegisteredUser userFromDatabase = new RegisteredUser();
-		userFromDatabase.setId(533L);
-		userFromDatabase.setEmail(usersEmailAddress);
-		
-		String someBadEmail = "badtest@test.com";
-		String someIncorrectPassword = "password";
-		
-		expect(userDataManager.getByEmail(someBadEmail)).andReturn(null).once();
-		
-		replay(userDataManager);
-		
-		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
-				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
-		try {
-			RegisteredUser authenticatedUser = segueAuthenticator.authenticate(someBadEmail, someIncorrectPassword);
-			fail("This should fail as a bad email and password has been provided.");
-			
-		} catch (NoUserException e) {
-			// success. This is what we expect.
-		} 
-	}
-	
-	/**
-	 * Verify that the authenticator creates and authenticates correctly..
-	 * @throws SegueDatabaseException 
-	 * @throws IncorrectCredentialsProvidedException 
-	 * @throws NoCredentialsAvailableException 
-	 * @throws InvalidPasswordException 
-	 * @throws NoUserException 
-	 */
-	@Test
-	public final void segueLocalAuthenticator_setPasswordAndImmediateAuthenticate_correctEmailAndPasswordProvided()
-			throws SegueDatabaseException, IncorrectCredentialsProvidedException,
-			NoCredentialsAvailableException, InvalidPasswordException, InvalidKeySpecException, NoSuchAlgorithmException {
-		String someCorrectPasswordPlainText = "test5eguePassw0rd";
-		String usersEmailAddress = "test@test.com";
+        replay(userDataManager, passwordDataManager);
+
+        SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
+                this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
+        try {
+            RegisteredUser authenticatedUser = segueAuthenticator.authenticate(usersEmailAddress, someIncorrectPassword);
+            fail("This should fail as a bad password has been provided.");
+
+        } catch (IncorrectCredentialsProvidedException e) {
+            // success
+
+        }
+    }
+
+    /**
+     * Verify that setOrChangeUsersPassword fails on a bad e-mail and password.
+     *
+     * @throws SegueDatabaseException
+     * @throws IncorrectCredentialsProvidedException
+     * @throws NoCredentialsAvailableException
+     * @throws NoUserException
+     */
+    @Test
+    public final void segueLocalAuthenticator_authenticate_badEmailAndIncorrectPasswordProvided()
+            throws SegueDatabaseException, IncorrectCredentialsProvidedException,
+            NoCredentialsAvailableException, InvalidKeySpecException, NoSuchAlgorithmException {
+        String someCorrectPasswordPlainText = "test5eguePassw0rd";
+        String someCorrectPasswordHashFromDB = "NyACfIYjYUGK7EbtlMAV48+dgyXpa+DPUKHmR1IjY/nAI2xydZUuqtVYc/shQnJ9fhquDOu56C57NGUPsxJ52Q==";
+        String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
+        String usersEmailAddress = "test@test.com";
+
+        RegisteredUser userFromDatabase = new RegisteredUser();
+        userFromDatabase.setId(533L);
+        userFromDatabase.setEmail(usersEmailAddress);
+
+        String someBadEmail = "badtest@test.com";
+        String someIncorrectPassword = "password";
+
+        expect(userDataManager.getByEmail(someBadEmail)).andReturn(null).once();
+
+        replay(userDataManager);
+
+        SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
+                this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
+        try {
+            RegisteredUser authenticatedUser = segueAuthenticator.authenticate(someBadEmail, someIncorrectPassword);
+            fail("This should fail as a bad email and password has been provided.");
+
+        } catch (NoUserException e) {
+            // success. This is what we expect.
+        }
+    }
+
+    /**
+     * Verify that the authenticator creates and authenticates correctly..
+     *
+     * @throws SegueDatabaseException
+     * @throws IncorrectCredentialsProvidedException
+     * @throws NoCredentialsAvailableException
+     * @throws InvalidPasswordException
+     * @throws NoUserException
+     */
+    @Test
+    public final void segueLocalAuthenticator_setPasswordAndImmediateAuthenticate_correctEmailAndPasswordProvided()
+            throws SegueDatabaseException, IncorrectCredentialsProvidedException,
+            NoCredentialsAvailableException, InvalidPasswordException, InvalidKeySpecException, NoSuchAlgorithmException {
+        String someCorrectPasswordPlainText = "test5eguePassw0rd";
+        String usersEmailAddress = "test@test.com";
         String someCorrectPasswordHashFromDB = "NyACfIYjYUGK7EbtlMAV48+dgyXpa+DPUKHmR1IjY/nAI2xydZUuqtVYc/shQnJ9fhquDOu56C57NGUPsxJ52Q==";
         String someCorrectSecureSaltFromDB = "P77Fhqu2/SAVGDCtu9IkHg==";
 
-		RegisteredUser userFromDatabase = new RegisteredUser();
-		userFromDatabase.setId(533L);
-		userFromDatabase.setEmail(usersEmailAddress);
+        RegisteredUser userFromDatabase = new RegisteredUser();
+        userFromDatabase.setId(533L);
+        userFromDatabase.setEmail(usersEmailAddress);
 
-		LocalUserCredential luc = new LocalUserCredential();
-		luc.setPassword(someCorrectPasswordHashFromDB);
+        LocalUserCredential luc = new LocalUserCredential();
+        luc.setPassword(someCorrectPasswordHashFromDB);
         luc.setSecureSalt(someCorrectSecureSaltFromDB);
         luc.setSecurityScheme("SeguePBKDF2v1");
 
-		expect(userDataManager.getByEmail(usersEmailAddress)).andReturn(userFromDatabase).once();
+        expect(userDataManager.getByEmail(usersEmailAddress)).andReturn(userFromDatabase).once();
         expect(passwordDataManager.getLocalUserCredential(anyLong())).andReturn(luc).atLeastOnce();
-		expect(passwordDataManager.createOrUpdateLocalUserCredential(anyObject())).andReturn(luc).atLeastOnce();
+        expect(passwordDataManager.createOrUpdateLocalUserCredential(anyObject())).andReturn(luc).atLeastOnce();
 
-		replay(userDataManager, passwordDataManager);
-		
-		SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
-				this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
-		try {
-			// first try and mutate the user object using the the set method.
-			// this should set the password and secure hash on the user object.
-			segueAuthenticator.setOrChangeUsersPassword(userFromDatabase, someCorrectPasswordPlainText);
-			
-			// now try and authenticate using the password we just created.
-			RegisteredUser authenticatedUser = segueAuthenticator.authenticate(usersEmailAddress, someCorrectPasswordPlainText);
+        replay(userDataManager, passwordDataManager);
 
-		} catch (NoUserException e) {
-			fail("We expect a user to be returned");
-		} 
-	}
+        SegueLocalAuthenticator segueAuthenticator = new SegueLocalAuthenticator(this.userDataManager, this.passwordDataManager,
+                this.propertiesLoader, possibleAlgorithms, preferredAlgorithm);
+        try {
+            // first try and mutate the user object using the the set method.
+            // this should set the password and secure hash on the user object.
+            segueAuthenticator.setOrChangeUsersPassword(userFromDatabase, someCorrectPasswordPlainText);
+
+            // now try and authenticate using the password we just created.
+            RegisteredUser authenticatedUser = segueAuthenticator.authenticate(usersEmailAddress, someCorrectPasswordPlainText);
+
+        } catch (NoUserException e) {
+            fail("We expect a user to be returned");
+        }
+    }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Nick Rogers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/auth/TwitterAuthenticatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/comm/EmailManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/comm/MailGunEmailManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/comm/MailGunEmailManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/comm/MailGunEmailManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/comm/MailGunEmailManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/dao/GitContentManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/dao/GitContentManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/database/GitDbTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/database/GitDbTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -7,7 +7,7 @@ package uk.ac.cam.cl.dtg.segue.etl;
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProviderTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/util/PostCodeLocationResolverTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/util/PostCodeLocationResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  *
  * You may obtain a copy of the License at
- * 		http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/util/PostCodeLocationResolverTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/util/PostCodeLocationResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Alistair Stead
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**Review this PR with whitespace ignored!**

This fixes the 10 worst Checkstyle violating files, stops us from using `/**` JavaDoc syntax for the Apache 2 licences, replaces the tab in the Apache 2 licence with four spaces as the Apache 2 website actually uses, and removes tabs from the worst of the mixed tab-space files.

You may also want to view this commit by commit, since the two Apache 2 cleanups touch hundreds of files but make very few actual changes.

It is by no means a complete cleanup, but it is maybe a quarter of the Checkstyle violations gone in very little effort. I hope this might stop new code from copying bad examples!