### PR TITLE
Database queries using arrays

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AbstractUserPreferenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AbstractUserPreferenceManager.java
@@ -40,18 +40,6 @@ public abstract class AbstractUserPreferenceManager {
             throws SegueDatabaseException;
 
     /**
-     * Get a specific preference for many users.
-     * @param preferenceType - the type of preferences interested in
-     * @param preferenceName - the name of the specific preference
-     * @param users - a list of user objects interested in
-     * @return a map of user IDs to the UserPreference objects
-     * @throws SegueDatabaseException - if a database error occurs
-     */
-    public abstract Map<Long, UserPreference> getUsersPreference(final String preferenceType, final String preferenceName,
-                                                                 final List<RegisteredUserDTO> users)
-            throws SegueDatabaseException;
-
-    /**
      * Get all preferences of one type for a specific user.
      * @param preferenceType - the type of preferences interested in
      * @param userId - the ID of the user interested in
@@ -68,16 +56,6 @@ public abstract class AbstractUserPreferenceManager {
      * @throws SegueDatabaseException - if a database error occurs
      */
     public abstract List<UserPreference> getAllUserPreferences(final long userId)
-            throws SegueDatabaseException;
-
-    /**
-     * Get all preferences of one type for many users.
-     * @param preferenceType - the type of preferences interested in
-     * @param users - a list of user objects interested in
-     * @return a map of user IDs to a list of the UserPreference objects
-     * @throws SegueDatabaseException - if a database error occurs
-     */
-    public abstract Map<Long, List<UserPreference>> getUserPreferences(final String preferenceType, final List<RegisteredUserDTO> users)
             throws SegueDatabaseException;
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
@@ -31,6 +31,7 @@ import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
 import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 
 import java.io.IOException;
+import java.sql.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -44,6 +45,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
@@ -232,51 +234,41 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
             throws SegueDatabaseException {
 
         if (userIds.isEmpty()) {
-            return Maps.newHashMap();
+            return Collections.emptyMap();
         }
 
-        try (Connection conn = database.getDatabaseConnection()) {
-            StringBuilder query = new StringBuilder();
-            query.append("SELECT id, user_id, question_id, correct, timestamp FROM question_attempts WHERE");
+        String query = "SELECT id, user_id, question_id, correct, timestamp FROM question_attempts"
+                     + " WHERE user_id = ANY(?) ORDER BY \"timestamp\" ASC";
 
-            // add all of the user ids we are interested in.
-            if (!userIds.isEmpty()) {
-                String inParams = userIds.stream().map(u -> "?").collect(Collectors.joining(", "));
-                query.append(String.format(" user_id IN (%s)", inParams));
-            }
-            query.append(" ORDER BY \"timestamp\" ASC");
+        Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> mapToReturn
+                = userIds.stream().collect(Collectors.toMap(Function.identity(), k -> Maps.newHashMap()));
 
-            try (PreparedStatement pst = conn.prepareStatement(query.toString())) {
+        try (Connection conn = database.getDatabaseConnection();
+             PreparedStatement pst = conn.prepareStatement(query)) {
 
-                Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> mapToReturn = Maps.newHashMap();
+            Array userIdArray = conn.createArrayOf("INTEGER", userIds.toArray());
+            pst.setArray(1, userIdArray);
 
-                int index = 1;
-                for (Long userId : userIds) {
-                    pst.setLong(index++, userId);
-                    mapToReturn.put(userId, new HashMap<>());
-                }
+            try (ResultSet results = pst.executeQuery()) {
+                while (results.next()) {
+                    LightweightQuestionValidationResponse partialQuestionAttempt = resultsToLightweightValidationResponse(results);
 
-                try (ResultSet results = pst.executeQuery()) {
-                    while (results.next()) {
-                        LightweightQuestionValidationResponse partialQuestionAttempt = resultsToLightweightValidationResponse(results);
+                    String questionPageId = extractPageIdFromQuestionId(partialQuestionAttempt.getQuestionId());
+                    String questionId = partialQuestionAttempt.getQuestionId();
+                    Long userId = results.getLong("user_id");
 
-                        String questionPageId = extractPageIdFromQuestionId(partialQuestionAttempt.getQuestionId());
-                        String questionId = partialQuestionAttempt.getQuestionId();
-                        Long userId = results.getLong("user_id");
-
-                        Map<String, Map<String, List<LightweightQuestionValidationResponse>>> mapOfQuestionAttemptsByPage
+                    Map<String, Map<String, List<LightweightQuestionValidationResponse>>> mapOfQuestionAttemptsByPage
                                 = mapToReturn.get(userId);
 
-                        Map<String, List<LightweightQuestionValidationResponse>> attemptsForThisQuestionPage =
-                                mapOfQuestionAttemptsByPage.computeIfAbsent(questionPageId, k -> Maps.newHashMap());
+                    Map<String, List<LightweightQuestionValidationResponse>> attemptsForThisQuestionPage =
+                            mapOfQuestionAttemptsByPage.computeIfAbsent(questionPageId, k -> Maps.newHashMap());
 
-                        List<LightweightQuestionValidationResponse> listOfResponses =
-                                attemptsForThisQuestionPage.computeIfAbsent(questionId, k -> Lists.newArrayList());
+                    List<LightweightQuestionValidationResponse> listOfResponses =
+                            attemptsForThisQuestionPage.computeIfAbsent(questionId, k -> Lists.newArrayList());
 
-                        listOfResponses.add(partialQuestionAttempt);
-                    }
-                    return mapToReturn;
+                    listOfResponses.add(partialQuestionAttempt);
                 }
+                return mapToReturn;
             }
         } catch (SQLException e) {
             throw new SegueDatabaseException("Postgres exception", e);
@@ -287,10 +279,8 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
     public Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>>
         getMatchingLightweightQuestionAttempts(final List<Long> userIds, final List<String> allQuestionPageIds)
             throws SegueDatabaseException {
-        if (allQuestionPageIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        if (userIds.isEmpty()) {
+
+        if (allQuestionPageIds.isEmpty() || userIds.isEmpty()) {
             return Collections.emptyMap();
         }
 
@@ -301,31 +291,25 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
             return this.getLightweightQuestionAttemptsByUsers(userIds);
         }
 
+        Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> mapToReturn
+                = userIds.stream().collect(Collectors.toMap(Function.identity(), k -> Maps.newHashMap()));;
+
         try (Connection conn = database.getDatabaseConnection()) {
             StringBuilder query = new StringBuilder();
-            query.append("SELECT id, user_id, question_id, correct, timestamp FROM question_attempts WHERE");
-            
-            // add all of the user ids we are interested in.
-            if (!userIds.isEmpty()) {
-                String inParams = userIds.stream().map(u -> "?").collect(Collectors.joining(", "));
-                query.append(String.format(" user_id IN (%s)", inParams));
-            }
+            query.append("SELECT id, user_id, question_id, correct, timestamp FROM question_attempts");
+            query.append(" WHERE user_id = ANY(?)");
 
             // add all of the question page ids we are interested in
             String questionIdsOr = uniquePageIds.stream().map(q -> "question_id LIKE ?").collect(Collectors.joining(" OR "));
             query.append(" AND (").append(questionIdsOr).append(")");
             query.append(" ORDER BY \"timestamp\" ASC");
-            
+
             try (PreparedStatement pst = conn.prepareStatement(query.toString())) {
 
-                Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> mapToReturn
-                        = Maps.newHashMap();
-
                 int index = 1;
-                for (Long userId : userIds) {
-                    pst.setLong(index++, userId);
-                    mapToReturn.put(userId, new HashMap<>());
-                }
+
+                Array userIdArray = conn.createArrayOf("INTEGER", userIds.toArray());
+                pst.setArray(index++, userIdArray);
 
                 for (String pageId : uniquePageIds) {
                     // Using LIKE matching on part IDs; add % wildcard to end of each page ID, and ensure any underscores
@@ -353,6 +337,8 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
                         listOfResponses.add(partialQuestionAttempt);
                     }
                     return mapToReturn;
+                } finally {
+                    userIdArray.free();
                 }
             }
         } catch (SQLException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -770,8 +770,7 @@ public class AdminFacade extends AbstractSegueFacade {
             @QueryParam("schoolOther") @Nullable final String schoolOther,
             @QueryParam("postcode") @Nullable final String postcode,
             @QueryParam("postcodeRadius") @Nullable final String postcodeRadius,
-            @QueryParam("schoolURN") @Nullable final String schoolURN,
-            @QueryParam("subjectOfInterest") @Nullable final String subjectOfInterest) {
+            @QueryParam("schoolURN") @Nullable final String schoolURN) {
 
         RegisteredUserDTO currentUser;
         try {
@@ -909,23 +908,6 @@ public class AdminFacade extends AbstractSegueFacade {
                 }
             }
 
-            // FIXME - this shouldn't really be in a segue class!
-            if (subjectOfInterest != null && !subjectOfInterest.isEmpty()) {
-                List<RegisteredUserDTO> subjectFilteredUsers = new ArrayList<>();
-                Map<Long, List<UserPreference>> userPreferences = userPreferenceManager.getUserPreferences(IsaacUserPreferences.SUBJECT_INTEREST.name(), foundUsers);
-
-                for (RegisteredUserDTO userToFilter: foundUsers) {
-                    if (userPreferences.containsKey(userToFilter.getId())) {
-                        for (UserPreference pref : userPreferences.get(userToFilter.getId())) {
-                            if (pref.getPreferenceName().equals(subjectOfInterest) && pref.getPreferenceValue()) {
-                                subjectFilteredUsers.add(userToFilter);
-                            }
-                        }
-                    }
-                }
-                foundUsers = subjectFilteredUsers;
-            }
-
             // Calculate the ETag
             EntityTag etag = new EntityTag(foundUsers.size() + foundUsers.toString().hashCode()
                     + userPrototype.toString().hashCode() + "");
@@ -938,7 +920,7 @@ public class AdminFacade extends AbstractSegueFacade {
             int searchResultsLimit;
             try {
                 searchResultsLimit = Integer.parseInt(this.getProperties().getProperty(Constants.SEARCH_RESULTS_HARD_LIMIT));
-            } catch(NumberFormatException e) {
+            } catch (NumberFormatException e) {
                 searchResultsLimit = 2000; // Hard-coded, but only as a fail-safe.
             }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
@@ -482,7 +482,6 @@ public class PgUserGroupPersistenceManager implements IUserGroupPersistenceManag
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement(query);
         ) {
-            // Use a single Array, rather than many parameters; cf. the many params approach in findGroupsByIds.
             Array groupIdsArray = conn.createArrayOf("INTEGER", groupIds.toArray());
             pst.setArray(1, groupIdsArray);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
@@ -30,6 +30,7 @@ import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 
 import jakarta.annotation.Nullable;
+import java.sql.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -284,22 +285,18 @@ public class PgUserGroupPersistenceManager implements IUserGroupPersistenceManag
     @Override
     public List<UserGroup> findGroupsByIds(final List<Long> groupIds) throws SegueDatabaseException {
 
-        if (null == groupIds || groupIds.size() == 0) {
+        if (null == groupIds || groupIds.isEmpty()) {
             return Collections.emptyList();
         }
 
-        String query = "SELECT * FROM groups WHERE id IN ("
-                + groupIds.stream().map(g -> "?").collect(Collectors.joining(", "))
-                + ") AND group_status <> ?;";
+        String query = "SELECT * FROM groups WHERE id = ANY(?) AND group_status <> ?;";
 
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement(query)
         ) {
-            int index = 1;
-            for (Long groupId : groupIds) {
-                pst.setLong(index++, groupId);
-            }
-            pst.setString(index, GroupStatus.DELETED.name());
+            Array groupIdsArray = conn.createArrayOf("INTEGER", groupIds.toArray());
+            pst.setArray(1, groupIdsArray);
+            pst.setString(2, GroupStatus.DELETED.name());
 
             try (ResultSet results = pst.executeQuery()) {
                 List<UserGroup> listOfResults = Lists.newArrayList();
@@ -308,6 +305,8 @@ public class PgUserGroupPersistenceManager implements IUserGroupPersistenceManag
                 }
 
                 return listOfResults;
+            } finally {
+                groupIdsArray.free();
             }
 
         } catch (SQLException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -700,7 +700,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
     private RegisteredUser createUser(final RegisteredUser userToCreate) throws SegueDatabaseException {    
         // make sure student is default role if none set
         if (null == userToCreate.getRole()) {
-        	userToCreate.setRole(Role.STUDENT);
+            userToCreate.setRole(Role.STUDENT);
         }
         
         // make sure NOT_VERIFIED is default email verification status if none set
@@ -754,6 +754,8 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
                 } else {
                     throw new SQLException("Creating user failed, no ID obtained.");
                 }
+            } finally {
+                userContexts.free();
             }
 
         } catch (SQLException e) {
@@ -799,10 +801,19 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             throw new SegueDatabaseException("The user you have tried to update does not exist.");
         }
 
-        String query = "UPDATE users SET family_name = ?, given_name = ?, email = ?, role = ?, date_of_birth = ?," +
-                " gender = ?, registration_date = ?, school_id = ?, school_other = ?, last_updated = ?," +
-                " email_verification_status = ?, last_seen = ?, email_verification_token = ?, email_to_verify = ?," +
-                " registered_contexts = ?, registered_contexts_last_confirmed = ?, country_code = ? WHERE id = ?;";
+        String query = "UPDATE users SET family_name = ?, given_name = ?, email = ?, role = ?, date_of_birth = ?,"
+                + " gender = ?, registration_date = ?, school_id = ?, school_other = ?, last_updated = ?,"
+                + " email_verification_status = ?, last_seen = ?, email_verification_token = ?, email_to_verify = ?,"
+                + " registered_contexts = ?, registered_contexts_last_confirmed = ?, country_code = ? WHERE id = ?;";
+
+        List<String> userContextsJsonb = Lists.newArrayList();
+        if (userToCreate.getRegisteredContexts() != null) {
+            for (UserContext registeredContext : userToCreate.getRegisteredContexts()) {
+                userContextsJsonb.add(jsonMapper.writeValueAsString(registeredContext));
+            }
+        }
+        Array userContexts = conn.createArrayOf("jsonb", userContextsJsonb.toArray());
+
         try (PreparedStatement pst = conn.prepareStatement(query)) {
             // TODO: Change this to annotations or something to rely exclusively on the pojo.
             setValueHelper(pst, 1, userToCreate.getFamilyName());
@@ -819,13 +830,7 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             setValueHelper(pst, 12, userToCreate.getLastSeen());
             setValueHelper(pst, 13, userToCreate.getEmailVerificationToken());
             setValueHelper(pst, 14, userToCreate.getEmailToVerify());
-            List<String> userContextsJsonb = Lists.newArrayList();
-            if (userToCreate.getRegisteredContexts() != null) {
-                for (UserContext registeredContext : userToCreate.getRegisteredContexts()) {
-                    userContextsJsonb.add(jsonMapper.writeValueAsString(registeredContext));
-                }
-            }
-            pst.setArray(15, conn.createArrayOf("jsonb", userContextsJsonb.toArray()));
+            pst.setArray(15, userContexts);
             setValueHelper(pst, 16, userToCreate.getRegisteredContextsLastConfirmed());
             setValueHelper(pst, 17, userToCreate.getCountryCode());
             setValueHelper(pst, 18, userToCreate.getId());
@@ -836,6 +841,8 @@ public class PgUsers extends AbstractPgDataManager implements IUserDataManager {
             }
 
             return this.getById(existingUserRecord.getId());
+        } finally {
+            userContexts.free();
         }
     }
     


### PR DESCRIPTION
Move some more database queries from using variable-length parameter lists to using ARRAYs, and ensure existing arrays are freed immediately after use.
Also remove one complex query to bulk load user preferences which was no longer in use by staff users since the data it queries has not been editable by users since ~2021.