### PR TITLE
Update sketcher question DO/DTO to support axis labels

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacGraphSketcherQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacGraphSketcherQuestion.java
@@ -30,5 +30,22 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 @JsonContentType("isaacGraphSketcherQuestion")
 @ValidatesWith(IsaacGraphSketcherValidator.class)
 public class IsaacGraphSketcherQuestion extends IsaacQuestionBase {
+    private String axisLabelX;
+    private String axisLabelY;
 
+    public String getAxisLabelX() {
+        return axisLabelX;
+    }
+
+    public String getAxisLabelY() {
+        return axisLabelY;
+    }
+
+    public void setAxisLabelX(String axisLabelX) {
+        this.axisLabelX = axisLabelX;
+    }
+
+    public void setAxisLabelY(String axisLabelY) {
+        this.axisLabelY = axisLabelY;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
@@ -27,4 +27,22 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 @JsonContentType("isaacGraphSketcherQuestion")
 @ValidatesWith(IsaacGraphSketcherValidator.class)
 public class IsaacGraphSketcherQuestionDTO extends IsaacSymbolicQuestionDTO {
+    private String axisLabelX;
+    private String axisLabelY;
+
+    public String getAxisLabelX() {
+        return axisLabelX;
+    }
+
+    public String getAxisLabelY() {
+        return axisLabelY;
+    }
+
+    public void setAxisLabelX(String axisLabelX) {
+        this.axisLabelX = axisLabelX;
+    }
+
+    public void setAxisLabelY(String axisLabelY) {
+        this.axisLabelY = axisLabelY;
+    }
 }


### PR DESCRIPTION
Adds axisLabelX and axisLabelY fields to the IsaacGraphSketcherQuestion DO and DTO for use with the new content editor update enabling this functionality.