### PR TITLE
Replace unnecessary multi-user database query

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
@@ -75,18 +75,6 @@ public interface IUserDataManager {
             throws SegueDatabaseException;
 
     /**
-     * Get all the linked accounts by users in a list.
-     *
-     * @param users
-     *             - the list of DOs to search for.
-     * @return List of authentication providers (or empty list) per user.
-     * @throws SegueDatabaseException
-     *             - If there is an internal database error.
-     */
-    Map<RegisteredUser, List<AuthenticationProvider>> getAuthenticationProvidersByUsers(final List<RegisteredUser> users)
-            throws SegueDatabaseException;
-
-    /**
      * Get UserAuthenticationSettings Object
      * This object provides information on how a user can login based on linked accounts and if they have a Segue account
      *

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -110,40 +110,17 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
     }
 
     @Override
-    public List<AuthenticationProvider> getAuthenticationProvidersByUser(final RegisteredUser user)
-            throws SegueDatabaseException {
-        return this.getAuthenticationProvidersByUsers(Collections.singletonList(user)).get(user);
-    }
-
-    @Override
-    public Map<RegisteredUser, List<AuthenticationProvider>> getAuthenticationProvidersByUsers(final List<RegisteredUser> users) throws SegueDatabaseException {
-        StringBuilder sb = new StringBuilder("SELECT * FROM linked_accounts WHERE user_id IN (");
-        List<String> questionMarks = IntStream.range(0, users.size()).mapToObj(i -> "?").collect(Collectors.toList());
-        sb.append(String.join(",", questionMarks)).append(");");
+    public List<AuthenticationProvider> getAuthenticationProvidersByUser(RegisteredUser user) throws SegueDatabaseException {
+        String query = "SELECT * FROM linked_accounts WHERE user_id = ?;";
         try (Connection conn = database.getDatabaseConnection();
-             PreparedStatement pst = conn.prepareStatement(sb.toString());
+             PreparedStatement pst = conn.prepareStatement(query);
         ) {
-            int userParamIndex = 1;
-            // These will come in handy later...
-            Map<Long, RegisteredUser> userMap = users.stream().collect(Collectors.toMap(RegisteredUser::getId, Function.identity()));
-            Map<RegisteredUser, List<AuthenticationProvider>> authenticationProviders = new HashMap<>();
-            // Add the parameters into the query
-            for (RegisteredUser user : users) {
-                pst.setLong(userParamIndex++, user.getId());
-                authenticationProviders.put(userMap.get(user.getId()), new ArrayList<>());
-            }
+            pst.setLong(1, user.getId());
 
-            // There appears to be a hard limit of 32767 parameters (source: the Internet) while using a prepared
-            // statement over JDBC. However, one can circumvent that by running the query from a string. This is
-            // generally a bad idea, unless a prepared statement is used to construct the query first, which is probably
-            // still a bad idea, only slightly less so.
-            // TL;DR: Sorry...
-            try (Statement statement = conn.createStatement();
-                 ResultSet queryResults = statement.executeQuery(pst.toString());
-            ) {
+            List<AuthenticationProvider> authenticationProviders = Lists.newArrayList();
+            try (ResultSet queryResults = pst.executeQuery()) {
                 while (queryResults.next()) {
-                    RegisteredUser user = userMap.get(queryResults.getLong("user_id"));
-                    authenticationProviders.get(user).add(AuthenticationProvider.valueOf(queryResults.getString("provider")));
+                    authenticationProviders.add(AuthenticationProvider.valueOf(queryResults.getString("provider")));
                 }
                 return authenticationProviders;
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -677,7 +677,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
     private RegisteredUser createUser(final RegisteredUser userToCreate) throws SegueDatabaseException {    
         // make sure student is default role if none set
         if (null == userToCreate.getRole()) {
-        	userToCreate.setRole(Role.STUDENT);
+            userToCreate.setRole(Role.STUDENT);
         }
         
         // make sure NOT_VERIFIED is default email verification status if none set

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -201,8 +201,8 @@ public class UserManagerTest {
         replay(request);
 
         expect(dummyDatabase.getById(validUserId)).andReturn(returnUser);
-        expect(dummyDatabase.getAuthenticationProvidersByUsers(Collections.singletonList(returnUser)))
-                .andReturn(ImmutableMap.of(returnUser, Lists.newArrayList(AuthenticationProvider.GOOGLE))).once();
+        expect(dummyDatabase.getAuthenticationProvidersByUser(returnUser))
+                .andReturn(Lists.newArrayList(AuthenticationProvider.GOOGLE)).once();
         expect(dummyDatabase.getSegueAccountExistenceByUsers(Collections.singletonList(returnUser)))
                 .andReturn(ImmutableMap.of(returnUser, false)).atLeastOnce();
         replay(dummyQuestionDatabase);
@@ -381,10 +381,8 @@ public class UserManagerTest {
                 new Date(), Gender.MALE, null, new Date(), null, null, null, null);
         mappedUser.setSessionToken(0);
 
-        expect(dummyDatabase.getAuthenticationProvidersByUsers(Collections.singletonList(mappedUser)))
-                .andReturn(new HashMap<RegisteredUser, List<AuthenticationProvider>>() {{
-                    put(mappedUser, Lists.newArrayList(AuthenticationProvider.GOOGLE));
-                }}).atLeastOnce();
+        expect(dummyDatabase.getAuthenticationProvidersByUser(mappedUser))
+                .andReturn(Lists.newArrayList(AuthenticationProvider.GOOGLE)).atLeastOnce();
         expect(dummyDatabase.getSegueAccountExistenceByUsers(Collections.singletonList(mappedUser)))
                 .andReturn(ImmutableMap.of(mappedUser, false)).atLeastOnce();
 


### PR DESCRIPTION
We never use the multi-user authentication provider query except in tests, and there we use it with singleton lists anyway. The query was not well constructed, and a single-user version is much simpler, safer, and far more readable.

This commit also removes the unused method from the interface, and alters the tests to use the single-user method.
