### PR TITLE
Remove unused statistics methods and database code

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/LogEventFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/LogEventFacade.java
@@ -20,16 +20,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
+import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.AnonymousUserDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.SegueResourceMisuseException;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.monitors.IMisuseMonitor;
 import uk.ac.cam.cl.dtg.segue.api.monitors.LogEventMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
-import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.AnonymousUserDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.Consumes;
@@ -39,8 +40,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
-
 import java.util.Map;
 
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
@@ -63,7 +62,7 @@ public class LogEventFacade extends AbstractSegueFacade {
      * Injectable constructor.
      * 
      * @param properties
-     *            the propertiesLoader.
+     *            - the propertiesLoader.
      * @param logManager
      *            - For logging interesting user events.
      * @param misuseMonitor
@@ -85,7 +84,7 @@ public class LogEventFacade extends AbstractSegueFacade {
      * @param httpRequest
      *            - to enable retrieval of session information.
      * @param eventJSON
-     *            - the event information to record as a json map <String, String>.
+     *            - the event information to record as a json Map(String, String).
      * @return 200 for success or 400 for failure.
      */
     @POST

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/IStatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/IStatisticsManager.java
@@ -1,18 +1,9 @@
 package uk.ac.cam.cl.dtg.segue.api.managers;
 
-import org.joda.time.LocalDate;
-import uk.ac.cam.cl.dtg.segue.dao.ResourceNotFoundException;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
-import uk.ac.cam.cl.dtg.segue.dao.schools.UnableToIndexSchoolsException;
-import uk.ac.cam.cl.dtg.isaac.dos.users.School;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
-import uk.ac.cam.cl.dtg.segue.search.SegueSearchException;
-import uk.ac.cam.cl.dtg.util.locations.Location;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -21,10 +12,12 @@ import java.util.Map;
 public interface IStatisticsManager {
 
     /**
-     * Output general stats. This returns a Map of String to Object and is intended to be sent directly to a
+     * Output general statistics.
+     * <p>
+     * This returns a Map of String to Object and is intended to be sent directly to a
      * serializable facade endpoint.
      *
-     * @return ImmutableMap<String, String> (stat name, stat value)
+     * @return ImmutableMap(String, String) of (stat name, stat value)
      * @throws SegueDatabaseException - if there is a database error.
      */
     Map<String, Object> getGeneralStatistics()
@@ -40,55 +33,6 @@ public interface IStatisticsManager {
      *             if there is a problem with the database.
      */
     Long getLogCount(final String logTypeOfInterest) throws SegueDatabaseException;
-
-    /**
-     * Get an overview of all school performance. This is for analytics / admin users.
-     *
-     * @return list of school to statistics mapping. The object in the map is another map with keys connections,
-     *         numberActiveLastThirtyDays.
-     *
-     * @throws UnableToIndexSchoolsException
-     *             - if there is a problem getting school details.
-     */
-    List<Map<String, Object>> getSchoolStatistics()
-            throws UnableToIndexSchoolsException, SegueSearchException;
-
-    /**
-     * Get the number of users per school.
-     *
-     * @return A map of schools to integers (representing the number of registered users)
-     * @throws UnableToIndexSchoolsException as per the description
-     */
-    Map<School, List<RegisteredUserDTO>> getUsersBySchool() throws UnableToIndexSchoolsException, SegueSearchException;
-
-    /**
-     * Find all users belonging to a given school.
-     *
-     * @param schoolId
-     *            - that we are interested in.
-     * @return list of users.
-     * @throws SegueDatabaseException
-     *             - if there is a general database error
-     * @throws ResourceNotFoundException
-     *             - if we cannot locate the school requested.
-     * @throws UnableToIndexSchoolsException
-     *             - if the school list has not been indexed.
-     */
-    List<RegisteredUserDTO> getUsersBySchoolId(final String schoolId) throws ResourceNotFoundException,
-            SegueDatabaseException, UnableToIndexSchoolsException, SegueSearchException;
-
-    /**
-     * @return a list of userId's to last event timestamp
-     */
-    Map<String, Date> getLastSeenUserMap();
-
-    /**
-     * @param qualifyingLogEvent
-     *            the string event type that will be looked for.
-     * @return a map of userId's to last event timestamp
-     * @throws SegueDatabaseException
-     */
-    Map<String, Date> getLastSeenUserMap(String qualifyingLogEvent) throws SegueDatabaseException;
 
     /**
      * getUserQuestionInformation. Produces a map that contains information about the total questions attempted,
@@ -107,81 +51,11 @@ public interface IStatisticsManager {
             throws SegueDatabaseException, ContentManagerException;
 
     /**
-     * getEventLogsByDate.
-     *
-     * @param eventTypes
-     *            - of interest
-     * @param fromDate
-     *            - of interest
-     * @param toDate
-     *            - of interest
-     * @param binDataByMonth
-     *            - shall we group data by the first of every month?
-     * @return Map of eventType --> map of dates and frequency
-     * @throws SegueDatabaseException
-     */
-    Map<String, Map<LocalDate, Long>> getEventLogsByDate(final Collection<String> eventTypes,
-                                                                final Date fromDate, final Date toDate, final boolean binDataByMonth) throws SegueDatabaseException;
-
-    /**
-     * getEventLogsByDate.
-     *
-     * @param eventTypes
-     *            - of interest
-     * @param fromDate
-     *            - of interest
-     * @param toDate
-     *            - of interest
-     * @param userList
-     *            - user prototype to filter events. e.g. user(s) with a particular id or role.
-     * @param binDataByMonth
-     *            - shall we group data by the first of every month?
-     * @return Map of eventType --> map of dates and frequency
-     * @throws SegueDatabaseException
-     */
-    Map<String, Map<LocalDate, Long>> getEventLogsByDateAndUserList(final Collection<String> eventTypes,
-                                                                           final Date fromDate, final Date toDate, final List<RegisteredUserDTO> userList,
-                                                                           final boolean binDataByMonth) throws SegueDatabaseException;
-
-
-    /**
-     * Calculate the number of users from the list provided that meet the criteria.
-     *
-     * @param users
-     *            - collection of users to consider.
-     * @param lastSeenUserMap
-     *            - The map of user event data. UserId --> last event date.
-     * @param daysFromToday
-     *            - the number of days from today that should be included in the calculation e.g. 7 would be the last
-     *            week's data.
-     * @return a collection containing the users who meet the criteria
-     */
-    public Collection<RegisteredUserDTO> getNumberOfUsersActiveForLastNDays(final Collection<RegisteredUserDTO> users,
-                                                                            final Map<String, Date> lastSeenUserMap, final int daysFromToday);
-
-    /**
-     * getLocationInformation.
-     *
-     * @param fromDate
-     *            - date to start search
-     * @param toDate
-     *            - date to end search
-     * @return the list of all locations we know about..
-     * @throws SegueDatabaseException
-     *             if we can't read from the database.
-     */
-    @SuppressWarnings("unchecked")
-    Collection<Location> getLocationInformation(final Date fromDate, final Date toDate) throws SegueDatabaseException;
-
-
-    /**
-     * Gets additional information for a user outlining their progress for teacher-based activity
+     * Gets additional information for a user outlining their progress for teacher-based activity.
      *
      * @param userOfInterest the user we want infor for
      * @return a map of teacher activities and the user's progress in each of them
      */
     Map<String, Object> getDetailedUserStatistics(final RegisteredUserDTO userOfInterest);
-
-
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -1012,8 +1012,6 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
      *            - dependency
      * @param contentManager
      *            - dependency
-     * @param locationHistoryManager
-     *            - dependency
      * @param groupManager
      *            - dependency
      * @param questionManager
@@ -1024,13 +1022,13 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Singleton
     @Inject
     private static StatisticsManager getStatsManager(final UserAccountManager userManager, final ILogManager logManager,
-                                                     final GitContentManager contentManager, final LocationManager locationHistoryManager,
+                                                     final GitContentManager contentManager,
                                                      final GroupManager groupManager, final QuestionManager questionManager,
                                                      final ContentSummarizerService contentSummarizerService,
                                                      final IUserStreaksManager userStreaksManager) {
 
         if (null == statsManager) {
-            statsManager = new StatisticsManager(userManager, logManager, contentManager, locationHistoryManager,
+            statsManager = new StatisticsManager(userManager, logManager, contentManager,
                     groupManager, questionManager, contentSummarizerService, userStreaksManager);
             log.info("Created Singleton of Statistics Manager");
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -1010,8 +1010,6 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
      *            - dependency
      * @param logManager
      *            - dependency
-     * @param schoolManager
-     *            - dependency
      * @param contentManager
      *            - dependency
      * @param locationHistoryManager
@@ -1025,16 +1023,15 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Provides
     @Singleton
     @Inject
-    private static StatisticsManager getStatsManager(final UserAccountManager userManager,
-                                                     final ILogManager logManager, final SchoolListReader schoolManager,
-                                                     final GitContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex, final LocationManager locationHistoryManager,
+    private static StatisticsManager getStatsManager(final UserAccountManager userManager, final ILogManager logManager,
+                                                     final GitContentManager contentManager, final LocationManager locationHistoryManager,
                                                      final GroupManager groupManager, final QuestionManager questionManager,
                                                      final ContentSummarizerService contentSummarizerService,
                                                      final IUserStreaksManager userStreaksManager) {
 
         if (null == statsManager) {
-            statsManager = new StatisticsManager(userManager, logManager, schoolManager, contentManager, contentIndex,
-                    locationHistoryManager, groupManager, questionManager, contentSummarizerService, userStreaksManager);
+            statsManager = new StatisticsManager(userManager, logManager, contentManager, locationHistoryManager,
+                    groupManager, questionManager, contentSummarizerService, userStreaksManager);
             log.info("Created Singleton of Statistics Manager");
         }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ILogManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/ILogManager.java
@@ -15,20 +15,11 @@
  */
 package uk.ac.cam.cl.dtg.segue.dao;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.joda.time.LocalDate;
-
-import uk.ac.cam.cl.dtg.segue.api.Constants.LogType;
-import uk.ac.cam.cl.dtg.isaac.dos.LogEvent;
-import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * Interface for logging components.
@@ -98,20 +89,6 @@ public interface ILogManager {
     void transferLogEventsToRegisteredUser(final String oldUserId, final String newUserId);
 
     /**
-     * Allows filtering by date range.
-     * 
-     * @param type
-     *            - string representing the type of event to find.
-     * @param fromDate
-     *            - date to start search
-     * @param toDate
-     *            - date to end search.
-     * @return all events of the type requested or null if none available. The map should be of type String, Object
-     * @throws SegueDatabaseException 
-     */
-    Collection<LogEvent> getLogsByType(String type, Date fromDate, Date toDate) throws SegueDatabaseException;
-
-    /**
      * Convenience method to find out how many of a particular type of event have been logged.
      * 
      * @param type
@@ -120,67 +97,4 @@ public interface ILogManager {
      * @throws SegueDatabaseException 
      */
     Long getLogCountByType(String type) throws SegueDatabaseException;
-
-    /**
-     * Allows filtering by date range.
-     * 
-     * @param type
-     *            - string representing the type of event to find.
-     * @param fromDate
-     *            - date to start search
-     * @param toDate
-     *            - date to end search.
-     * @param usersOfInterest
-     *            - users of interest.
-     * @return all events of the type requested or null if none available. The map should be of type String, Object
-     * @throws SegueDatabaseException
-     *             - if there is a problem contacting the underlying database
-     */
-    Collection<LogEvent> getLogsByType(String type, Date fromDate, Date toDate, List<RegisteredUserDTO> usersOfInterest)
-            throws SegueDatabaseException;
-
-    /**
-     * Utility method that will generate a map of type -- > localDate -- > number of events.
-     * 
-     * This is done at the database level to allow efficient use of memory.
-     * 
-     * @param eventTypes
-     *            - string representing the type of event to find.
-     * @param fromDate
-     *            - date to start search
-     * @param toDate
-     *            - date to end search.
-     * @param usersOfInterest
-     *            - users of interest.
-     * @param binDataByMonth
-     *            - if true then the data will be put into bins by the 1st of the month if false you will get one per
-     *            day that an event occurred.
-     * @return a map of type -- > localDate -- > number of events
-     * @throws SegueDatabaseException - if there is a problem contacting the underlying database
-     */
-    Map<String, Map<LocalDate, Long>> getLogCountByDate(Collection<String> eventTypes, Date fromDate, Date toDate,
-            List<RegisteredUserDTO> usersOfInterest, boolean binDataByMonth) throws SegueDatabaseException;
-
-    /**
-     * @return get a set of all ip addresses ever seen in the log events.
-     */
-    Set<String> getAllIpAddresses();
-
-    /**
-     * A more efficient way of getting the last log for all users.
-     * 
-     * @param qualifyingLogEventType
-     *            - the log event type to include in the data.
-     * @return where string is the user id and the logevent is the most recent
-     * @throws SegueDatabaseException - if there is a problem contacting the underlying database
-     */
-    Map<String, Date> getLastLogDateForAllUsers(final String qualifyingLogEventType) throws SegueDatabaseException;
-
-    /**
-     * returns a set of event types known about from the db.
-     * 
-     * @return Set of event types.
-     * @throws SegueDatabaseException - if there is a problem contacting the underlying database
-     */
-    Set<String> getAllEventTypes() throws SegueDatabaseException;
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LogManagerEventPublisher.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LogManagerEventPublisher.java
@@ -16,14 +16,13 @@
 
 package uk.ac.cam.cl.dtg.segue.dao;
 
-import org.joda.time.LocalDate;
-import uk.ac.cam.cl.dtg.isaac.dos.LogEvent;
 import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
-import uk.ac.cam.cl.dtg.segue.api.Constants.LogType;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  *  Abstract class for publishing logged events to interested listeners.
@@ -33,46 +32,36 @@ import java.util.*;
  */
 public abstract class LogManagerEventPublisher implements ILogManager {
 
-    private ILogManager logManager;
-    private Collection<LoggingEventHandler> logListeners;
+    private final ILogManager logManager;
+    private final Collection<LoggingEventHandler> logListeners;
 
     public LogManagerEventPublisher(final ILogManager logManager) {
         this.logManager = logManager;
+        this.logListeners = new HashSet<>();
     }
 
 
     /**
-     * Add listener object to collection of listeners that wish to subscribe to events raised
+     * Add listener object to collection of listeners that wish to subscribe to events raised.
      *
      * @param listener
      *            - the listener who wants to subscribe to raised events
      */
     public void addListener(final LoggingEventHandler listener) {
-
-        if (null == logListeners) {
-            logListeners = new HashSet<>();
-        }
-
         this.logListeners.add(listener);
     }
 
-
-
-
-    /**Method Overrides*/
+    /*Method Overrides*/
 
     @Override
     public void logEvent(final AbstractSegueUserDTO user, final HttpServletRequest httpRequest, final LogType eventType, final Object eventDetails) {
 
         this.logManager.logEvent(user, httpRequest, eventType, eventDetails);
 
-        if (null != logListeners) {
-
-            for (LoggingEventHandler listener: logListeners) {
-                listener.handleEvent(user, httpRequest, eventType.name(), eventDetails);
-            }
-
+        for (LoggingEventHandler listener : logListeners) {
+            listener.handleEvent(user, httpRequest, eventType.name(), eventDetails);
         }
+
     }
 
     @Override
@@ -80,13 +69,10 @@ public abstract class LogManagerEventPublisher implements ILogManager {
 
         this.logManager.logExternalEvent(user, httpRequest, eventType, eventDetails);
 
-        if (null != logListeners) {
-
-            for (LoggingEventHandler listener: logListeners) {
-                listener.handleEvent(user, httpRequest, eventType, eventDetails);
-            }
-
+        for (LoggingEventHandler listener : logListeners) {
+            listener.handleEvent(user, httpRequest, eventType, eventDetails);
         }
+
     }
 
     @Override
@@ -94,12 +80,8 @@ public abstract class LogManagerEventPublisher implements ILogManager {
 
         this.logManager.logInternalEvent(user, eventType, eventDetails);
 
-        if (null != logListeners) {
-
-            for (LoggingEventHandler listener: logListeners) {
-                listener.handleEvent(user, null, eventType.name(), eventDetails);
-            }
-
+        for (LoggingEventHandler listener : logListeners) {
+            listener.handleEvent(user, null, eventType.name(), eventDetails);
         }
 
     }
@@ -109,64 +91,16 @@ public abstract class LogManagerEventPublisher implements ILogManager {
 
         this.logManager.transferLogEventsToRegisteredUser(oldUserId, newUserId);
 
-        if (null != logListeners) {
-
-            for (LoggingEventHandler listener: logListeners) {
-                listener.transferLogEventsToRegisteredUser(oldUserId, newUserId);
-            }
-
+        for (LoggingEventHandler listener : logListeners) {
+            listener.transferLogEventsToRegisteredUser(oldUserId, newUserId);
         }
 
-    }
-
-    @Override
-    public Collection<LogEvent> getLogsByType(final String type, final Date fromDate, final Date toDate)
-            throws SegueDatabaseException {
-
-        return this.logManager.getLogsByType(type, fromDate, toDate);
     }
 
     @Override
     public Long getLogCountByType(final String type) throws SegueDatabaseException {
 
         return this.logManager.getLogCountByType(type);
-
-    }
-
-    @Override
-    public Collection<LogEvent> getLogsByType(String type, Date fromDate, Date toDate, List<RegisteredUserDTO> usersOfInterest)
-            throws SegueDatabaseException{
-
-        return this.logManager.getLogsByType(type, fromDate, toDate, usersOfInterest);
-
-    }
-
-    @Override
-    public Map<String, Map<LocalDate, Long>> getLogCountByDate(Collection<String> eventTypes, Date fromDate, Date toDate,
-                                                               List<RegisteredUserDTO> usersOfInterest, boolean binDataByMonth) throws SegueDatabaseException{
-
-        return this.logManager.getLogCountByDate(eventTypes, fromDate, toDate, usersOfInterest, binDataByMonth);
-
-    }
-
-    @Override
-    public Set<String> getAllIpAddresses(){
-
-        return this.logManager.getAllIpAddresses();
-
-    }
-
-    @Override
-    public Map<String, Date> getLastLogDateForAllUsers(final String qualifyingLogEventType) throws SegueDatabaseException{
-
-        return this.logManager.getLastLogDateForAllUsers(qualifyingLogEventType);
-
-    }
-
-    @Override
-    public Set<String> getAllEventTypes() throws SegueDatabaseException{
-
-        return this.logManager.getAllEventTypes();
 
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManager.java
@@ -17,22 +17,18 @@ package uk.ac.cam.cl.dtg.segue.dao;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.util.Lists;
-import com.google.api.client.util.Maps;
-import com.google.api.client.util.Sets;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.commons.lang3.Validate;
-import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.api.Constants.LogType;
-import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 import uk.ac.cam.cl.dtg.isaac.dos.LogEvent;
 import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 import uk.ac.cam.cl.dtg.util.RequestIPExtractor;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -42,17 +38,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
-import static uk.ac.cam.cl.dtg.isaac.api.Constants.ALL_ACCEPTED_LOG_TYPES;
+import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics.LOG_EVENT;
 
 /**
@@ -165,12 +153,6 @@ public class PgLogManager implements ILogManager {
     }
 
     @Override
-    public Collection<LogEvent> getLogsByType(final String type, final Date fromDate, final Date toDate)
-            throws SegueDatabaseException {
-        return this.getLogsByUserAndType(type, fromDate, toDate, null);
-    }
-
-    @Override
     public Long getLogCountByType(final String type) throws SegueDatabaseException {
         String query = "SELECT COUNT(*) AS TOTAL FROM logged_events WHERE event_type = ?";
         try (Connection conn = database.getDatabaseConnection();
@@ -184,284 +166,6 @@ public class PgLogManager implements ILogManager {
             }
         } catch (SQLException e) {
             throw new SegueDatabaseException("Postgres exception: Unable to count log events by type", e);
-        }
-    }
-
-    @Override
-    public Collection<LogEvent> getLogsByType(final String type, final Date fromDate, final Date toDate,
-            final List<RegisteredUserDTO> usersOfInterest) throws SegueDatabaseException {
-
-        List<String> usersIdsList = Lists.newArrayList();
-        for (RegisteredUserDTO u : usersOfInterest) {
-            usersIdsList.add(u.getId().toString());
-        }
-
-        return this.getLogsByUserAndType(type, fromDate, toDate, usersIdsList);
-    }
-
-    @Override
-    public Map<String, Map<LocalDate, Long>> getLogCountByDate(final Collection<String> eventTypes,
-            final Date fromDate, final Date toDate, final List<RegisteredUserDTO> usersOfInterest,
-            final boolean binDataByMonth) throws SegueDatabaseException {
-        Validate.notNull(eventTypes);
-
-        List<String> usersIdsList = Lists.newArrayList();
-        if (usersOfInterest != null) {
-            for (RegisteredUserDTO u : usersOfInterest) {
-                usersIdsList.add(u.getId().toString());
-            }
-        }
-
-        Map<String, Map<LocalDate, Long>> result = Maps.newHashMap();
-
-        for (String typeOfInterest : eventTypes) {
-            Map<Date, Long> rs = this.getLogsCountByMonthFilteredByUserAndType(typeOfInterest, fromDate, toDate,
-                    usersIdsList);
-
-            if (!result.containsKey(typeOfInterest)) {
-                result.put(typeOfInterest, new HashMap<LocalDate, Long>());
-            }
-
-            for (Entry<Date, Long> le : rs.entrySet()) {
-                LocalDate localisedDate = new LocalDate(le.getKey());
-
-                if (result.get(typeOfInterest).containsKey(localisedDate)) {
-                    result.get(typeOfInterest).put(localisedDate,
-                            result.get(typeOfInterest).get(localisedDate) + le.getValue());
-                } else {
-                    result.get(typeOfInterest).put(localisedDate, le.getValue());
-                }
-            }
-        }
-
-        return result;
-    }
-
-    @Override
-    public Set<String> getAllIpAddresses() {
-        Set<String> ipAddresses = Sets.newHashSet();
-        String query = "SELECT DISTINCT ip_address FROM logged_events";
-        try (Connection conn = database.getDatabaseConnection();
-             PreparedStatement pst = conn.prepareStatement(query);
-             ResultSet results = pst.executeQuery();
-        ) {
-            while (results.next()) {
-                ipAddresses.add(results.getString("ip_address"));
-            }
-
-        } catch (SQLException e) {
-            log.error("Unable to get all ip addresses due to a database error.", e);
-
-        }
-
-        return ipAddresses;
-    }
-
-    @Override
-    public Map<String, Date> getLastLogDateForAllUsers(final String qualifyingLogEventType)
-            throws SegueDatabaseException {
-        String query = "SELECT DISTINCT ON (user_id) user_id, \"timestamp\" FROM logged_events WHERE event_type = ? ORDER BY user_id, id DESC;";
-        try (Connection conn = database.getDatabaseConnection();
-             PreparedStatement pst = conn.prepareStatement(query);
-        ) {
-            pst.setString(1, qualifyingLogEventType);
-
-            try (ResultSet results = pst.executeQuery()) {
-                Map<String, Date> resultToReturn = Maps.newHashMap();
-
-                while (results.next()) {
-                    resultToReturn.put(results.getString("user_id"), results.getDate("timestamp"));
-                }
-
-                return resultToReturn;
-            }
-        } catch (SQLException e) {
-            throw new SegueDatabaseException("Unable to find last log for all users", e);
-        }
-    }
-
-    @Override
-    public Set<String> getAllEventTypes() throws SegueDatabaseException {
-        String query = "SELECT event_type FROM logged_events GROUP BY event_type";
-        try (Connection conn = database.getDatabaseConnection();
-             PreparedStatement pst = conn.prepareStatement(query);
-             ResultSet results = pst.executeQuery();
-        ) {
-            Set<String> eventTypesRecorded = Sets.newHashSet();
- 
-            while (results.next()) {
-                eventTypesRecorded.add(results.getString("event_type"));
-            }
-
-            return eventTypesRecorded;
-        } catch (SQLException e) {
-            throw new SegueDatabaseException("Unable to find event types", e);
-        }
-    }
-
-    /**
-     * Creates a log event from a pg results set..
-     * 
-     * @param results
-     *            - result set containing the informaiton about the log event.
-     * @return a log event
-     * @throws SQLException
-     *             if we cannot read the requested column.
-     */
-    private LogEvent buildPgLogEventFromPgResult(final ResultSet results) throws SQLException {
-        return new LogEvent(results.getString("event_type"), results.getString("event_details_type"),
-                results.getObject("event_details"), results.getString("user_id"),
-                results.getBoolean("anonymous_user"), results.getString("user_id"), results.getDate("timestamp"));
-    }
-
-    /**
-     * getLogsCountByMonthFilteredByUserAndType.
-     * 
-     * An optimised method for getting log counts data by month.
-     * This relies on the database doing the binning for us.
-     * 
-     * @param type
-     *            - type of log event to search for.
-     * @param fromDate
-     *            - the earliest date the log event can have occurred
-     * @param toDate
-     *            - the latest date the log event can have occurred
-     * @param userIds
-     *            - the list of users ids we are interested in.
-     * @return a collection of log events that match the above criteria or an empty collection.
-     * @throws SegueDatabaseException
-     *             - if we cannot retrieve the data from the database.
-     */
-    private Map<Date, Long> getLogsCountByMonthFilteredByUserAndType(final String type, final Date fromDate,
-            final Date toDate, final Collection<String> userIds) throws SegueDatabaseException {
-        Validate.notNull(fromDate);
-        Validate.notNull(toDate);
-
-        StringBuilder queryToBuild = new StringBuilder();
-        queryToBuild.append("WITH filtered_logs AS (SELECT * FROM logged_events WHERE event_type=?");
-        if (userIds != null && !userIds.isEmpty()) {
-            StringBuilder inParams = new StringBuilder();
-            inParams.append("?");
-            for (int i = 1; i < userIds.size(); i++) {
-                inParams.append(",?");
-            }
-
-            queryToBuild.append(String.format(" AND user_id IN (%s)", inParams.toString()));
-
-        }
-        queryToBuild.append(") ");
-        // The following LEFT JOIN gives us months with no events in as required, but need count(id) not count(1) to
-        // count actual logged events (where id strictly NOT NULL) in those months, and not count an extra '1' for
-        // empty months where id is NULL by definition of the JOIN.
-        queryToBuild.append("SELECT to_char(gen_month, 'YYYY-MM-01'), count(id)");
-        queryToBuild.append(" FROM generate_series(date_trunc('month', ?::timestamp), ?, INTERVAL '1' MONTH) m(gen_month)");
-        queryToBuild.append(" LEFT OUTER JOIN filtered_logs ON ( date_trunc('month', \"timestamp\") = date_trunc('month', gen_month) )");
-        queryToBuild.append(" GROUP BY gen_month ORDER BY gen_month ASC;");
-
-        try (Connection conn = database.getDatabaseConnection();
-             PreparedStatement pst = conn.prepareStatement(queryToBuild.toString());
-        ) {
-            pst.setString(1, type);
-
-            int index = 2;
-            if (userIds != null) {
-                for (String userId : userIds) {
-                    pst.setString(index++, userId);
-                }
-            }
-            pst.setTimestamp(index++, new java.sql.Timestamp(fromDate.getTime()));
-            pst.setTimestamp(index++, new java.sql.Timestamp(toDate.getTime()));
-
-            try (ResultSet results = pst.executeQuery()) {
-                SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-
-                Map<Date, Long> mapToReturn = Maps.newHashMap();
-                while (results.next()) {
-                    mapToReturn.put(formatter.parse(results.getString("to_char")), results.getLong("count"));
-                }
-
-                return mapToReturn;
-            }
-        } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
-        } catch (ParseException e) {
-            throw new SegueDatabaseException("Unable to parse date exception", e);
-        }
-    }
-    
-    /**
-     * getLogsByUserAndType.
-     * 
-     * WARNING: This should be used with care. Do not request too much
-     * TODO: add pagination
-     * 
-     * @param type
-     *            - type of log event to search for.
-     * @param fromDate
-     *            - the earliest date the log event can have occurred
-     * @param toDate
-     *            - the latest date the log event can have occurred
-     * @param userIds
-     *            - the list of users ids we are interested in.
-     * @return a collection of log events that match the above criteria or an empty collection.
-     * @throws SegueDatabaseException
-     *             - if we cannot retrieve the data from the database.
-     */
-    private Collection<LogEvent> getLogsByUserAndType(final String type, final Date fromDate, final Date toDate,
-            final Collection<String> userIds) throws SegueDatabaseException {
-
-        String query = "SELECT * FROM logged_events WHERE event_type = ?";
-
-        if (fromDate != null) {
-            query += " AND timestamp > ?";
-        }
-
-        if (toDate != null) {
-            query += " AND timestamp < ?";
-        }
-
-        if (userIds != null && !userIds.isEmpty()) {
-            StringBuilder inParams = new StringBuilder();
-            inParams.append("?");
-            for (int i = 1; i < userIds.size(); i++) {
-                inParams.append(",?");
-            }
-
-            query += String.format(" AND user_id IN (%s)", inParams.toString());
-
-        }
-
-        try (Connection conn = database.getDatabaseConnection();
-             PreparedStatement pst = conn.prepareStatement(query);
-        ) {
-            pst.setString(1, type);
-
-            int index = 2;
-
-            if (fromDate != null) {
-                pst.setTimestamp(index++, new java.sql.Timestamp(fromDate.getTime()));
-            }
-            if (toDate != null) {
-                pst.setTimestamp(index++, new java.sql.Timestamp(toDate.getTime()));
-            }
-
-            if (userIds != null) {
-                for (String userId : userIds) {
-                    pst.setString(index++, userId);
-                }
-            }
-
-            try (ResultSet results = pst.executeQuery()) {
-
-                List<LogEvent> returnResult = Lists.newArrayList();
-                while (results.next()) {
-                    returnResult.add(buildPgLogEventFromPgResult(results));
-                }
-
-                return returnResult;
-            }
-        } catch (SQLException e) {
-            throw new SegueDatabaseException("Postgres exception", e);
         }
     }
 
@@ -496,8 +200,8 @@ public class PgLogManager implements ILogManager {
             LOG_EVENT.labels(eventType).inc();
         }
 
-        String query = "INSERT INTO logged_events(user_id, anonymous_user, event_type, event_details_type," +
-                " event_details, ip_address, timestamp) VALUES (?, ?, ?, ?, ?::text::jsonb, ?::inet, ?);";
+        String query = "INSERT INTO logged_events(user_id, anonymous_user, event_type, event_details_type,"
+                + " event_details, ip_address, timestamp) VALUES (?, ?, ?, ?, ?::text::jsonb, ?::inet, ?);";
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
         ) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManagerEventListener.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManagerEventListener.java
@@ -17,13 +17,13 @@
 package uk.ac.cam.cl.dtg.segue.dao;
 
 /**
- *  Postgres implementation of abstract log manager/even publisher
+ *  Postgres implementation of abstract log manager/event publisher.
  *
  *  @author Dan Underwood
  */
 public class PgLogManagerEventListener extends LogManagerEventPublisher {
 
-    public PgLogManagerEventListener(PgLogManager logManager){
+    public PgLogManagerEventListener(PgLogManager logManager) {
         super(logManager);
     }
 


### PR DESCRIPTION
I am attempting to clean up things that access `logged_events`. At the end of this PR, there are precisely three methods that touch the logged events table, reflecting the three current use-cases in the API: to log a new event; to merge anonymous log events into a registered user; and to count logs by type for the stats page.

All other code paths that used `logged_events` were unreachable from the API surface and were mostly historic analysis code. This PR removes those methods, which did school analysis and analysis of log event counts over time. For performance and separation-of-concerns reasons, we no longer do any form of analysis like this using the live API.