### PR TITLE
Allow custom curve limit in sketcher questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacGraphSketcherQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacGraphSketcherQuestion.java
@@ -30,8 +30,17 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 @JsonContentType("isaacGraphSketcherQuestion")
 @ValidatesWith(IsaacGraphSketcherValidator.class)
 public class IsaacGraphSketcherQuestion extends IsaacQuestionBase {
+    private int maxNumCurves;
     private String axisLabelX;
     private String axisLabelY;
+
+    public int getMaxNumCurves() {
+        return maxNumCurves;
+    }
+
+    public void setMaxNumCurves(int maxNumCurves) {
+        this.maxNumCurves = maxNumCurves;
+    }
 
     public String getAxisLabelX() {
         return axisLabelX;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacGraphSketcherQuestionDTO.java
@@ -27,8 +27,17 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 @JsonContentType("isaacGraphSketcherQuestion")
 @ValidatesWith(IsaacGraphSketcherValidator.class)
 public class IsaacGraphSketcherQuestionDTO extends IsaacSymbolicQuestionDTO {
+    private int maxNumCurves;
     private String axisLabelX;
     private String axisLabelY;
+
+    public int getMaxNumCurves() {
+        return maxNumCurves;
+    }
+
+    public void setMaxNumCurves(int maxNumCurves) {
+        this.maxNumCurves = maxNumCurves;
+    }
 
     public String getAxisLabelX() {
         return axisLabelX;


### PR DESCRIPTION
Change Sketcher DO and DTO to support new `maxNumCurves` property