### PR TITLE
Increase axisSlop to prevent erroneous quadrant triggers

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherSettings.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacGraphSketcherSettings.java
@@ -25,7 +25,7 @@ import org.isaacphysics.graphchecker.settings.SettingsWrapper;
  */
 public class IsaacGraphSketcherSettings implements SettingsWrapper {
 
-    private static final double ISAAC_AXIS_SLOP = 0.0025;
+    private static final double ISAAC_AXIS_SLOP = 0.005;
     private static final double ISAAC_ORIGIN_SLOP = 0.01;
 
     @Override


### PR DESCRIPTION
This allows for functions to stop on axis and not count as passing into the other quadrant.