### PR TITLE
Add ability for student self-removal from groups

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserGroup.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/UserGroup.java
@@ -32,6 +32,7 @@ public class UserGroup {
     private boolean archived;
     private boolean additionalManagerPrivileges;
     private Date lastUpdated;
+    private boolean selfRemoval;
 
     /**
      * Default Constructor.
@@ -53,7 +54,7 @@ public class UserGroup {
      *            - date created.
      */
     public UserGroup(@Nullable final Long id, final String groupName, final Long ownerId, final GroupStatus status, final Date created,
-                     final boolean archived, final boolean additionalManagerPrivileges, final Date lastUpdated) {
+                     final boolean archived, final boolean additionalManagerPrivileges, final Date lastUpdated, final boolean selfRemoval) {
         this.id = id;
         this.groupName = groupName;
         this.ownerId = ownerId;
@@ -62,6 +63,7 @@ public class UserGroup {
         this.archived = archived;
         this.additionalManagerPrivileges = additionalManagerPrivileges;
         this.lastUpdated = lastUpdated;
+        this.selfRemoval = selfRemoval;
     }
 
     /**
@@ -226,5 +228,24 @@ public class UserGroup {
      */
     public void setLastUpdated(final Date lastUpdated) {
         this.lastUpdated = lastUpdated;
+    }
+
+    /**
+     * Gets whether students can remove themselves from the group.
+     *
+     * @return whether students can remove themselves from the group
+     */
+    public boolean getSelfRemoval() {
+        return selfRemoval;
+    }
+
+    /**
+     * Sets whether students can remove themselves from the group.
+     *
+     * @param selfRemoval
+     *            the status student self-removal to set
+     */
+    public void setSelfRemoval(final boolean selfRemoval) {
+        this.selfRemoval = selfRemoval;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/UserGroupDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/UserGroupDTO.java
@@ -39,6 +39,7 @@ public class UserGroupDTO {
     private Long ownerId;
     private Date created;
     private Date lastUpdated;
+    private boolean selfRemoval;
     private String token;
     private boolean archived;
     private boolean additionalManagerPrivileges;
@@ -66,12 +67,13 @@ public class UserGroupDTO {
      *            - date created.
      */
     public UserGroupDTO(@Nullable final Long id, final String groupName, final Long ownerId, final Date created, final Date lastUpdated,
-                        final boolean archived) {
+                        final boolean selfRemoval, final boolean archived) {
         this.id = id;
         this.groupName = groupName;
         this.ownerId = ownerId;
         this.created = created;
         this.lastUpdated = lastUpdated;
+        this.selfRemoval = selfRemoval;
         this.archived = archived;
         this.additionalManagers = Sets.newHashSet();
     }
@@ -193,6 +195,25 @@ public class UserGroupDTO {
      */
     public void setLastUpdated(final Date lastUpdated) {
         this.lastUpdated = lastUpdated;
+    }
+
+    /**
+     * Gets whether students can remove themselves from the group.
+     *
+     * @return whether students can remove themselves from the group
+     */
+    public boolean getSelfRemoval() {
+        return selfRemoval;
+    }
+
+    /**
+     * Sets whether students can remove themselves from the group.
+     *
+     * @param selfRemoval
+     *            the status student self-removal to set
+     */
+    public void setSelfRemoval(final boolean selfRemoval) {
+        this.selfRemoval = selfRemoval;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GroupsFacade.java
@@ -545,7 +545,7 @@ public class GroupsFacade extends AbstractSegueFacade {
 
             UserGroupDTO groupBasedOnId = groupManager.getGroupById(groupId);
 
-            if (!GroupManager.hasAdditionalManagerPrivileges(groupBasedOnId, currentRegisteredUser.getId())) {
+            if (!groupBasedOnId.getSelfRemoval() && !GroupManager.hasAdditionalManagerPrivileges(groupBasedOnId, currentRegisteredUser.getId())) {
                 return new SegueErrorResponse(Status.FORBIDDEN, "You are neither the owner of this group, nor an additional manager with additional privileges!").toResponse();
             }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -117,7 +117,7 @@ public class GroupManager {
         Objects.requireNonNull(groupOwner);
 
         Date now = new Date();
-        UserGroup group = new UserGroup(null, groupName, groupOwner.getId(), GroupStatus.ACTIVE, now, false, false, now);
+        UserGroup group = new UserGroup(null, groupName, groupOwner.getId(), GroupStatus.ACTIVE, now, false, false, now, false);
 
         return this.convertGroupToDTO(groupDatabase.createGroup(group));
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUserGroupPersistenceManager.java
@@ -113,7 +113,7 @@ public class PgUserGroupPersistenceManager implements IUserGroupPersistenceManag
             group.setStatus(GroupStatus.ACTIVE);
         }
 
-        String query = "UPDATE groups SET group_name=?, owner_id=?, created=?, archived=?, additional_manager_privileges=?, group_status=?, last_updated=? WHERE id = ?;";
+        String query = "UPDATE groups SET group_name=?, owner_id=?, created=?, archived=?, self_removal=?, additional_manager_privileges=?, group_status=?, last_updated=? WHERE id = ?;";
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement(query);
         ) {
@@ -121,10 +121,11 @@ public class PgUserGroupPersistenceManager implements IUserGroupPersistenceManag
             pst.setLong(2, group.getOwnerId());
             pst.setTimestamp(3, new Timestamp(group.getCreated().getTime()));
             pst.setBoolean(4, group.isArchived());
-            pst.setBoolean(5, group.isAdditionalManagerPrivileges());
-            pst.setString(6, group.getStatus().name());
-            pst.setTimestamp(7, new Timestamp(group.getLastUpdated().getTime()));
-            pst.setLong(8, group.getId());
+            pst.setBoolean(5, group.getSelfRemoval());
+            pst.setBoolean(6, group.isAdditionalManagerPrivileges());
+            pst.setString(7, group.getStatus().name());
+            pst.setTimestamp(8, new Timestamp(group.getLastUpdated().getTime()));
+            pst.setLong(9, group.getId());
             
             if (pst.executeUpdate() == 0) {
                 throw new SegueDatabaseException("Unable to save group.");
@@ -548,7 +549,7 @@ public class PgUserGroupPersistenceManager implements IUserGroupPersistenceManag
         return new UserGroup(set.getLong("id"), set.getString("group_name"), set.getLong("owner_id"),
                 GroupStatus.valueOf(set.getString("group_status")), set.getDate("created"),
                 set.getBoolean("archived"), set.getBoolean("additional_manager_privileges"),
-                set.getDate("last_updated"));
+                set.getDate("last_updated"), set.getBoolean("self_removal"));
     }
 
     private GroupMembership buildMembershipRecord(final ResultSet set) throws SQLException {

--- a/src/main/resources/db_scripts/migrations/2024-04-groups_student_self_removal.sql
+++ b/src/main/resources/db_scripts/migrations/2024-04-groups_student_self_removal.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ONLY public.groups ADD COLUMN self_removal boolean
+    DEFAULT false;

--- a/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
+++ b/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
@@ -186,7 +186,8 @@ CREATE TABLE public.groups (
     archived boolean DEFAULT false NOT NULL,
     group_status text DEFAULT 'ACTIVE'::text,
     last_updated timestamp without time zone,
-    additional_manager_privileges boolean DEFAULT false
+    additional_manager_privileges boolean DEFAULT false,
+    self_removal boolean DEFAULT false
 );
 
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -218,7 +218,7 @@ public class IsaacTest {
 
         studentGroup.setAdditionalManagers(Collections.singleton(secondTeacherSummary));
 
-        studentInactiveGroup = new UserGroupDTO(++id, "studentInactiveGroup", teacher.getId(), somePastDate, somePastDate, false);
+        studentInactiveGroup = new UserGroupDTO(++id, "studentInactiveGroup", teacher.getId(), somePastDate, somePastDate, false, false);
 
         studentGroups = ImmutableList.of(studentGroup.getId(), studentInactiveGroup.getId());
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/GroupsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/GroupsFacadeIT.java
@@ -78,7 +78,7 @@ public class GroupsFacadeIT extends IsaacIntegrationTest {
         replay(createGroupRequest);
 
         UserGroup userGroup = new UserGroup(null, "Test Teacher's New Group", TEST_TEACHER_ID,
-                GroupStatus.ACTIVE, new Date(), false, false, new Date());
+                GroupStatus.ACTIVE, new Date(), false, false, new Date(), false);
 
         // Act
         // make request
@@ -103,7 +103,7 @@ public class GroupsFacadeIT extends IsaacIntegrationTest {
         replay(createGroupRequest);
 
         UserGroup userGroup = new UserGroup(null, "Test Tutor's New Group", TEST_TUTOR_ID,
-                GroupStatus.ACTIVE, new Date(), false, false, new Date());
+                GroupStatus.ACTIVE, new Date(), false, false, new Date(), false);
 
         // Act
         // make request

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SignupFlowIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SignupFlowIT.java
@@ -84,7 +84,7 @@ public class SignupFlowIT extends IsaacIntegrationTest {
         replay(createGroupRequest);
 
         UserGroup userGroup = new UserGroup(null, "Unverified Teacher's Group", TEST_UNVERIFIED_CAVEAT_ID,
-                GroupStatus.ACTIVE, new Date(), false, false, new Date());
+                GroupStatus.ACTIVE, new Date(), false, false, new Date(), false);
 
         // Act
         // make request - this requires a caveat-free login

--- a/src/test/resources/dump-test-database.sh
+++ b/src/test/resources/dump-test-database.sh
@@ -19,6 +19,6 @@ docker exec -it postgres psql -U rutherford -c "TRUNCATE TABLE quartz_cluster.qr
 docker exec -it postgres psql -U rutherford -c "TRUNCATE TABLE quartz_cluster.qrtz_triggers CASCADE"
 
 echo "Dumping test data..."
-docker exec -it postgres pg_dump -U rutherford --data-only > test-postgres-rutherford-data-dump.sql
+docker exec -it postgres pg_dump -U rutherford --data-only > src/test/resources/test-postgres-rutherford-data-dump.sql
 
 echo "... done. Check your test-postgres-rutherford-data-dump.sql for any issues, then commit and push."

--- a/src/test/resources/test-postgres-rutherford-data-dump.sql
+++ b/src/test/resources/test-postgres-rutherford-data-dump.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 12.9 (Debian 12.9-1.pgdg110+1)
--- Dumped by pg_dump version 12.9 (Debian 12.9-1.pgdg110+1)
+-- Dumped from database version 12.16 (Debian 12.16-1.pgdg120+1)
+-- Dumped by pg_dump version 12.16 (Debian 12.16-1.pgdg120+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -55,10 +55,10 @@ COPY public.gameboards (id, title, contents, wildcard, wildcard_position, game_f
 -- Data for Name: groups; Type: TABLE DATA; Schema: public; Owner: rutherford
 --
 
-COPY public.groups (id, group_name, owner_id, created, archived, group_status, last_updated, additional_manager_privileges) FROM stdin;
-1	AB Group (Test)	5	2022-07-06 15:36:58	f	ACTIVE	\N	f
-2	BC Group (Dave)	10	2022-07-06 15:37:32	f	ACTIVE	\N	f
-4	AB Group 2 (Test Tutor)	12	2022-12-12 14:48:40.245	f	ACTIVE	2022-12-12 14:48:40.245	f
+COPY public.groups (id, group_name, owner_id, created, archived, group_status, last_updated, additional_manager_privileges, self_removal) FROM stdin;
+1	AB Group (Test)	5	2022-07-06 15:36:58	f	ACTIVE	\N	f	f
+2	BC Group (Dave)	10	2022-07-06 15:37:32	f	ACTIVE	\N	f	f
+4	AB Group 2 (Test Tutor)	12	2022-12-12 14:48:40.245	f	ACTIVE	2022-12-12 14:48:40.245	f	f
 \.
 
 


### PR DESCRIPTION
Adds `self_removal` as a property of groups.
The removal in the frontend reuses the existing group removal endpoint, but adds a new condition to skip the check for teacher validation if the group permits self-removal. 

**(note -- failing as it requires application of the database migration)**