### PR TITLE
Enable paginated news pods

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -118,7 +118,7 @@ public final class Constants {
 
     public static final String ALL_BOARDS = "ALL";
     public static final Integer DEFAULT_GAMEBOARDS_RESULTS_LIMIT = 6;
-    public static final Integer MAX_PODS_TO_RETURN = 10;
+    public static final Integer MAX_PODS_TO_RETURN = 12;
     public static final Integer SEARCH_MAX_WINDOW_SIZE = 10000;
     public static final Integer GAMEBOARD_MAX_TITLE_LENGTH = 255;
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/services/ContentService.java
@@ -49,6 +49,23 @@ public class ContentService {
             final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
             @Nullable final Integer startIndex, @Nullable final Integer limit
     ) throws ContentManagerException {
+        return findMatchingContent(fieldsToMatch, startIndex, limit, null);
+    }
+
+    /**
+     * This method will return a ResultsWrapper<ContentDTO> based on the parameters supplied.
+     *
+     * @param fieldsToMatch    - List of Boolean search clauses that must be true for the returned content.
+     * @param startIndex       - the start index for the search results.
+     * @param limit            - the max number of results to return.
+     * @param sortInstructions - Map of sorting functions to use in ElasticSearch query
+     * @return Response containing a ResultsWrapper<ContentDTO> or a Response containing null if none found.
+     */
+    public final ResultsWrapper<ContentDTO> findMatchingContent(
+            final List<GitContentManager.BooleanSearchClause> fieldsToMatch,
+            @Nullable final Integer startIndex, @Nullable final Integer limit,
+            @Nullable Map<String, Constants.SortOrder> sortInstructions
+    ) throws ContentManagerException {
 
         Integer newLimit = Constants.DEFAULT_RESULTS_LIMIT;
         Integer newStartIndex = 0;
@@ -60,7 +77,7 @@ public class ContentService {
             newStartIndex = startIndex;
         }
 
-        return this.contentManager.findByFieldNames(fieldsToMatch, newStartIndex, newLimit);
+        return this.contentManager.findByFieldNames(fieldsToMatch, newStartIndex, newLimit, sortInstructions);
     }
 
     /**


### PR DESCRIPTION
- Sorts pods by ID rather than title, so they are returned in date-order (most recent first);
- Added a new endpoint to enable requests for pods starting from a given index under this sorting;
- Return 12 pods at once (displays more nicely on 1- (mobile), 2- (tablet), 3- (phy) and 4- (ada)-card-width pages).
