### PR TITLE
Unit tests for PR #520

### DIFF
--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -839,27 +839,35 @@ public class IsaacNumericValidatorTest {
     }
 
     /**
-     * Test that the validator converts null valued significant figures to the default value and thus does not incur
-     * an error while disregardSignificantFigures is not set
+     * Test that the validator converts null valued significant figures to the default value and thus evaluates the
+     * the answer as correct while disregardSignificantFigures is not set
      */
     @Test
-    public final void isaacNumericValidator_nullSigFig_correct() {
+    public final void isaacNumericValidator_correctAnswerWithNullSigFigsInQuestion_responseIsCorrect() {
         // ARRANGE
-        IsaacNumericQuestion question = createIsaacNumericQuestion(false, null, null);
+        List<IsaacNumericQuestion> questions = new LinkedList<>();
+
+        questions.add(createIsaacNumericQuestion(false, null, null));
+        questions.add(createIsaacNumericQuestion(false, 1, null));
+        questions.add(createIsaacNumericQuestion(false, null, 2));
 
         List<Choice> answerList = Lists.newArrayList();
-
         Quantity correctAnswer = new Quantity("2.1", "None");
         correctAnswer.setCorrect(true);
-
         answerList.add(correctAnswer);
-        question.setChoices(answerList);
+
+        for(IsaacNumericQuestion question : questions) {
+            question.setChoices(answerList);
+        }
 
         // ACT
-        QuestionValidationResponse response = validator.validateQuestionResponse(question, correctAnswer);
+        for (IsaacNumericQuestion q : questions) {
+            QuestionValidationResponse response = validator.validateQuestionResponse(q, correctAnswer);
 
         // ASSERT
-        assertTrue(response.isCorrect());
+            System.out.println(response.isCorrect());
+            assertTrue(response.isCorrect());
+        }
     }
 
     /**
@@ -867,7 +875,7 @@ public class IsaacNumericValidatorTest {
      * one while disregardSignificantFigures is not set
      */
     @Test
-    public final void isaacNumericValidator_sigFigLessThanOne_unanswerableQuestionResponse() {
+    public final void isaacNumericValidator_correctAnswerWithSigFigLessThanOne_unanswerableQuestionResponse() {
         // ARRANGE
         List<IsaacNumericQuestion> questions = new LinkedList<>();
 
@@ -898,7 +906,7 @@ public class IsaacNumericValidatorTest {
      * the minimum significant figures while disregardSignificantFigures is not set
      */
     @Test
-    public final void isaacNumericValidator_maxLessThanMin_unanswerableQuestionResponse() {
+    public final void isaacNumericValidator_correctAnswerWithMaxLessThanMin_unanswerableQuestionResponse() {
         // ARRANGE
         IsaacNumericQuestion question = createIsaacNumericQuestion(false, 2, 1);
 
@@ -922,7 +930,7 @@ public class IsaacNumericValidatorTest {
      * disregardSignificantFigures is not set
      */
     @Test
-    public final void isaacNumericValidator_minLessThanMax_correct() {
+    public final void isaacNumericValidator_correctAnswerWithMinLessThanMax_responseIsCorrect() {
         // ARRANGE
         IsaacNumericQuestion question = createIsaacNumericQuestion(false, 5, 6);
 
@@ -942,11 +950,11 @@ public class IsaacNumericValidatorTest {
     }
 
     /**
-     * Test that the validator returns an "unanswerable question" response if any of the significant figures are below
-     * one while disregardSignificantFigures is not set
+     * Test that the validator returns a correct answer response regardless of whether the significant figures are
+     * incorrect when disregardSignificantFigures is set
      */
     @Test
-    public final void isaacNumericValidator_disregardSigFigs_correctRegardless() {
+    public final void isaacNumericValidator_correctAnswerWithDisregardSigFigs_responseIsCorrectRegardless() {
         // ARRANGE
         List<IsaacNumericQuestion> questions = new LinkedList<>();
 
@@ -955,6 +963,9 @@ public class IsaacNumericValidatorTest {
         correctAnswer.setCorrect(true);
         answerList.add(correctAnswer);
 
+        questions.add(createIsaacNumericQuestion(false, null, null));
+        questions.add(createIsaacNumericQuestion(false, 1, null));
+        questions.add(createIsaacNumericQuestion(false, null, 2));
         questions.add(createIsaacNumericQuestion(true, 0, 1));
         questions.add(createIsaacNumericQuestion(true, 1, 0));
         questions.add(createIsaacNumericQuestion(true, 0, 0));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -30,9 +30,11 @@ import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Quantity;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -836,6 +838,142 @@ public class IsaacNumericValidatorTest {
         assertFalse(response.isCorrect());
     }
 
+    /**
+     * Test that the validator converts null valued significant figures to the default value and thus does not incur
+     * an error while disregardSignificantFigures is not set
+     */
+    @Test
+    public final void isaacNumericValidator_nullSigFig_correct() {
+        // ARRANGE
+        IsaacNumericQuestion question = createIsaacNumericQuestion(false, null, null);
+
+        List<Choice> answerList = Lists.newArrayList();
+
+        Quantity correctAnswer = new Quantity("2.1", "None");
+        correctAnswer.setCorrect(true);
+
+        answerList.add(correctAnswer);
+        question.setChoices(answerList);
+
+        // ACT
+        QuestionValidationResponse response = validator.validateQuestionResponse(question, correctAnswer);
+
+        // ASSERT
+        assertTrue(response.isCorrect());
+    }
+
+    /**
+     * Test that the validator returns an "unanswerable question" response if any of the significant figures are below
+     * one while disregardSignificantFigures is not set
+     */
+    @Test
+    public final void isaacNumericValidator_sigFigLessThanOne_unanswerableQuestionResponse() {
+        // ARRANGE
+        List<IsaacNumericQuestion> questions = new LinkedList<>();
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity correctAnswer = new Quantity("2.1", "None");
+        correctAnswer.setCorrect(true);
+        answerList.add(correctAnswer);
+
+        questions.add(createIsaacNumericQuestion(false, 0, 1));
+        questions.add(createIsaacNumericQuestion(false, 1, 0));
+        questions.add(createIsaacNumericQuestion(false, 0, 0));
+
+        for(IsaacNumericQuestion question : questions) {
+            question.setChoices(answerList);
+        }
+
+        // ACT
+        for (IsaacNumericQuestion q : questions) {
+            QuestionValidationResponse response = validator.validateQuestionResponse(q, correctAnswer);
+
+        // ASSERT
+            assertEquals("This question cannot be answered correctly.", response.getExplanation().getValue());
+        }
+    }
+
+    /**
+     * Test that the validator returns an "unanswerable question" response if maximum significant figures is below
+     * the minimum significant figures while disregardSignificantFigures is not set
+     */
+    @Test
+    public final void isaacNumericValidator_maxLessThanMin_unanswerableQuestionResponse() {
+        // ARRANGE
+        IsaacNumericQuestion question = createIsaacNumericQuestion(false, 2, 1);
+
+        List<Choice> answerList = Lists.newArrayList();
+
+        Quantity correctAnswer = new Quantity("2.1", "None");
+        correctAnswer.setCorrect(true);
+
+        answerList.add(correctAnswer);
+        question.setChoices(answerList);
+
+        // ACT
+        QuestionValidationResponse response = validator.validateQuestionResponse(question, correctAnswer);
+
+        // ASSERT
+        assertEquals("This question cannot be answered correctly.", response.getExplanation().getValue());
+    }
+
+    /**
+     * Test that the validator correctly validates questions when both significant figures are set correctly while
+     * disregardSignificantFigures is not set
+     */
+    @Test
+    public final void isaacNumericValidator_minLessThanMax_correct() {
+        // ARRANGE
+        IsaacNumericQuestion question = createIsaacNumericQuestion(false, 5, 6);
+
+        List<Choice> answerList = Lists.newArrayList();
+
+        Quantity correctAnswer = new Quantity("2.12345", "None");
+        correctAnswer.setCorrect(true);
+
+        answerList.add(correctAnswer);
+        question.setChoices(answerList);
+
+        // ACT
+        QuestionValidationResponse response = validator.validateQuestionResponse(question, correctAnswer);
+
+        // ASSERT
+        assertTrue(response.isCorrect());
+    }
+
+    /**
+     * Test that the validator returns an "unanswerable question" response if any of the significant figures are below
+     * one while disregardSignificantFigures is not set
+     */
+    @Test
+    public final void isaacNumericValidator_disregardSigFigs_correctRegardless() {
+        // ARRANGE
+        List<IsaacNumericQuestion> questions = new LinkedList<>();
+
+        List<Choice> answerList = Lists.newArrayList();
+        Quantity correctAnswer = new Quantity("2.1", "None");
+        correctAnswer.setCorrect(true);
+        answerList.add(correctAnswer);
+
+        questions.add(createIsaacNumericQuestion(true, 0, 1));
+        questions.add(createIsaacNumericQuestion(true, 1, 0));
+        questions.add(createIsaacNumericQuestion(true, 0, 0));
+        questions.add(createIsaacNumericQuestion(true, 2, 1));
+        questions.add(createIsaacNumericQuestion(true, 5, 6));
+
+        for(IsaacNumericQuestion question : questions) {
+            question.setChoices(answerList);
+        }
+
+        // ACT
+        for (IsaacNumericQuestion q : questions) {
+            QuestionValidationResponse response = validator.validateQuestionResponse(q, correctAnswer);
+
+            // ASSERT
+            assertTrue(response.isCorrect());
+        }
+    }
+
     //  ---------- Helper methods to test internal functionality of the validator class ----------
 
     private void testSigFigRoundingWorks(String inputValue, int sigFigToRoundTo, double expectedResult) throws Exception {
@@ -882,5 +1020,31 @@ public class IsaacNumericValidatorTest {
                 assertTrue("Expected incorrect sig fig for " + number + " @ " + sigFig + "sf", incorrectSigFig);
             }
         }
+    }
+
+    /**
+     * Helper method for the recordContentTypeSpecificError tests,
+     * generates an IsaacNumericQuestion with provided significant figure information
+     *
+     * @param disregardSigFig - Whether to set the disregardSignificantFigures to true
+     * @param sigFigMin       - The minimum significant figures value
+     * @param sigFigMax       - The maximum significant figures value
+     * @return The new IsaacNumericQuestion object
+     */
+    private IsaacNumericQuestion createIsaacNumericQuestion(final Boolean disregardSigFig,
+                                                            final Integer sigFigMin,
+                                                            final Integer sigFigMax) {
+        IsaacNumericQuestion question = new IsaacNumericQuestion();
+
+        // TODO: See if there is a "better" way of initialising object fields
+        question.setTitle("");
+        question.setType("isaacQuestion");
+        question.setChoices(new LinkedList<>());
+
+        question.setDisregardSignificantFigures(disregardSigFig);
+        question.setSignificantFiguresMin(sigFigMin);
+        question.setSignificantFiguresMax(sigFigMax);
+
+        return question;
     }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -182,7 +182,7 @@ public class ContentIndexerTest {
         Set<Content> contents = Whitebox.invokeMethod(
                 defaultContentIndexer, "flattenContentObjects", rootNode);
 
-        assertTrue(contents.size() == numNodes);
+        assertEquals(numNodes, contents.size());
 
         for (Content c : contents) {
             boolean containsElement = elements.contains(c);
@@ -192,14 +192,14 @@ public class ContentIndexerTest {
             }
         }
 
-        assertTrue(elements.size() == 0);
+        assertEquals(0, elements.size());
     }
 
     /**
      * Test that recordContentTypeSpecificError does not add an error message to indexProblemCache when neither
      * significant figure is set whilst disregardSignificantFigures is not set
      *
-     * @throws Exception
+     * @throws Exception as reflection may not find method
      */
     @Test
     public void recordContentTypeSpecificError_noSigFigSet_checkNoError()
@@ -230,7 +230,7 @@ public class ContentIndexerTest {
      * Test that recordContentTypeSpecificError adds an error message to indexProblemCach when only one significant
      * figure is specified and the other is set to null whilst disregardSignificantFigures is not set
      *
-     * @throws Exception
+     * @throws Exception as reflection may not find method
      */
     @Test
     public void recordContentTypeSpecificError_onlyOneSigFigSet_checkErrorIsCorrect()
@@ -264,7 +264,7 @@ public class ContentIndexerTest {
      * Test that recordContentTypeSpecificError adds an error message to indexProblemCache when both significant
      * figures are specified but either is less than 1 whilst disregardSignificantFigures is not set
      *
-     * @throws Exception
+     * @throws Exception as reflection may not find method
      */
     @Test
     public void recordContentTypeSpecificError_bothSigFigSetLessThan1_checkErrorIsCorrect()
@@ -299,7 +299,7 @@ public class ContentIndexerTest {
      * Test that recordContentTypeSpecificError adds an error message to indexProblemCache when the maximum significant
      * figure is less than the minimum significant figure (both above 1) whilst disregardSignificantFigures is not set
      *
-     * @throws Exception
+     * @throws Exception as reflection may not find method
      */
     @Test
     public void recordContentTypeSpecificError_maxLessThanMin_checkErrorIsCorrect()
@@ -333,7 +333,7 @@ public class ContentIndexerTest {
      * significant figure is less than the maximum significant figure (both above 1) whilst disregardSignificantFigures
      * is not set
      *
-     * @throws Exception
+     * @throws Exception as reflection may not find method
      */
     @Test
     public void recordContentTypeSpecificError_minLessThanMax_checkNoError()
@@ -364,7 +364,7 @@ public class ContentIndexerTest {
      * Test that recordContentTypeSpecificError does not add an error message to indexProblemCache when
      * disregardSignificantFigures is not set
      *
-     * @throws Exception
+     * @throws Exception as reflection may not find method
      */
     @Test
     public void recordContentTypeSpecificError_disregardSigFigsSet_checkNoError()

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -23,6 +23,7 @@ import java.util.*;
 import com.google.api.client.util.Maps;
 import com.google.api.client.util.Sets;
 import com.google.common.collect.ImmutableMap;
+import org.apache.logging.log4j.core.pattern.AbstractStyleNameConverter;
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -30,6 +31,7 @@ import org.powermock.reflect.Whitebox;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacNumericQuestion;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
@@ -67,7 +69,7 @@ public class ContentIndexerTest {
     }
 
     /**
-     * Test that the buildSearchIndex sends all of the various different segue data
+     * Test that the buildSearchIndex sends all the various different segue data
      * to the searchProvider and we haven't forgotten anything.
      *
      * @throws Exception
@@ -193,6 +195,209 @@ public class ContentIndexerTest {
         assertTrue(elements.size() == 0);
     }
 
+    /**
+     * Test that recordContentTypeSpecificError does not add an error message to indexProblemCache when neither
+     * significant figure is set whilst disregardSignificantFigures is not set
+     *
+     * @throws Exception
+     */
+    @Test
+    public void recordContentTypeSpecificError_noSigFigSet_checkNoError()
+            throws Exception {
+        // ARRANGE
+        final Map<Content, List<String>> indexProblemCache = new HashMap<>();
+        final List<Content> contents = new LinkedList<>();
+        contents.add(createIsaacNumericQuestion(false, null, null, "null"));
+
+        // ACT
+        for (Content content : contents) {
+            Whitebox.invokeMethod(
+                    defaultContentIndexer,
+                    "recordContentTypeSpecificError",
+                    "",
+                    content,
+                    indexProblemCache
+            );
+        }
+
+        // ASSERT
+        for (Content key : indexProblemCache.keySet()) {
+            assertTrue(indexProblemCache.get(key).isEmpty());
+        }
+    }
+
+    /**
+     * Test that recordContentTypeSpecificError adds an error message to indexProblemCach when only one significant
+     * figure is specified and the other is set to null whilst disregardSignificantFigures is not set
+     *
+     * @throws Exception
+     */
+    @Test
+    public void recordContentTypeSpecificError_onlyOneSigFigSet_checkErrorIsCorrect()
+            throws Exception {
+        // ARRANGE
+        final Map<Content, List<String>> indexProblemCache = new HashMap<>();
+        final List<Content> contents = new LinkedList<>();
+        contents.add(createIsaacNumericQuestion(false, 1, null, "min_set"));
+        contents.add(createIsaacNumericQuestion(false, null, 1, "max_set"));
+
+        // ACT
+        for (Content content : contents) {
+            Whitebox.invokeMethod(
+                    defaultContentIndexer,
+                    "recordContentTypeSpecificError",
+                    "",
+                    content,
+                    indexProblemCache
+            );
+        }
+
+        // ASSERT
+        for (Content key : indexProblemCache.keySet()) {
+            for (String problem : indexProblemCache.get(key)) {
+                assertTrue(problem.contains("has only one significant figure bound"));
+            }
+        }
+    }
+
+    /**
+     * Test that recordContentTypeSpecificError adds an error message to indexProblemCache when both significant
+     * figures are specified but either is less than 1 whilst disregardSignificantFigures is not set
+     *
+     * @throws Exception
+     */
+    @Test
+    public void recordContentTypeSpecificError_bothSigFigSetLessThan1_checkErrorIsCorrect()
+            throws Exception {
+        // ARRANGE
+        final Map<Content, List<String>> indexProblemCache = new HashMap<>();
+        final List<Content> contents = new LinkedList<>();
+        contents.add(createIsaacNumericQuestion(false, 1, 0, "max_fault"));
+        contents.add(createIsaacNumericQuestion(false, 0, 1, "min_fault"));
+        contents.add(createIsaacNumericQuestion(false, 0, 0, "both_fault"));
+
+        // ACT
+        for (Content content : contents) {
+            Whitebox.invokeMethod(
+                    defaultContentIndexer,
+                    "recordContentTypeSpecificError",
+                    "",
+                    content,
+                    indexProblemCache
+            );
+        }
+
+        // ASSERT
+        for (Content key : indexProblemCache.keySet()) {
+            for (String problem : indexProblemCache.get(key)) {
+                assertTrue(problem.contains("either bound might be less than 1"));
+            }
+        }
+    }
+
+    /**
+     * Test that recordContentTypeSpecificError adds an error message to indexProblemCache when the maximum significant
+     * figure is less than the minimum significant figure (both above 1) whilst disregardSignificantFigures is not set
+     *
+     * @throws Exception
+     */
+    @Test
+    public void recordContentTypeSpecificError_maxLessThanMin_checkErrorIsCorrect()
+            throws Exception {
+        // ARRANGE
+        final Map<Content, List<String>> indexProblemCache = new HashMap<>();
+        final List<Content> contents = new LinkedList<>();
+        contents.add(createIsaacNumericQuestion(false, 2, 1, "order_fault"));
+
+        // ACT
+        for (Content content : contents) {
+            Whitebox.invokeMethod(
+                    defaultContentIndexer,
+                    "recordContentTypeSpecificError",
+                    "",
+                    content,
+                    indexProblemCache
+            );
+        }
+
+        // ASSERT
+        for (Content key : indexProblemCache.keySet()) {
+            for (String problem : indexProblemCache.get(key)) {
+                assertTrue(problem.contains("The upper bound may be below the lower bound"));
+            }
+        }
+    }
+
+    /**
+     * Test that recordContentTypeSpecificError does not add an error message to indexProblemCache when the minimum
+     * significant figure is less than the maximum significant figure (both above 1) whilst disregardSignificantFigures
+     * is not set
+     *
+     * @throws Exception
+     */
+    @Test
+    public void recordContentTypeSpecificError_minLessThanMax_checkNoError()
+            throws Exception {
+        // ARRANGE
+        final Map<Content, List<String>> indexProblemCache = new HashMap<>();
+        final List<Content> contents = new LinkedList<>();
+        contents.add(createIsaacNumericQuestion(false, 1, 2, "order_correct"));
+
+        // ACT
+        for (Content content : contents) {
+            Whitebox.invokeMethod(
+                    defaultContentIndexer,
+                    "recordContentTypeSpecificError",
+                    "",
+                    content,
+                    indexProblemCache
+            );
+        }
+
+        // ASSERT
+        for (Content key : indexProblemCache.keySet()) {
+            assertTrue(indexProblemCache.get(key).isEmpty());
+        }
+    }
+
+    /**
+     * Test that recordContentTypeSpecificError does not add an error message to indexProblemCache when
+     * disregardSignificantFigures is not set
+     *
+     * @throws Exception
+     */
+    @Test
+    public void recordContentTypeSpecificError_disregardSigFigsSet_checkNoError()
+            throws Exception {
+        // ARRANGE
+        final Map<Content, List<String>> indexProblemCache = new HashMap<>();
+        final List<Content> contents = new LinkedList<>();
+        contents.add(createIsaacNumericQuestion(true, null, null, "null"));
+        contents.add(createIsaacNumericQuestion(true, 1, null, "min_set"));
+        contents.add(createIsaacNumericQuestion(true, null, 1, "max_set"));
+        contents.add(createIsaacNumericQuestion(true, 0, 1, "min_fault"));
+        contents.add(createIsaacNumericQuestion(true, 1, 0, "max_fault"));
+        contents.add(createIsaacNumericQuestion(true, 0, 0, "both_fault"));
+        contents.add(createIsaacNumericQuestion(true, 2, 1, "order_fault"));
+        contents.add(createIsaacNumericQuestion(true, 1, 2, "order_correct"));
+
+        // ACT
+        for (Content content : contents) {
+            Whitebox.invokeMethod(
+                    defaultContentIndexer,
+                    "recordContentTypeSpecificError",
+                    "",
+                    content,
+                    indexProblemCache
+            );
+        }
+
+        // ASSERT
+        for (Content key : indexProblemCache.keySet()) {
+            assertTrue(indexProblemCache.get(key).isEmpty());
+        }
+    }
+
     private Content createContentHierarchy(final int numLevels,
                                            final Set<Content> flatSet) {
         List<ContentBase> children = new LinkedList<ContentBase>();
@@ -223,6 +428,37 @@ public class ContentIndexerTest {
                                               final String id) {
         return new Content(id, "", "", "", "", "", "", "", children, "",
                 "", new LinkedList<>(), false, false, new HashSet<>(), 1);
+    }
+
+    /**
+     * Helper method for the recordContentTypeSpecificError tests,
+     * generates an IsaacNumericQuestion with provided significant figure information
+     *
+     * @param disregardSigFig
+     *              - Whether to set the disregardSignificantFigures to true
+     * @param sigFigMin
+     *              - The minimum significant figures value
+     * @param sigFigMax
+     *              - The maximum significant figures value
+     * @return The new IsaacNumericQuestion object
+     */
+    private IsaacNumericQuestion createIsaacNumericQuestion(final Boolean disregardSigFig,
+                                                            final Integer sigFigMin,
+                                                            final Integer sigFigMax,
+                                                            final String id) {
+        IsaacNumericQuestion question = new IsaacNumericQuestion();
+
+        // TODO: See if there is a "better" way of initialising object fields
+        question.setId(id);
+        question.setTitle("");
+        question.setType("isaacQuestion");
+        question.setChoices(new LinkedList<>());
+
+        question.setDisregardSignificantFigures(disregardSigFig);
+        question.setSignificantFiguresMin(sigFigMin);
+        question.setSignificantFiguresMax(sigFigMax);
+
+        return question;
     }
 
     /**


### PR DESCRIPTION
Adds unit tests for handling significant figures when they prevent a question from being answerable. Verifies that the correct warnings are sent and that these are not sent when the significant figures are meant to be disregarded.