### PR TITLE
ETL: halt on exceptions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -72,7 +72,7 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
  * Created by Ian on 17/10/2016.
  */
 public class ContentIndexer {
-    private static final Logger log = LoggerFactory.getLogger(Content.class);
+    private static final Logger log = LoggerFactory.getLogger(ContentIndexer.class);
 
     private static ConcurrentHashMap<String, Boolean> versionLocks = new ConcurrentHashMap<>();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -140,7 +140,13 @@ public class ContentIndexer {
             log.info("Finished recording content errors, took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
 
             startTime = System.nanoTime();
-            buildElasticSearchIndex(version, contentCache, tagsList, allUnits, publishedUnits, indexProblemCache);
+            try {
+                buildElasticSearchIndex(version, contentCache, tagsList, allUnits, publishedUnits, indexProblemCache);
+            } catch (Exception e) {
+                log.warn("Exception during indexing, cleaning up partial indices!");
+                expungeAnyContentTypeIndicesRelatedToVersion(version);  // This may itself fail if ElasticSearch is broken!
+                throw e;
+            }
             endTime = System.nanoTime();
             log.info("Finished indexing git content cache, took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -644,7 +644,7 @@ public class ContentIndexer {
                                                       final Set<String> tagsList,
                                                       final Map<String, String> allUnits,
                                                       final Map<String, String> publishedUnits,
-                                                      final Map<Content, List<String>> indexProblemCache) {
+                                                      final Map<Content, List<String>> indexProblemCache) throws Exception {
         if (anyContentTypesAreIndexedForVersion(sha)) {
             expungeAnyContentTypeIndicesRelatedToVersion(sha);
         }
@@ -713,8 +713,10 @@ public class ContentIndexer {
             log.info("Bulk content error indexing took: " + ((endTime - startTime) / NANOSECONDS_IN_A_MILLISECOND) + "ms");
         } catch (JsonProcessingException e) {
             log.error("Unable to serialise sha or tags");
+            throw new Exception("Unable to serialise sha or tags");
         } catch (SegueSearchException e) {
             log.error("Unable to index sha, tags, units or content errors.");
+            throw new Exception("Unable to index sha, tags, units or content errors.", e);
         }
 
 
@@ -726,8 +728,10 @@ public class ContentIndexer {
             log.info("Search index request sent for: " + sha);
         } catch (SegueSearchException e) {
             log.error("Error whilst trying to perform bulk index operation.", e);
+            throw new Exception("Error whilst trying to perform bulk index operation.", e);
         } catch (ActionRequestValidationException e) {
-            log.error("Error validating content during index",e);
+            log.error("Error validating content during index", e);
+            throw new Exception("Error validating content during index", e);
         }
     }
 


### PR DESCRIPTION
I am sure there could be a subtype of Exception created here, but we do not use the type of the exception anywhere, and the parent methods also throw Exception 🤷

These exceptions prevent indexing from proceeding on error, which has happened several times recently with fairly undesired consequences. Hard failures like these could leave the indices in invalid states,
many of which will be dealt with by the expungeAnyContentTypeIndicesRelatedToVersion check at the start of buildElasticSearchIndex. I have added one further attempt to purge indices on error, though if the error is with ES, then this will fail too.