### PR TITLE
Purge unused contentIndex parameter

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -20,7 +20,6 @@ import com.google.api.client.util.Maps;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import com.opencsv.CSVWriter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -115,7 +114,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     private final GroupManager groupManager;
 
     private final GitContentManager contentManager;
-    private final String contentIndex;
     private final UserBadgeManager userBadgeManager;
     private final UserAssociationManager userAssociationManager;
     private final UserAccountManager userAccountManager;
@@ -137,7 +135,6 @@ public class EventsFacade extends AbstractIsaacFacade {
     public EventsFacade(final AbstractConfigLoader properties, final ILogManager logManager,
                         final EventBookingManager bookingManager,
                         final UserAccountManager userManager, final GitContentManager contentManager,
-                        @Named(Constants.CONTENT_INDEX) final String contentIndex,
                         final UserBadgeManager userBadgeManager,
                         final UserAssociationManager userAssociationManager,
                         final GroupManager groupManager,
@@ -147,7 +144,6 @@ public class EventsFacade extends AbstractIsaacFacade {
         this.bookingManager = bookingManager;
         this.userManager = userManager;
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
         this.userBadgeManager = userBadgeManager;
         this.userAssociationManager = userAssociationManager;
         this.groupManager = groupManager;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -15,8 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.isaac.api;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.google.inject.Inject;
@@ -26,7 +24,13 @@ import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.api.services.ContentSummarizerService;
-import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
+import uk.ac.cam.cl.dtg.isaac.dos.IUserStreaksManager;
+import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.IStatisticsManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
@@ -37,13 +41,7 @@ import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
-import uk.ac.cam.cl.dtg.isaac.dos.IUserStreaksManager;
-import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
-import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
-import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
+import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.DefaultValue;
@@ -58,17 +56,12 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
@@ -95,29 +88,6 @@ public class IsaacController extends AbstractIsaacFacade {
     private final UserBadgeManager userBadgeManager;
     private final IUserStreaksManager userStreaksManager;
     private final ContentSummarizerService contentSummarizerService;
-
-    private static long lastQuestionCount = 0L;
-
-    // Question counts are slow to calculate, so cache for up to 10 minutes. We may want to move this to a more
-    // reusable place (such as statsManager.getLogCount) if we find ourselves using this pattern more).
-    private final Supplier<Long> questionCountCache = Suppliers.memoizeWithExpiration(new Supplier<Long>() {
-        public Long get() {
-            Executors.newSingleThreadExecutor().submit(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        log.info("Triggering question answer count query.");
-                        lastQuestionCount = statsManager.getLogCount(SegueServerLogType.ANSWER_QUESTION.name());
-                        log.info("Question answer count query complete.");
-                    } catch (SegueDatabaseException e) {
-                        lastQuestionCount = 0L;
-                    }
-                }
-            });
-
-            return lastQuestionCount;
-        }
-    }, 10, TimeUnit.MINUTES);
 
     /**
      * Creates an instance of the isaac controller which provides the REST endpoints for the isaac api.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -20,7 +20,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jboss.resteasy.annotations.GZIP;
@@ -92,7 +91,6 @@ public class IsaacController extends AbstractIsaacFacade {
     private final IStatisticsManager statsManager;
     private final UserAccountManager userManager;
     private final UserAssociationManager associationManager;
-    private final String contentIndex;
     private final GitContentManager contentManager;
     private final UserBadgeManager userBadgeManager;
     private final IUserStreaksManager userStreaksManager;
@@ -144,7 +142,6 @@ public class IsaacController extends AbstractIsaacFacade {
                            final ILogManager logManager, final IStatisticsManager statsManager,
                            final UserAccountManager userManager, final GitContentManager contentManager,
                            final UserAssociationManager associationManager,
-                           @Named(CONTENT_INDEX) final String contentIndex,
                            final IUserStreaksManager userStreaksManager,
                            final UserBadgeManager userBadgeManager,
                            final ContentSummarizerService contentSummarizerService) {
@@ -152,7 +149,6 @@ public class IsaacController extends AbstractIsaacFacade {
         this.statsManager = statsManager;
         this.userManager = userManager;
         this.associationManager = associationManager;
-        this.contentIndex = contentIndex;
         this.contentManager = contentManager;
         this.userBadgeManager = userBadgeManager;
         this.userStreaksManager = userStreaksManager;
@@ -195,15 +191,13 @@ public class IsaacController extends AbstractIsaacFacade {
             return SegueErrorResponse.getBadRequestResponse(String.format("Search string exceeded %s character limit.", SEARCH_TEXT_CHAR_LIMIT));
         }
 
-        // Calculate the ETag on current live version of the content
-        // NOTE: Assumes that the latest version of the content is being used.
+        // Calculate the ETag on current version of the content
         EntityTag etag = new EntityTag(
-                this.contentIndex.hashCode()
+                String.valueOf(this.contentManager.getCurrentContentSHA().hashCode()
                         + searchString.hashCode()
                         + types.hashCode()
                         + startIndex.hashCode()
-                        + limit.hashCode()
-                        + ""
+                        + limit.hashCode())
         );
 
         Response cachedResponse = generateCachedResponse(request, etag);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -18,7 +18,6 @@ package uk.ac.cam.cl.dtg.isaac.api;
 import com.google.api.client.util.Maps;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import ma.glasnost.orika.MapperFacade;
@@ -97,9 +96,7 @@ public class PagesFacade extends AbstractIsaacFacade {
     private final URIManager uriManager;
     private final QuestionManager questionManager;
     private final GitContentManager contentManager;
-
     private final GameManager gameManager;
-    private final String contentIndex;
 
     /**
      * Creates an instance of the pages controller which provides the REST endpoints for accessing page content.
@@ -122,14 +119,12 @@ public class PagesFacade extends AbstractIsaacFacade {
      *            - So we can look up attempt information.
      * @param gameManager
      *            - For looking up gameboard information.
-     * @param contentIndex
-     *            - Index for the content to serve
      */
     @Inject
     public PagesFacade(final ContentService api, final AbstractConfigLoader propertiesLoader,
                        final ILogManager logManager, final MapperFacade mapper, final GitContentManager contentManager,
                        final UserAccountManager userManager, final URIManager uriManager, final QuestionManager questionManager,
-                       final GameManager gameManager, @Named(CONTENT_INDEX) final String contentIndex) {
+                       final GameManager gameManager) {
         super(propertiesLoader, logManager);
         this.api = api;
         this.mapper = mapper;
@@ -138,7 +133,6 @@ public class PagesFacade extends AbstractIsaacFacade {
         this.uriManager = uriManager;
         this.questionManager = questionManager;
         this.gameManager = gameManager;
-        this.contentIndex = contentIndex;
     }
 
     /**
@@ -769,7 +763,7 @@ public class PagesFacade extends AbstractIsaacFacade {
             fieldsToMatch.put(TYPE_FIELDNAME, Arrays.asList(POD_FRAGMENT_TYPE));
             fieldsToMatch.put(TAGS_FIELDNAME, Arrays.asList(subject));
 
-            ResultsWrapper<ContentDTO> pods = api.findMatchingContent(this.contentIndex,
+            ResultsWrapper<ContentDTO> pods = api.findMatchingContent(
                     ContentService.generateDefaultFieldToMatch(fieldsToMatch), 0, MAX_PODS_TO_RETURN);
 
             return Response.ok(pods).cacheControl(getCacheControl(NUMBER_SECONDS_IN_TEN_MINUTES, true))
@@ -950,8 +944,7 @@ public class PagesFacade extends AbstractIsaacFacade {
             @Nullable final Map<String, BooleanOperator> booleanOperatorOverrideMap, final Integer startIndex, final Integer limit) throws ContentManagerException {
         ResultsWrapper<ContentDTO> c;
 
-        c = api.findMatchingContent(this.contentIndex,
-                ContentService.generateDefaultFieldToMatch(fieldsToMatch, booleanOperatorOverrideMap), startIndex, limit);
+        c = api.findMatchingContent(ContentService.generateDefaultFieldToMatch(fieldsToMatch, booleanOperatorOverrideMap), startIndex, limit);
 
         ResultsWrapper<ContentSummaryDTO> summarizedContent = new ResultsWrapper<ContentSummaryDTO>(
                 this.extractContentSummaryFromList(c.getResults()),

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/FastTrackManger.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/FastTrackManger.java
@@ -3,18 +3,17 @@ package uk.ac.cam.cl.dtg.isaac.api.managers;
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardItem;
+import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.api.services.ContentService;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
-import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
-import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
-import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import java.util.Arrays;
@@ -31,7 +30,6 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 public class FastTrackManger {
     private static final Logger log = LoggerFactory.getLogger(FastTrackManger.class);
 
-    private final String contentIndex;
     private final GitContentManager contentManager;
     private final GameManager gameboardManager;
     private final Set<String> fastTrackGamebaordIds;
@@ -43,15 +41,12 @@ public class FastTrackManger {
      *            - so we can augment game objects with actual detailed content
      * @param gameboardManager
      *            - a gamebaord manager that deals with storing and retrieving gameboards.
-     * @param contentIndex
-     *            - the current content index of interest.
      */
     @Inject
     public FastTrackManger(final AbstractConfigLoader properties, final GitContentManager contentManager,
-                           final GameManager gameboardManager, @Named(CONTENT_INDEX) final String contentIndex) {
+                           final GameManager gameboardManager) {
 
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
         this.gameboardManager = gameboardManager;
         String commaSeparatedIds = properties.getProperty(FASTTRACK_GAMEBOARD_WHITELIST);
         this.fastTrackGamebaordIds = new HashSet<>(Arrays.asList(commaSeparatedIds.split(",")));

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -19,7 +19,6 @@ import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import ma.glasnost.orika.MapperFacade;
 import org.apache.commons.collections4.comparators.ComparatorChain;
 import org.apache.commons.lang3.Validate;
@@ -89,10 +88,7 @@ public class GameManager {
     private final GameboardPersistenceManager gameboardPersistenceManager;
     private final Random randomGenerator;
     private final MapperFacade mapper;
-
     private final GitContentManager contentManager;
-    private final String contentIndex;
-
     private final QuestionManager questionManager;
 
     /**
@@ -106,17 +102,14 @@ public class GameManager {
      *            - a persistence manager that deals with storing and retrieving gameboards.
      * @param mapper
      *            - allows mapping between DO and DTO object types.
-     * @param contentIndex
-     *            - the current content index of interest.
      */
     @Inject
     public GameManager(final GitContentManager contentManager,
                        final GameboardPersistenceManager gameboardPersistenceManager, final MapperFacade mapper,
-                       final QuestionManager questionManager, @Named(CONTENT_INDEX) final String contentIndex) {
+                       final QuestionManager questionManager) {
         this.contentManager = contentManager;
         this.gameboardPersistenceManager = gameboardPersistenceManager;
         this.questionManager = questionManager;
-        this.contentIndex = contentIndex;
 
         this.randomGenerator = new Random();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
@@ -105,7 +105,7 @@ public class QuizManager {
                     BooleanOperator.NOT, Collections.singletonList(visibleToRole)));
         }
 
-        ResultsWrapper<ContentDTO> content = this.contentService.findMatchingContent(null, fieldsToMatch, startIndex, limit);
+        ResultsWrapper<ContentDTO> content = this.contentService.findMatchingContent(fieldsToMatch, startIndex, limit);
 
         return this.contentSummarizerService.extractContentSummaryFromResultsWrapper(content, QuizSummaryDTO.class);
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -25,7 +25,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import ma.glasnost.orika.MapperFacade;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -38,14 +37,14 @@ import uk.ac.cam.cl.dtg.isaac.dos.IsaacWildcard;
 import uk.ac.cam.cl.dtg.isaac.dto.GameFilter;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.GameboardItem;
+import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
-import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
-import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 
 import jakarta.annotation.Nullable;
 import java.io.IOException;
@@ -87,7 +86,6 @@ public class GameboardPersistenceManager {
     private final ObjectMapper objectMapper; // used for json serialisation
 
     private final GitContentManager contentManager;
-    private final String contentIndex;
 
     private final URIManager uriManager;
 
@@ -108,11 +106,10 @@ public class GameboardPersistenceManager {
      */
     @Inject
     public GameboardPersistenceManager(final PostgresSqlDb database, final GitContentManager contentManager,
-                                       final MapperFacade mapper, final ObjectMapper objectMapper, final URIManager uriManager, @Named(CONTENT_INDEX) final String contentIndex) {
+                                       final MapperFacade mapper, final ObjectMapper objectMapper, final URIManager uriManager) {
         this.database = database;
         this.mapper = mapper;
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
         this.objectMapper = objectMapper;
         this.uriManager = uriManager;
         this.gameboardNonPersistentStorage = CacheBuilder.newBuilder()

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -17,7 +17,6 @@ package uk.ac.cam.cl.dtg.segue.api;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.util.Maps;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
@@ -38,6 +37,16 @@ import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.api.managers.EventBookingManager;
+import uk.ac.cam.cl.dtg.isaac.dos.AbstractUserPreferenceManager;
+import uk.ac.cam.cl.dtg.isaac.dos.UserPreference;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
+import uk.ac.cam.cl.dtg.isaac.dos.users.EmailVerificationStatus;
+import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
+import uk.ac.cam.cl.dtg.isaac.dos.users.School;
+import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.UserIdMergeDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryForAdminUsersDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.ExternalAccountSynchronisationException;
 import uk.ac.cam.cl.dtg.segue.api.managers.IExternalAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.SegueResourceMisuseException;
@@ -56,16 +65,6 @@ import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.segue.dao.schools.SchoolListReader;
 import uk.ac.cam.cl.dtg.segue.dao.schools.UnableToIndexSchoolsException;
-import uk.ac.cam.cl.dtg.isaac.dos.AbstractUserPreferenceManager;
-import uk.ac.cam.cl.dtg.isaac.dos.UserPreference;
-import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
-import uk.ac.cam.cl.dtg.isaac.dos.users.EmailVerificationStatus;
-import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
-import uk.ac.cam.cl.dtg.isaac.dos.users.School;
-import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.UserIdMergeDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryForAdminUsersDTO;
 import uk.ac.cam.cl.dtg.segue.etl.GithubPushEventPayload;
 import uk.ac.cam.cl.dtg.segue.scheduler.SegueJobService;
 import uk.ac.cam.cl.dtg.segue.search.SegueSearchException;
@@ -75,8 +74,6 @@ import uk.ac.cam.cl.dtg.util.locations.LocationServerException;
 import uk.ac.cam.cl.dtg.util.locations.PostCodeRadius;
 
 import jakarta.annotation.Nullable;
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -103,6 +100,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
@@ -1214,13 +1213,12 @@ public class AdminFacade extends AbstractSegueFacade {
     @Path("/diagnostics")
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
-    public Response getDiagnostics(@Context final Request request, @Context final HttpServletRequest httpServletRequest) {
+    public Response getDiagnostics(@Context final HttpServletRequest httpServletRequest) {
 
         try {
 
             if (isUserAnAdmin(userManager, httpServletRequest)) {
 
-                ObjectMapper mapper = new ObjectMapper();
                 Map<String, Object> diagnosticReport = Maps.newHashMap();
                 Map<String, Object> websocketReport = Maps.newHashMap();
                 Map<String, Object> runtimeReport = Maps.newHashMap();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
@@ -18,18 +18,18 @@ package uk.ac.cam.cl.dtg.segue.api;
 
 import com.google.api.client.util.Lists;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
-import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
+import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -40,8 +40,6 @@ import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -59,21 +57,17 @@ public class GlossaryFacade extends AbstractSegueFacade {
     private static final Logger log = LoggerFactory.getLogger(GlossaryFacade.class);
 
     private final GitContentManager contentManager;
-    private final String contentIndex;
 
     /**
      * @param properties     - to allow access to system properties.
      * @param contentManager - so that metadata about content can be accessed.
-     * @param contentIndex   - to access the right version of the content.
      * @param logManager     - for logging events using the logging api.
      */
     @Inject
     public GlossaryFacade(final AbstractConfigLoader properties, final GitContentManager contentManager,
-                          @Named(CONTENT_INDEX) final String contentIndex,
                           final ILogManager logManager) {
         super(properties, logManager);
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
@@ -83,8 +83,6 @@ public class GroupsFacade extends AbstractSegueFacade {
 
     private static final Logger log = LoggerFactory.getLogger(GroupsFacade.class);
     private final AssignmentManager assignmentManager;
-    private final GameManager gameManager;
-
     private final GroupManager groupManager;
     private final UserAssociationManager associationManager;
     private final UserBadgeManager userBadgeManager;
@@ -102,14 +100,13 @@ public class GroupsFacade extends AbstractSegueFacade {
     @Inject
     public GroupsFacade(final AbstractConfigLoader properties, final UserAccountManager userManager,
                         final ILogManager logManager, AssignmentManager assignmentManager,
-                        final GameManager gameManager, final GroupManager groupManager,
+                        final GroupManager groupManager,
                         final UserAssociationManager associationsManager,
                         final UserBadgeManager userBadgeManager,
                         final IMisuseMonitor misuseMonitor) {
         super(properties, logManager);
         this.userManager = userManager;
         this.assignmentManager = assignmentManager;
-        this.gameManager = gameManager;
         this.groupManager = groupManager;
         this.associationManager = associationsManager;
         this.userBadgeManager = userBadgeManager;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
@@ -16,21 +16,8 @@
 package uk.ac.cam.cl.dtg.segue.api;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
 import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +39,6 @@ import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.SegueResourceMisuseException;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
-import uk.ac.cam.cl.dtg.segue.api.managers.UserBadgeManager;
 import uk.ac.cam.cl.dtg.segue.api.monitors.AnonQuestionAttemptMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.IMisuseMonitor;
 import uk.ac.cam.cl.dtg.segue.api.monitors.IPQuestionAttemptMisuseHandler;
@@ -67,6 +53,18 @@ import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 import uk.ac.cam.cl.dtg.util.RequestIPExtractor;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
@@ -87,10 +85,8 @@ public class QuestionFacade extends AbstractSegueFacade {
 
     private final ContentMapper mapper;
     private final GitContentManager contentManager;
-    private final String contentIndex;
     private final UserAccountManager userManager;
     private final QuestionManager questionManager;
-    private final UserBadgeManager userBadgeManager;
     private final UserAssociationManager userAssociationManager;
     private IMisuseMonitor misuseMonitor;
     private IUserStreaksManager userStreaksManager;
@@ -114,10 +110,9 @@ public class QuestionFacade extends AbstractSegueFacade {
      */
     @Inject
     public QuestionFacade(final AbstractConfigLoader properties, final ContentMapper mapper,
-                          final GitContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex, final UserAccountManager userManager,
+                          final GitContentManager contentManager, final UserAccountManager userManager,
                           final QuestionManager questionManager,
                           final ILogManager logManager, final IMisuseMonitor misuseMonitor,
-                          final UserBadgeManager userBadgeManager,
                           final IUserStreaksManager userStreaksManager,
                           final UserAssociationManager userAssociationManager) {
         super(properties, logManager);
@@ -125,11 +120,9 @@ public class QuestionFacade extends AbstractSegueFacade {
         this.questionManager = questionManager;
         this.mapper = mapper;
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
         this.userManager = userManager;
         this.misuseMonitor = misuseMonitor;
         this.userStreaksManager = userStreaksManager;
-        this.userBadgeManager = userBadgeManager;
         this.userAssociationManager = userAssociationManager;
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueContentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/SegueContentFacade.java
@@ -22,13 +22,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.api.services.ContentService;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
-import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
-import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
-import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import jakarta.annotation.Nullable;
 import jakarta.ws.rs.GET;
@@ -40,11 +41,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
-
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
@@ -62,7 +60,6 @@ public class SegueContentFacade extends AbstractSegueFacade {
     private static final Logger log = LoggerFactory.getLogger(SegueContentFacade.class);
 
     private final GitContentManager contentManager;
-    private final String contentIndex;
     private final ContentService contentService;
 
     /**
@@ -76,20 +73,16 @@ public class SegueContentFacade extends AbstractSegueFacade {
      */
     @Inject
     public SegueContentFacade(final AbstractConfigLoader properties, final GitContentManager contentManager,
-                              @Named(CONTENT_INDEX) final String contentIndex,
                               final ILogManager logManager, final ContentService contentService) {
         super(properties, logManager);
 
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
         this.contentService = contentService;
     }
 
     /**
      * This method will return a ResultsWrapper<ContentDTO> based on the parameters supplied.
-     * 
-     * @param version
-     *            - the version of the content to search. If null it will default to the current live version.
+     *
      * @param fieldsToMatch
      *            - List of Boolean search clauses that must be true for the returned content.
      * @param startIndex
@@ -98,22 +91,19 @@ public class SegueContentFacade extends AbstractSegueFacade {
      *            - the max number of results to return.
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
-    public final ResultsWrapper<ContentDTO> findMatchingContent(final String version,
-            final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
+    public final ResultsWrapper<ContentDTO> findMatchingContent(final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
             @Nullable final Integer startIndex, @Nullable final Integer limit) throws ContentManagerException {
 
-        return contentService.findMatchingContent(version, fieldsToMatch, startIndex, limit);
+        return contentService.findMatchingContent(fieldsToMatch, startIndex, limit);
     }
 
     /**
      * This method will return a ResultsWrapper<ContentDTO> based on the parameters supplied. Providing the results in a
      * randomised order.
-     * 
-     * This method is the same as {@link #findMatchingContentRandomOrder(String, List, Integer, Integer, Long)} but uses
+     *
+     * This method is the same as {@link #findMatchingContentRandomOrder(List, Integer, Integer, Long)} but uses
      * a default random seed.
-     * 
-     * @param version
-     *            - the version of the content to search. If null it will default to the current live version.
+     *
      * @param fieldsToMatch
      *            - List of Boolean search clauses that must be true for the returned content.
      * @param startIndex
@@ -123,17 +113,15 @@ public class SegueContentFacade extends AbstractSegueFacade {
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
     public final ResultsWrapper<ContentDTO> findMatchingContentRandomOrder(
-            @Nullable final String version, final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
+            final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
             final Integer startIndex, final Integer limit) {
-        return this.findMatchingContentRandomOrder(version, fieldsToMatch, startIndex, limit, null);
+        return this.findMatchingContentRandomOrder(fieldsToMatch, startIndex, limit, null);
     }
 
     /**
      * This method will return a ResultsWrapper<ContentDTO> based on the parameters supplied. Providing the results in a
      * randomised order.
-     * 
-     * @param version
-     *            - the version of the content to search. If null it will default to the current live version.
+     *
      * @param fieldsToMatch
      *            - List of Boolean search clauses that must be true for the returned content.
      * @param startIndex
@@ -145,15 +133,11 @@ public class SegueContentFacade extends AbstractSegueFacade {
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
     public final ResultsWrapper<ContentDTO> findMatchingContentRandomOrder(
-            @Nullable final String version, final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
+            final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
             final Integer startIndex, final Integer limit, final Long randomSeed) {
 
-        String newVersion = this.contentIndex;
         Integer newLimit = DEFAULT_RESULTS_LIMIT;
         Integer newStartIndex = 0;
-        if (version != null) {
-            newVersion = version;
-        }
         if (limit != null) {
             newLimit = limit;
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/NotificationPicker.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/NotificationPicker.java
@@ -18,13 +18,6 @@ package uk.ac.cam.cl.dtg.segue.api.managers;
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
-import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.api.Constants.BooleanOperator;
-import uk.ac.cam.cl.dtg.segue.dao.ResourceNotFoundException;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
-import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.isaac.dos.IUserNotification;
 import uk.ac.cam.cl.dtg.isaac.dos.IUserNotification.NotificationStatus;
 import uk.ac.cam.cl.dtg.isaac.dos.IUserNotifications;
@@ -33,6 +26,10 @@ import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.NotificationDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.segue.dao.ResourceNotFoundException;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -40,8 +37,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * This class is responsible for selecting notifications from various sources so that users can be told about them.
@@ -50,7 +46,6 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
 public class NotificationPicker {
     private IUserNotifications notifications;
     private final GitContentManager contentManager;
-    private final String contentIndex;
 
     /**
      * @param contentManager
@@ -59,10 +54,8 @@ public class NotificationPicker {
      *            - the DAO allowing the recording of which notifications have been shown to whom.
      */
     @Inject
-    public NotificationPicker(final GitContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex,
-                              final PgUserNotifications notifications) {
+    public NotificationPicker(final GitContentManager contentManager, final PgUserNotifications notifications) {
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
         this.notifications = notifications;
     }
 
@@ -92,7 +85,7 @@ public class NotificationPicker {
         List<ContentDTO> resultsToReturn = Lists.newArrayList();
 
         for (ContentDTO c : allContentNotifications.getResults()) {
-        	IUserNotification record = listOfRecordedNotifications.get(c.getId());
+            IUserNotification record = listOfRecordedNotifications.get(c.getId());
             if (!(c instanceof NotificationDTO)) {
                 // skip if not a notification somehow.
                 continue;
@@ -117,7 +110,7 @@ public class NotificationPicker {
                 // or they have but they postponed it...
                 Calendar postPoneExpiry = Calendar.getInstance();
                 postPoneExpiry.setTime(record.getCreated());
-                postPoneExpiry.add(Calendar.SECOND, Constants.NUMBER_SECONDS_IN_ONE_DAY);
+                postPoneExpiry.add(Calendar.SECOND, NUMBER_SECONDS_IN_ONE_DAY);
 
                 if (new Date().after(postPoneExpiry.getTime())) {
                     resultsToReturn.add(c);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -87,7 +87,6 @@ public class StatisticsManager implements IStatisticsManager {
     private ILogManager logManager;
     private SchoolListReader schoolManager;
     private final GitContentManager contentManager;
-    private final String contentIndex;
     private GroupManager groupManager;
     private QuestionManager questionManager;
     private ContentSummarizerService contentSummarizerService;
@@ -128,7 +127,6 @@ public class StatisticsManager implements IStatisticsManager {
     @Inject
     public StatisticsManager(final UserAccountManager userManager, final ILogManager logManager,
                              final SchoolListReader schoolManager, final GitContentManager contentManager,
-                             @Named(CONTENT_INDEX) final String contentIndex,
                              final LocationManager locationHistoryManager, final GroupManager groupManager,
                              final QuestionManager questionManager, final ContentSummarizerService contentSummarizerService,
                              final IUserStreaksManager userStreaksManager) {
@@ -137,7 +135,6 @@ public class StatisticsManager implements IStatisticsManager {
         this.schoolManager = schoolManager;
 
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
 
         this.locationHistoryManager = locationHistoryManager;
         this.groupManager = groupManager;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserBadgeManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserBadgeManager.java
@@ -3,25 +3,22 @@ package uk.ac.cam.cl.dtg.segue.api.managers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import uk.ac.cam.cl.dtg.isaac.api.managers.AssignmentManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.EventBookingManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
+import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
+import uk.ac.cam.cl.dtg.isaac.dos.UserBadge;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.segue.dao.userBadges.IUserBadgePersistenceManager;
+import uk.ac.cam.cl.dtg.segue.dao.userBadges.IUserBadgePolicy;
 import uk.ac.cam.cl.dtg.segue.dao.userBadges.teacherBadges.TeacherAssignmentsBadgePolicy;
 import uk.ac.cam.cl.dtg.segue.dao.userBadges.teacherBadges.TeacherCpdBadgePolicy;
 import uk.ac.cam.cl.dtg.segue.dao.userBadges.teacherBadges.TeacherGameboardsBadgePolicy;
 import uk.ac.cam.cl.dtg.segue.dao.userBadges.teacherBadges.TeacherGroupsBadgePolicy;
-import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
-import uk.ac.cam.cl.dtg.isaac.dos.UserBadge;
-import uk.ac.cam.cl.dtg.segue.dao.userBadges.IUserBadgePolicy;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 
 import java.util.Map;
-
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
 
 /**
  * Management layer for updating and retrieving badge states
@@ -51,13 +48,11 @@ public class UserBadgeManager {
      * @param assignmentManager assignment manager object for badge policy dependencies
      * @param gameManager game manager object for badge policy dependencies
      * @param contentManager content manager object for badge policy dependencies
-     * @param contentIndex specifies content version
      */
     @Inject
     public UserBadgeManager(IUserBadgePersistenceManager userBadgePersistenceManager, GroupManager groupManager,
                             EventBookingManager bookingManager, AssignmentManager assignmentManager, GameManager gameManager,
-                            GitContentManager contentManager, @Named(CONTENT_INDEX) String contentIndex,
-                            ITransactionManager transactionManager) {
+                            GitContentManager contentManager, ITransactionManager transactionManager) {
 
         this.userBadgePersistenceManager = userBadgePersistenceManager;
         this.transactionManager = transactionManager;
@@ -66,7 +61,7 @@ public class UserBadgeManager {
         badgePolicies.put(Badge.TEACHER_ASSIGNMENTS_SET, new TeacherAssignmentsBadgePolicy(assignmentManager, gameManager));
         badgePolicies.put(Badge.TEACHER_GAMEBOARDS_CREATED, new TeacherGameboardsBadgePolicy(gameManager));
         badgePolicies.put(Badge.TEACHER_CPD_EVENTS_ATTENDED,
-                new TeacherCpdBadgePolicy(bookingManager, contentManager, contentIndex));
+                new TeacherCpdBadgePolicy(bookingManager, contentManager));
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserBadgeManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserBadgeManager.java
@@ -58,7 +58,7 @@ public class UserBadgeManager {
         this.transactionManager = transactionManager;
 
         badgePolicies.put(Badge.TEACHER_GROUPS_CREATED, new TeacherGroupsBadgePolicy(groupManager));
-        badgePolicies.put(Badge.TEACHER_ASSIGNMENTS_SET, new TeacherAssignmentsBadgePolicy(assignmentManager, gameManager));
+        badgePolicies.put(Badge.TEACHER_ASSIGNMENTS_SET, new TeacherAssignmentsBadgePolicy(assignmentManager));
         badgePolicies.put(Badge.TEACHER_GAMEBOARDS_CREATED, new TeacherGameboardsBadgePolicy(gameManager));
         badgePolicies.put(Badge.TEACHER_CPD_EVENTS_ATTENDED,
                 new TeacherCpdBadgePolicy(bookingManager, contentManager));

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
@@ -17,53 +17,42 @@ package uk.ac.cam.cl.dtg.segue.api.services;
 
 import com.google.api.client.util.Lists;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
+import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
-import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
-import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.ID_FIELDNAME;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.NESTED_QUERY_FIELDS;
-import static uk.ac.cam.cl.dtg.segue.api.Constants.TYPE_FIELDNAME;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 public class ContentService {
     private final GitContentManager contentManager;
-    private final String contentIndex;
 
     @Inject
-    public ContentService(final GitContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex) {
+    public ContentService(final GitContentManager contentManager) {
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
     }
 
     /**
      * This method will return a ResultsWrapper<ContentDTO> based on the parameters supplied.
      *
-     * @param version       - the version of the content to search. If null it will default to the current live version.
      * @param fieldsToMatch - List of Boolean search clauses that must be true for the returned content.
      * @param startIndex    - the start index for the search results.
      * @param limit         - the max number of results to return.
      * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
      */
     public final ResultsWrapper<ContentDTO> findMatchingContent(
-            final String version, final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
+            final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
             @Nullable final Integer startIndex, @Nullable final Integer limit
     ) throws ContentManagerException {
 
-        String newVersion = this.contentIndex;
         Integer newLimit = Constants.DEFAULT_RESULTS_LIMIT;
         Integer newStartIndex = 0;
 
-        if (version != null) {
-            newVersion = version;
-        }
         if (limit != null) {
             newLimit = limit;
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -1027,13 +1027,13 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Inject
     private static StatisticsManager getStatsManager(final UserAccountManager userManager,
                                                      final ILogManager logManager, final SchoolListReader schoolManager,
-                                                     final GitContentManager contentManager, @Named(CONTENT_INDEX) final String contentIndex, final LocationManager locationHistoryManager,
+                                                     final GitContentManager contentManager, final LocationManager locationHistoryManager,
                                                      final GroupManager groupManager, final QuestionManager questionManager,
                                                      final ContentSummarizerService contentSummarizerService,
                                                      final IUserStreaksManager userStreaksManager) {
 
         if (null == statsManager) {
-            statsManager = new StatisticsManager(userManager, logManager, schoolManager, contentManager, contentIndex,
+            statsManager = new StatisticsManager(userManager, logManager, schoolManager, contentManager,
                     locationHistoryManager, groupManager, questionManager, contentSummarizerService, userStreaksManager);
             log.info("Created Singleton of Statistics Manager");
         }
@@ -1227,10 +1227,10 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Singleton
     private static GameboardPersistenceManager getGameboardPersistenceManager(final PostgresSqlDb database,
                                                                               final GitContentManager contentManager, final MapperFacade mapper, final ObjectMapper objectMapper,
-                                                                              final URIManager uriManager, @Named(CONTENT_INDEX) final String contentIndex) {
+                                                                              final URIManager uriManager) {
         if (null == gameboardPersistenceManager) {
             gameboardPersistenceManager = new GameboardPersistenceManager(database, contentManager, mapper,
-                    objectMapper, uriManager, contentIndex);
+                    objectMapper, uriManager);
             log.info("Creating Singleton of GameboardPersistenceManager");
         }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/userBadges/teacherBadges/TeacherAssignmentsBadgePolicy.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/userBadges/teacherBadges/TeacherAssignmentsBadgePolicy.java
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import uk.ac.cam.cl.dtg.isaac.api.managers.AssignmentManager;
-import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
+import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
 import uk.ac.cam.cl.dtg.isaac.dto.AssignmentDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.userBadges.IUserBadgePolicy;
-import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 
 import java.util.Iterator;
 
@@ -19,12 +18,9 @@ import java.util.Iterator;
 public class TeacherAssignmentsBadgePolicy implements IUserBadgePolicy {
 
     protected final AssignmentManager assignmentManager;
-    protected final GameManager gameManager;
 
-    public TeacherAssignmentsBadgePolicy(AssignmentManager assignmentManager,
-                                         GameManager gameManager) {
+    public TeacherAssignmentsBadgePolicy(AssignmentManager assignmentManager) {
         this.assignmentManager = assignmentManager;
-        this.gameManager = gameManager;
     }
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/userBadges/teacherBadges/TeacherCpdBadgePolicy.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/userBadges/teacherBadges/TeacherCpdBadgePolicy.java
@@ -4,15 +4,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import uk.ac.cam.cl.dtg.isaac.api.managers.EventBookingManager;
+import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
 import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.BookingStatus;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.segue.dao.userBadges.IUserBadgePolicy;
-import uk.ac.cam.cl.dtg.isaac.dos.ITransaction;
-import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -24,14 +24,11 @@ public class TeacherCpdBadgePolicy implements IUserBadgePolicy {
 
     private final EventBookingManager bookingManager;
     private final GitContentManager contentManager;
-    private final String contentIndex;
 
     public TeacherCpdBadgePolicy(EventBookingManager bookingManager,
-                                 GitContentManager contentManager,
-                                 String contentIndex) {
+                                 GitContentManager contentManager) {
         this.bookingManager = bookingManager;
         this.contentManager = contentManager;
-        this.contentIndex = contentIndex;
     }
 
     @Override

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
@@ -39,7 +39,7 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
     @BeforeEach
     public void setUp() {
         // Get an instance of the facade to test
-        eventsFacade = new EventsFacade(properties, logManager, eventBookingManager, userAccountManager, contentManager, "latest", userBadgeManager, userAssociationManager, groupManager, userAccountManager, schoolListReader, mapperFacade);
+        eventsFacade = new EventsFacade(properties, logManager, eventBookingManager, userAccountManager, contentManager, userBadgeManager, userAssociationManager, groupManager, userAccountManager, schoolListReader, mapperFacade);
     }
 
     @Test

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/GroupsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/GroupsFacadeIT.java
@@ -54,7 +54,7 @@ public class GroupsFacadeIT extends IsaacIntegrationTest {
     @BeforeEach
     public void setUp() throws Exception {
         // get an instance of the facade to test
-        this.groupsFacade = new GroupsFacade(properties, userAccountManager, logManager, assignmentManager, gameManager,
+        this.groupsFacade = new GroupsFacade(properties, userAccountManager, logManager, assignmentManager,
              groupManager, userAssociationManager, userBadgeManager, misuseMonitor);
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacControllerIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacControllerIT.java
@@ -52,7 +52,7 @@ public class IsaacControllerIT extends IsaacIntegrationTest {
     @BeforeEach
     public void setUp() {
         this.isaacControllerFacade = new IsaacController(properties, logManager, createNiceMock(StatisticsManager.class),
-                userAccountManager, contentManager, userAssociationManager, "latest",
+                userAccountManager, contentManager, userAssociationManager,
                 createNiceMock(IUserStreaksManager.class), userBadgeManager, contentSummarizerService);
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
@@ -320,8 +320,8 @@ public abstract class IsaacIntegrationTest {
         PgUserGroupPersistenceManager pgUserGroupPersistenceManager = new PgUserGroupPersistenceManager(postgresSqlDb);
         IAssignmentPersistenceManager assignmentPersistenceManager = new PgAssignmentPersistenceManager(postgresSqlDb, mapperFacade);
 
-        GameboardPersistenceManager gameboardPersistenceManager = new GameboardPersistenceManager(postgresSqlDb, contentManager, mapperFacade, objectMapper, new URIManager(properties), "latest");
-        gameManager = new GameManager(contentManager, gameboardPersistenceManager, mapperFacade, questionManager, "latest");
+        GameboardPersistenceManager gameboardPersistenceManager = new GameboardPersistenceManager(postgresSqlDb, contentManager, mapperFacade, objectMapper, new URIManager(properties));
+        gameManager = new GameManager(contentManager, gameboardPersistenceManager, mapperFacade, questionManager);
         groupManager = new GroupManager(pgUserGroupPersistenceManager, userAccountManager, gameManager, mapperFacade);
         userAssociationManager = new UserAssociationManager(pgAssociationDataManager, userAccountManager, groupManager);
         PgTransactionManager pgTransactionManager = new PgTransactionManager(postgresSqlDb);
@@ -331,7 +331,7 @@ public abstract class IsaacIntegrationTest {
         assignmentManager = new AssignmentManager(assignmentPersistenceManager, groupManager, new EmailService(properties, emailManager, groupManager, userAccountManager, mailGunEmailManager), gameManager, properties);
         schoolListReader = createNiceMock(SchoolListReader.class);
 
-        quizManager = new QuizManager(properties, new ContentService(contentManager, "latest"), contentManager, new ContentSummarizerService(mapperFacade, new URIManager(properties)), contentMapper);
+        quizManager = new QuizManager(properties, new ContentService(contentManager), contentManager, new ContentSummarizerService(mapperFacade, new URIManager(properties)), contentMapper);
         quizAssignmentPersistenceManager =  new PgQuizAssignmentPersistenceManager(postgresSqlDb, mapperFacade);
         quizAssignmentManager = new QuizAssignmentManager(quizAssignmentPersistenceManager, new EmailService(properties, emailManager, groupManager, userAccountManager, mailGunEmailManager), quizManager, groupManager, properties);
         assignmentService = new AssignmentService(userAccountManager);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
@@ -52,9 +52,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
     @BeforeEach
     public void setUp() {
-        this.pagesFacade = new PagesFacade(new ContentService(contentManager, "latest"), properties, logManager,
-                mapperFacade, contentManager, userAccountManager, new URIManager(properties), questionManager, gameManager,
-                "latest");
+        this.pagesFacade = new PagesFacade(new ContentService(contentManager), properties, logManager,
+                mapperFacade, contentManager, userAccountManager, new URIManager(properties), questionManager, gameManager);
     }
 
     @Test

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuestionFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuestionFacadeTest.java
@@ -21,17 +21,16 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import uk.ac.cam.cl.dtg.isaac.dos.IUserStreaksManager;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.api.QuestionFacade;
 import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
-import uk.ac.cam.cl.dtg.segue.api.managers.UserBadgeManager;
 import uk.ac.cam.cl.dtg.segue.api.monitors.IMisuseMonitor;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
-import uk.ac.cam.cl.dtg.isaac.dos.IUserStreaksManager;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import jakarta.ws.rs.core.EntityTag;
@@ -69,14 +68,13 @@ public class QuestionFacadeTest extends AbstractFacadeTest {
 
         String contentIndex = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
         IMisuseMonitor misuseMonitor = createMock(IMisuseMonitor.class);
-        UserBadgeManager userBadgeManager = createMock(UserBadgeManager.class);
         IUserStreaksManager userStreaksManager = createMock(IUserStreaksManager.class);
         UserAssociationManager userAssociationManager = createMock(UserAssociationManager.class);
 
         questionManager = createMock(QuestionManager.class);
 
-        questionFacade = new QuestionFacade(properties, contentMapper, contentManager, contentIndex,
-            userManager, questionManager, logManager, misuseMonitor, userBadgeManager, userStreaksManager, userAssociationManager);
+        questionFacade = new QuestionFacade(properties, contentMapper, contentManager,
+            userManager, questionManager, logManager, misuseMonitor, userStreaksManager, userAssociationManager);
 
         expect(contentManager.getCurrentContentSHA()).andStubReturn(contentIndex);
         expect(contentManager.getContentDOById(questionDO.getId())).andStubReturn(questionDO);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SignupFlowIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SignupFlowIT.java
@@ -75,7 +75,7 @@ public class SignupFlowIT extends IsaacIntegrationTest {
         // Arrange
         // create instance of groups facade
         GroupsFacade groupsFacade = new GroupsFacade(properties, userAccountManager, logManager, assignmentManager,
-                gameManager, groupManager, userAssociationManager, userBadgeManager, misuseMonitor);
+                groupManager, userAssociationManager, userBadgeManager, misuseMonitor);
 
         // log in as unverified teacher
         LoginResult caveatTeacherLogin = loginAs(httpSession, TEST_UNVERIFIED_CAVEAT_EMAIL,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManagerTest.java
@@ -73,8 +73,7 @@ public class GameManagerTest {
                 this.dummyContentManager,
                 this.dummyGameboardPersistenceManager,
                 this.dummyMapper,
-                this.dummyQuestionManager,
-                "latest"
+                this.dummyQuestionManager
         );
 
         // configure the mock GitContentManager to record the filters that are sent to it by getNextQuestionsForFilter()


### PR DESCRIPTION
We used to use this for the current content SHA, but we have not done so in a long time. Now it is merely `"live"` or `"latest"` - but only the ES related classes (`AdminFacade` and `GitContentManager`) should know what the content version is.
Using it elsewhere is likely to lead to bugs; as in `IsaacController` where it was used in a caching header despite the fact it never changes when content versions change.