### PR TITLE
Leave "published"  null if unset on Content DO

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Content.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Content.java
@@ -182,10 +182,6 @@ public class Content extends ContentBase {
     }
 
     public Boolean getPublished() {
-        if (null == published) {
-            return false;
-        }
-
         return published;
     }
 


### PR DESCRIPTION
Because we always change the published key to false if it is unset, it appears in every single piece of JSON that inherits from Content. This takes up space in our database, and spuriously means "false" appears in children of published pages because we only use the flag on top level pages and on question parts.
After c898ba71d06019d0d2ff7841524fcb28f3a14fbb made it safe for content indexing to have null published values, this change should not break anything, but will need further testing.