### PR TITLE
Group code cleanup

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -1164,10 +1164,9 @@ public class AssignmentFacade extends AbstractIsaacFacade {
             if (null == assignmentToDelete) {
                 return new SegueErrorResponse(Status.NOT_FOUND, "The assignment does not exist.").toResponse();
             }
-            if (!assigneeGroup.getOwnerId().equals(currentlyLoggedInUser.getId()) &&
-                    !GroupManager.isInAdditionalManagerList(assigneeGroup, currentlyLoggedInUser.getId())) {
+            if (!GroupManager.isOwnerOrAdditionalManager(assigneeGroup, currentlyLoggedInUser.getId())) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
-                        "You are not the owner of the group or a manager. Unable to delete it.").toResponse();
+                        "You are not the owner of the group or a manager. Unable to delete assignment.").toResponse();
             }
 
             // Check if user is additional manager, and if so if they are either the creator of the assignment or additional

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
@@ -301,7 +301,7 @@ public class GroupsFacade extends AbstractSegueFacade {
 
             RegisteredUserDTO userOfInterest = userManager.getUserDTOById(userId);
 
-            List<UserGroupDTO> groups = groupManager.getGroupsByOwner(userOfInterest);
+            List<UserGroupDTO> groups = groupManager.getAllGroupsOwnedAndManagedByUser(userOfInterest, false);
             return Response.ok(groups).cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
@@ -205,7 +205,7 @@ public class GroupsFacade extends AbstractSegueFacade {
                         .toResponse();
             }
 
-            List<UserGroupDTO> groups = groupManager.getGroupMembershipList(user);
+            List<UserGroupDTO> groups = groupManager.getGroupMembershipList(user, true);
 
             List<Map<String, Object>> results = Lists.newArrayList();
             for(UserGroupDTO group : groups) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -259,22 +259,6 @@ public class GroupManager {
     }
 
     /**
-     * getGroupsByOwner.
-     * 
-     * @param ownerUser
-     *            - the owner of the groups to search for.
-     * @param archivedGroupsOnly
-     *            if true then only archived groups will be returned,
-     *            if false then only unarchived groups will be returned.
-     * @return List of groups or empty list.
-     * @throws SegueDatabaseException if there is a db error
-     */
-    public List<UserGroupDTO> getGroupsByOwner(final RegisteredUserDTO ownerUser, boolean archivedGroupsOnly) throws SegueDatabaseException {
-        Validate.notNull(ownerUser);
-        return convertGroupsToDTOs(groupDatabase.getGroupsByOwner(ownerUser.getId(), archivedGroupsOnly));
-    }
-
-    /**
      * getGroupMembershipList. Gets the groups a user is a member of.
      * 
      * @param userToLookup

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -615,7 +615,7 @@ public class GroupManager {
                     log.debug(String.format("Group (%s) has owner ID (%s) that no longer exists!", groupDTO.getId(), groupDTO.getOwnerId()));
                 }
 
-                // Didn't bother using the user cache above for the below as the bottleneck was the group owner db calls.
+                // set additional manager summary:
                 Set<Long> additionalManagers = groupAdditionalManagers.get(groupDTO.getId());
                 Set<UserSummaryWithEmailAddressDTO> setOfUsers = Sets.newHashSet();
                 if (additionalManagers != null) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -291,18 +291,6 @@ public class GroupManager {
 
         return convertGroupsToDTOs(this.groupDatabase.getGroupMembershipList(userToLookup.getId()), augmentGroups);
     }
-    /**
-     * getGroupMembershipList. Gets the groups a user is a member of.
-     *
-     * @param userToLookup
-     *            - the user to search for group membership details for.
-     * @return the list of groups the user belongs to.
-     * @throws SegueDatabaseException
-     *             - if there is a database error.
-     */
-    public List<UserGroupDTO> getGroupMembershipList(final RegisteredUserDTO userToLookup) throws SegueDatabaseException {
-        return convertGroupsToDTOs(this.groupDatabase.getGroupMembershipList(userToLookup.getId()), true);
-    }
 
     /**
      * Adds a user to a group.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserGroupPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserGroupPersistenceManager.java
@@ -228,6 +228,15 @@ public interface IUserGroupPersistenceManager {
     Set<Long> getAdditionalManagerSetByGroupId(final Long groupId) throws SegueDatabaseException;
 
     /**
+     * Get the additional manager user IDs in bulk for a list of groups.
+     *
+     * @param groupIds - the groups IDs of interest
+     * @return map of group ID to set of manager user ids.
+     * @throws SegueDatabaseException on database failure
+     */
+    Map<Long, Set<Long>> getAdditionalManagerSetsByGroupIds(final Collection<Long> groupIds) throws SegueDatabaseException;
+
+    /**
      * Get groups by additional manager id.
      *
      * @param additionalManagerId


### PR DESCRIPTION
The convertGroupsToDTOs used to have a lookup cache for group owners, but not additional managers. However, the method loaded the manager IDs and then the user data for each manager _one_ by _one_, group by group; this could make hundreds of database queries, even if they were no duplicate users in the lists.

This PR adds a new method for bulk loading additional manager data for multiple groups at once, then refactors the group conversion to use the new method. The most efficient approach is to make a unique set of all owners and managers and load their user data once, so that is what the code does. Even though the streams approach means we now loop though the "groups" list ~5 times rather than once, the reduction in database queries from 2*n_groups to 2 is a massive performance improvement.

The tightening from Iterable to Collection was necessary to use Streams, and since we only pass in collections anyhow, caused no issues. Also suppress the warnings about missing users to debug.

The method does try a new approach to the existing "query multiple" problem; rather than using "... IN (?, ?, ?, ...)", this uses ARRAYs and does "... = ANY(?)". The query plan is identical, ~~but we have not used java.sql.Array for selection before so this is an experiment~~. (We [have actually used this before](https://github.com/isaacphysics/isaac-api/blob/v3.12.3/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java#L842)!)

---

There are a few other cleanup commits to either use consistent methods or remove unnecessary code.