### PR TITLE
Update dependencies and remove unused

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -6,7 +6,7 @@ COPY . /isaac-api
 RUN mvn package -Dmaven.test.skip=true
 
 # create clean jetty docker container
-FROM jetty:11.0.16-jdk11-eclipse-temurin as server
+FROM jetty:11.0.20-jdk11-eclipse-temurin as server
 USER root
 COPY --from=target /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-api.war
 RUN chmod 755 /var/lib/jetty/webapps/*

--- a/Dockerfile-etl
+++ b/Dockerfile-etl
@@ -6,7 +6,7 @@ COPY . /isaac-api
 RUN mvn package -Dmaven.test.skip=true -P etl
 
 # create clean jetty docker container
-FROM jetty:11.0.16-jdk11-eclipse-temurin as server
+FROM jetty:11.0.20-jdk11-eclipse-temurin as server
 USER root
 COPY --from=target /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-api.war
 RUN chmod 755 /var/lib/jetty/webapps/*

--- a/pom.xml
+++ b/pom.xml
@@ -11,25 +11,24 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <segue.version>v3.13.1-SNAPSHOT</segue.version>
-        <log4j.version>2.20.0</log4j.version>
-        <resteasy.version>6.2.5.Final</resteasy.version>
-        <guice.version>5.1.0</guice.version>
+        <log4j.version>2.22.1</log4j.version>
+        <resteasy.version>6.2.7.Final</resteasy.version>
+        <guice.version>7.0.0</guice.version>
         <oauth-client.version>1.34.1</oauth-client.version>
-        <jackson.version>2.15.3</jackson.version>
-        <jackson-databind.version>2.15.2</jackson-databind.version>
+        <jackson.version>2.16.1</jackson.version>
+        <jackson-databind.version>2.16.1</jackson-databind.version>
         <powermock.version>2.0.9</powermock.version>
         <junit-4.version>4.13.2</junit-4.version>
         <junit-5.version>5.9.3</junit-5.version>
         <swagger-ui-version>4.13.2</swagger-ui-version>
         <prometheus.version>0.8.0</prometheus.version>
-        <jetty-version>11.0.18</jetty-version>
+        <jetty-version>11.0.20</jetty-version>
         <jetty.port.api>8080</jetty.port.api>
         <jetty.port.etl>8090</jetty.port.etl>
         <testcontainers.version>1.17.3</testcontainers.version>
         <web.xml>web-api-live.xml</web.xml>
         <web.xml.etl>web-etl.xml</web.xml.etl>
         <web.xml.local>web-api-local.xml</web.xml.local>
-        <netty.version>4.1.100.Final</netty.version>
         <dependency-check.version>7.1.0</dependency-check.version>
         <ossindex.version>3.2.0</ossindex.version>
         <surefire.jacoco.args />
@@ -68,7 +67,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
+            <version>6.1.0-M1</version>
         </dependency>
 
         <dependency>
@@ -124,12 +123,12 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>6.7.0.202309050840-r</version>
+            <version>6.8.0.202311291450-r</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
-            <version>6.7.0.202309050840-r</version>
+            <version>6.8.0.202311291450-r</version>
         </dependency>
 
         <dependency>
@@ -141,7 +140,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.1.3-jre</version>
+            <version>33.0.0-jre</version>
         </dependency>
 
         <dependency>
@@ -164,7 +163,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
-            <version>1.43.3</version>
+            <version>1.44.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.apis</groupId>
@@ -193,12 +192,12 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-jaxrs2-jakarta</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.20</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations-jakarta</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.20</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -259,7 +258,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -273,7 +272,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
         </dependency>
 
@@ -306,7 +305,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.13.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -316,12 +315,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.10.0</version>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.7</version>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
@@ -363,19 +362,19 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.5.1</version>
+            <version>42.7.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.9.0</version>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.11.1</version>
+            <version>2.12.7</version>
         </dependency>
 
         <dependency>
@@ -387,23 +386,23 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.7.1</version>
+            <version>5.9</version>
         </dependency>
         <dependency>
             <groupId>net.sf.biweekly</groupId>
             <artifactId>biweekly</artifactId>
-            <version>0.6.6</version>
+            <version>0.6.8</version>
         </dependency>
 
         <dependency>
             <groupId>com.mailjet</groupId>
             <artifactId>mailjet-client</artifactId>
-            <version>5.2.4</version>
+            <version>5.2.5</version>
         </dependency>
         <dependency>
             <groupId>com.mailgun</groupId>
             <artifactId>mailgun-java</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -427,7 +426,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>2.1.0</version>
+            <version>3.0.0-M1</version>
         </dependency>
 
         <!-- Graph checker code -->
@@ -446,13 +445,13 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.76</version>
+            <version>1.77</version>
         </dependency>
 
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.0</version>
         </dependency>
 
         <!-- These two don't need to be included in the war package so their scope is "provided" which means we
@@ -469,13 +468,6 @@
             <artifactId>ossindex-maven-plugin</artifactId>
             <version>${ossindex.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>${netty.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 
@@ -623,7 +615,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.11</version>
                 <executions>
                     <execution>
                         <id>before-unit-test-execution</id>
@@ -713,23 +705,6 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
                 <version>3.8.6</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>2.10.1</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.http-client</groupId>
-                <artifactId>google-http-client-gson</artifactId>
-                <version>1.43.3</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>3.14.9</version>
             </dependency>
 
             <dependency>

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/MailGunEmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/MailGunEmailManager.java
@@ -35,7 +35,6 @@ import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -48,8 +47,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
-import static com.mailgun.util.Constants.EU_BASE_URL;
+import static com.mailgun.util.Constants.EU_REGION_BASE_URL;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.monitors.SegueMetrics.QUEUED_EMAIL;
 
@@ -75,7 +75,7 @@ public class MailGunEmailManager {
         if (null == this.mailgunMessagesApi) {
             log.info("Creating singleton MailgunMessagesApi object.");
             this.mailgunMessagesApi = MailgunClient
-                    .config(EU_BASE_URL, globalProperties.getProperty(MAILGUN_SECRET_KEY))
+                    .config(EU_REGION_BASE_URL, globalProperties.getProperty(MAILGUN_SECRET_KEY))
                     .logLevel(feign.Logger.Level.NONE)
                     .createApi(MailgunMessagesApi.class);
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
@@ -15,6 +15,25 @@
  */
 package uk.ac.cam.cl.dtg.util.locations;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.Lists;
+import com.google.api.client.util.Maps;
+import com.google.inject.Inject;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.dos.LocationHistory;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+
+import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -23,28 +42,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import io.netty.handler.codec.http.HttpResponseStatus;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.util.EntityUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.isaac.dos.LocationHistory;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.util.Lists;
-import com.google.api.client.util.Maps;
-import com.google.inject.Inject;
 
 /**
  * Class to allow postcode-related searches using external service.
@@ -240,7 +237,7 @@ public class PostCodeIOLocationResolver implements PostCodeLocationResolver {
 
         List<PostCode> returnList = Lists.newArrayList();
         int responseCode = (int) response.get("status");
-        if (responseCode == HttpResponseStatus.OK.code()) {
+        if (responseCode == Response.Status.OK.getStatusCode()) {
             ArrayList<HashMap<String, Object>> responseResult = (ArrayList<HashMap<String, Object>>) response
                     .get("result");
 


### PR DESCRIPTION
Notable changes:
 - Removed Netty, since it was used in one place and even then it was not clear why.
 - Upgraded slf4j a major version, which involved upgrading the log4j provider to slf4j2, but fully backwards compatible.
 - MailGun made a breaking change in a minor version, but simple to fix.