### PR TITLE
Add a page_id column to question_attempts

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
@@ -164,21 +164,22 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
     public void registerQuestionAttempt(final Long userId, final String questionPageId, final String fullQuestionId,
             final QuestionValidationResponse questionAttempt) throws SegueDatabaseException {
 
-        String query = "INSERT INTO question_attempts(user_id, question_id, question_attempt, correct, \"timestamp\")" +
-                " VALUES (?, ?, ?::text::jsonb, ?, ?);";
+        String query = "INSERT INTO question_attempts(user_id, page_id, question_id, question_attempt, correct, \"timestamp\")"
+                + " VALUES (?, ?, ?, ?::text::jsonb, ?, ?);";
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
         ) {
             pst.setLong(1, userId);
-            pst.setString(2, fullQuestionId);
-            pst.setString(3, objectMapper.writeValueAsString(questionAttempt));
+            pst.setString(2, questionPageId);
+            pst.setString(3, fullQuestionId);
+            pst.setString(4, objectMapper.writeValueAsString(questionAttempt));
 
             if (questionAttempt.isCorrect() != null) {
-                pst.setBoolean(4, questionAttempt.isCorrect());
+                pst.setBoolean(5, questionAttempt.isCorrect());
             } else {
-                pst.setNull(4, java.sql.Types.NULL);
+                pst.setNull(5, java.sql.Types.NULL);
             }
-            pst.setTimestamp(5, new java.sql.Timestamp(questionAttempt.getDateAttempted().getTime()));
+            pst.setTimestamp(6, new java.sql.Timestamp(questionAttempt.getDateAttempted().getTime()));
 
             if (pst.executeUpdate() == 0) {
                 throw new SegueDatabaseException("Unable to save question attempt.");

--- a/src/main/resources/db_scripts/migrations/2024-04-question_attempts_add_page_id.sql
+++ b/src/main/resources/db_scripts/migrations/2024-04-question_attempts_add_page_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE question_attempts ADD COLUMN page_id TEXT;


### PR DESCRIPTION
This prepares the ground for a move to using this column when loading question attempts from the database. We need to record the value for new rows before we can start migrating older rows to include the new column.
Currently the column cannot have a NOT NULL property, but this can be added later once the data is backfilled.