### PR TITLE
Allow page-level types to be deprecated and superseded

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -42,6 +42,7 @@ import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 
@@ -105,11 +106,11 @@ public class GameboardPersistenceManager {
      */
     @Inject
     public GameboardPersistenceManager(final PostgresSqlDb database, final GitContentManager contentManager,
-                                       final MapperFacade mapper, final ObjectMapper objectMapper, final URIManager uriManager) {
+                                       final MapperFacade mapper, final ContentMapper objectMapper, final URIManager uriManager) {
         this.database = database;
         this.mapper = mapper;
         this.contentManager = contentManager;
-        this.objectMapper = objectMapper;
+        this.objectMapper = objectMapper.getSharedContentObjectMapper();;
         this.uriManager = uriManager;
         this.gameboardNonPersistentStorage = CacheBuilder.newBuilder()
                 .expireAfterAccess(GAMEBOARD_TTL_MINUTES, TimeUnit.MINUTES).<String, GameboardDO> build();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
@@ -23,6 +23,7 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ExternalReference;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Image;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dos.content.SeguePage;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
 import uk.ac.cam.cl.dtg.util.locations.Address;
 import uk.ac.cam.cl.dtg.util.locations.Location;
@@ -38,7 +39,7 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
  */
 @DTOMapping(IsaacEventPageDTO.class)
 @JsonContentType("isaacEventPage")
-public class IsaacEventPage extends Content {
+public class IsaacEventPage extends SeguePage {
     private Date date;
     private Date end_date;
     private Date bookingDeadline;
@@ -82,6 +83,7 @@ public class IsaacEventPage extends Content {
                           @JsonProperty("relatedContent") List<String> relatedContent,
                           @JsonProperty("version") boolean published,
                           @JsonProperty("deprecated") Boolean deprecated,
+                          @JsonProperty("supersededBy") String supersededBy,
                           @JsonProperty("tags") Set<String> tags,
                           @JsonProperty("date") Date date, @JsonProperty("end_date") Date end_date,
                           @JsonProperty("bookingDeadline") Date bookingDeadline,
@@ -95,7 +97,7 @@ public class IsaacEventPage extends Content {
                           @JsonProperty("groupReservationLimit") Integer groupReservationLimit,
                           @JsonProperty("allowGroupReservations") Boolean allowGroupReservations) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null,
-                null, relatedContent, published, deprecated, tags, null);
+                null, relatedContent, published, deprecated, supersededBy, tags, null);
 
         this.date = date;
         this.end_date = end_date;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFeaturedProfile.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacFeaturedProfile.java
@@ -53,7 +53,6 @@ public class IsaacFeaturedProfile extends Content {
             @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent,
             @JsonProperty("version") boolean published,
-            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
             @JsonProperty("emailAddress") String emailAddress,
@@ -61,7 +60,7 @@ public class IsaacFeaturedProfile extends Content {
             @JsonProperty("homepage") String homepage) {
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, deprecated, tags, level);
+                relatedContent, published, tags, level);
 
         this.emailAddress = emailAddress;
         this.image = image;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPod.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPod.java
@@ -52,15 +52,13 @@ public class IsaacPod extends Content {
             @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent,
             @JsonProperty("version") boolean published,
-            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
-            @JsonProperty("emailAddress") String emailAddress,
             @JsonProperty("image") Image image,
             @JsonProperty("url") String url) {
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, deprecated, tags, level);
+                relatedContent, published, tags, level);
 
         this.url = url;
         this.image = image;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
@@ -15,17 +15,16 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dos;
 
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuestionPageDTO;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dos.content.SeguePage;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuestionPageDTO;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * IsaacQuestion Page DO.
@@ -35,7 +34,6 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.SeguePage;
 @JsonContentType("isaacQuestionPage")
 public class IsaacQuestionPage extends SeguePage {
     protected Float passMark;
-    protected String supersededBy;
     protected Integer difficulty;
 
     @JsonCreator
@@ -51,10 +49,9 @@ public class IsaacQuestionPage extends SeguePage {
             @JsonProperty("difficulty") Integer difficulty, @JsonProperty("passMark") Float passMark,
             @JsonProperty("supersededBy") String supersededBy) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, deprecated, supersededBy, tags, level);
 
         this.passMark = passMark;
-        this.supersededBy = supersededBy;
         this.difficulty = difficulty;
     }
 
@@ -72,11 +69,11 @@ public class IsaacQuestionPage extends SeguePage {
         this.passMark = passMark;
     }
 
-    public String getSupersededBy() { return supersededBy; }
+    public Integer getDifficulty() {
+        return difficulty;
+    }
 
-    public void setSupersededBy(String supersededBy) { this.supersededBy = supersededBy; }
-
-    public Integer getDifficulty() { return difficulty; }
-
-    public void setDifficulty(Integer difficulty) { this.difficulty = difficulty; }
+    public void setDifficulty(Integer difficulty) {
+        this.difficulty = difficulty;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
@@ -17,12 +17,12 @@ package uk.ac.cam.cl.dtg.isaac.dos;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizDTO;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dos.content.SeguePage;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizDTO;
 
 import java.util.List;
 import java.util.Set;
@@ -54,14 +54,15 @@ public class IsaacQuiz extends SeguePage {
             @JsonProperty("relatedContent") List<String> relatedContent,
             @JsonProperty("version") boolean published,
             @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("supersededBy") String supersededBy,
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
             @JsonProperty("visibleToStudents") boolean visibleToStudents,
             @JsonProperty("hiddenFromRoles") List<String> hiddenFromRoles,
-            @JsonProperty("rubric") Content rubric){
+            @JsonProperty("rubric") Content rubric) {
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, deprecated, tags, level);
+                relatedContent, published, deprecated, supersededBy, tags, level);
 
         this.visibleToStudents = visibleToStudents;
         this.hiddenFromRoles = hiddenFromRoles;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuizSection.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuizSection.java
@@ -17,11 +17,11 @@ package uk.ac.cam.cl.dtg.isaac.dos;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizSectionDTO;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuizSectionDTO;
 
 import java.util.List;
 import java.util.Set;
@@ -42,10 +42,9 @@ public class IsaacQuizSection extends Content {
                             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBase> children,
                             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
                             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") boolean published,
-                            @JsonProperty("deprecated") Boolean deprecated,
                             @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacWildcard.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacWildcard.java
@@ -17,12 +17,11 @@ package uk.ac.cam.cl.dtg.isaac.dos;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacWildcardDTO;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacWildcardDTO;
 
 import java.util.List;
 import java.util.Set;
@@ -44,11 +43,11 @@ public class IsaacWildcard extends Content {
             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBase> children,
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") boolean published,
-            @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("deprecated") Boolean deprecated, // Still needed to read old objects in database, never used.
             @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level,
             @JsonProperty("description") String description, @JsonProperty("url") String url) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
 
         this.description = description;
         this.url = url;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Content.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/Content.java
@@ -48,7 +48,6 @@ public class Content extends ContentBase {
     protected String attribution;
     protected List<String> relatedContent;
     protected Boolean published;
-    protected Boolean deprecated;
     protected Integer level;
     protected String prioritisedSearchableContent;
     protected String searchableContent;
@@ -62,7 +61,7 @@ public class Content extends ContentBase {
             @JsonProperty("children") List<ContentBase> children, @JsonProperty("value") String value,
             @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") Boolean published,
-            @JsonProperty("deprecated") Boolean deprecated, @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level) {
         this.id = id;
         this.title = title;
@@ -76,7 +75,6 @@ public class Content extends ContentBase {
         this.attribution = attribution;
         this.relatedContent = relatedContent;
         this.published = published;
-        this.deprecated = deprecated;
         this.children = children;
         this.tags = tags;
         this.level = level;
@@ -201,14 +199,6 @@ public class Content extends ContentBase {
      */
     public final void setChildren(List<ContentBase> children) {
         this.children = children;
-    }
-
-    public Boolean getDeprecated() {
-        return deprecated;
-    }
-
-    public void setDeprecated(Boolean deprecated) {
-        this.deprecated = deprecated;
     }
 
     public Integer getLevel() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/EmailTemplate.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/EmailTemplate.java
@@ -59,10 +59,10 @@ public class EmailTemplate extends Content {
     public EmailTemplate(final String _id, final String id, final String title, final String subtitle,
             final String type, final String author, final String encoding, final String canonicalSourceFile,
             final String layout, final List<ContentBase> children, final String value, final String attribution,
-            final List<String> relatedContent, final Boolean published, final Boolean deprecated,
+            final List<String> relatedContent, final Boolean published,
                          final Set<String> tags, final Integer level) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
 
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
@@ -15,13 +15,12 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dos.content;
 
-import java.util.List;
-import java.util.Set;
-
-import uk.ac.cam.cl.dtg.isaac.dto.content.SeguePageDTO;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.ac.cam.cl.dtg.isaac.dto.content.SeguePageDTO;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * Segue Page object.
@@ -31,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonContentType("page")
 public class SeguePage extends Content {
     private String summary;
+    private Boolean deprecated;
+    private String supersededBy;
 
     @JsonCreator
     public SeguePage(@JsonProperty("id") String id,
@@ -40,11 +41,15 @@ public class SeguePage extends Content {
             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBase> children,
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") Boolean published,
-            @JsonProperty("deprecated") Boolean deprecated, @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("deprecated") Boolean deprecated, @JsonProperty("supersededBy") String supersededBy,
+            @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
+
+        this.deprecated = deprecated;
+        this.supersededBy = supersededBy;
 
     }
 
@@ -68,5 +73,21 @@ public class SeguePage extends Content {
      */
     public final void setSummary(final String summary) {
         this.summary = summary;
+    }
+
+    public Boolean getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(Boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    public String getSupersededBy() {
+        return supersededBy;
+    }
+
+    public void setSupersededBy(String supersededBy) {
+        this.supersededBy = supersededBy;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -15,33 +15,33 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import uk.ac.cam.cl.dtg.isaac.dos.EventStatus;
-import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.BookingStatus;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ExternalReference;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.BookingStatus;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ImageDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.SeguePageDTO;
 import uk.ac.cam.cl.dtg.util.locations.Address;
 import uk.ac.cam.cl.dtg.util.locations.Location;
 
-import static uk.ac.cam.cl.dtg.segue.api.Constants.EVENT_GROUP_RESERVATION_DEFAULT_LIMIT;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * DTO for isaac Event.
  *
  */
 @JsonContentType("isaacEventPage")
-public class IsaacEventPageDTO extends ContentDTO {
+public class IsaacEventPageDTO extends SeguePageDTO {
     private Date date;
     private Date end_date;
     private Date bookingDeadline;
@@ -109,6 +109,7 @@ public class IsaacEventPageDTO extends ContentDTO {
                              @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
                              @JsonProperty("version") boolean published,
                              @JsonProperty("deprecated") Boolean deprecated,
+                             @JsonProperty("supersededBy") String supersededBy,
                              @JsonProperty("tags") Set<String> tags,
                              @JsonProperty("date") Date date,
                              @JsonProperty("end_date") Date end_date,
@@ -123,7 +124,7 @@ public class IsaacEventPageDTO extends ContentDTO {
                              @JsonProperty("groupReservationLimit") Integer groupReservationLimit,
                              @JsonProperty("allowGroupReservations") Boolean allowGroupReservations) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null, null,
-                relatedContent, published, deprecated, tags, null);
+                relatedContent, published, deprecated, supersededBy, tags, null);
 
         this.date = date;
         this.end_date = end_date;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFeaturedProfileDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacFeaturedProfileDTO.java
@@ -15,17 +15,16 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto;
 
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ImageDTO;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * DO for isaac featured profiles.
@@ -46,15 +45,15 @@ public class IsaacFeaturedProfileDTO extends ContentDTO {
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("version") boolean published, @JsonProperty("tags") Set<String> tags,
-            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("level") Integer level, @JsonProperty("src") String src,
             @JsonProperty("altText") String altText, @JsonProperty("emailAddress") String emailAddress,
             @JsonProperty("image") ImageDTO image, @JsonProperty("homepage") String homepage) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
 
         this.emailAddress = emailAddress;
         this.image = image;
+        this.homepage = homepage;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPodDTO.java
@@ -48,14 +48,13 @@ public class IsaacPodDTO extends ContentDTO {
             @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("version") boolean published,
-            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
             @JsonProperty("image") ImageDTO image,
             @JsonProperty("url") String url) {
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, deprecated, tags, level);
+                relatedContent, published, tags, level);
 
         this.url = url;
         this.image = image;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
@@ -32,7 +32,6 @@ import java.util.Set;
 @JsonContentType("isaacQuestionPage")
 public class IsaacQuestionPageDTO extends SeguePageDTO {
     protected Float passMark;
-    protected String supersededBy;
     protected Integer difficulty;
 
     @JsonCreator
@@ -52,12 +51,11 @@ public class IsaacQuestionPageDTO extends SeguePageDTO {
                 attribution, relatedContent, published, deprecated, supersededBy, tags, level);
 
         this.passMark = passMark;
-        this.supersededBy = supersededBy;
         this.difficulty = difficulty;
     }
 
     /**
-     * Default constructor required for Jackson
+     * Default constructor required for Jackson.
      */
     public IsaacQuestionPageDTO() {
 
@@ -71,12 +69,11 @@ public class IsaacQuestionPageDTO extends SeguePageDTO {
         this.passMark = passMark;
     }
 
-    public String getSupersededBy() { return supersededBy; }
+    public Integer getDifficulty() {
+        return difficulty;
+    }
 
-    public void setSupersededBy(String supersededBy) { this.supersededBy = supersededBy; }
-
-    public Integer getDifficulty() { return difficulty; }
-
-    public void setDifficulty(Integer difficulty) { this.difficulty = difficulty; }
-
+    public void setDifficulty(Integer difficulty) {
+        this.difficulty = difficulty;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
@@ -15,16 +15,15 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto;
 
-import java.util.List;
-import java.util.Set;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.SeguePageDTO;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Set;
 
 /**
  * IsaacQuestion Page DTO.
@@ -50,7 +49,7 @@ public class IsaacQuestionPageDTO extends SeguePageDTO {
             @JsonProperty("passMark") Float passMark, @JsonProperty("supersededBy") String supersededBy) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, deprecated, supersededBy, tags, level);
 
         this.passMark = passMark;
         this.supersededBy = supersededBy;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
@@ -64,6 +64,7 @@ public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleO
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("version") boolean published,
             @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("supersededBy") String supersededBy,
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("level") Integer level,
             @JsonProperty("visibleToStudents") boolean visibleToStudents,
@@ -72,7 +73,7 @@ public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleO
             @JsonProperty("rubric") ContentDTO rubric) {
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, deprecated, tags, level);
+                relatedContent, published, deprecated, supersededBy, tags, level);
 
         this.visibleToStudents = visibleToStudents;
         this.hiddenFromRoles = hiddenFromRoles;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizSectionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizSectionDTO.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
-import uk.ac.cam.cl.dtg.isaac.dto.content.SeguePageDTO;
 
 import java.util.List;
 import java.util.Set;
@@ -30,7 +30,7 @@ import java.util.Set;
  *
  */
 @JsonContentType("isaacQuizSection")
-public class IsaacQuizSectionDTO extends SeguePageDTO {
+public class IsaacQuizSectionDTO extends ContentDTO {
 
     @JsonCreator
     public IsaacQuizSectionDTO(@JsonProperty("id") String id,
@@ -41,11 +41,10 @@ public class IsaacQuizSectionDTO extends SeguePageDTO {
                                @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
                                @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
                                @JsonProperty("published") Boolean published, @JsonProperty("tags") Set<String> tags,
-                               @JsonProperty("deprecated") Boolean deprecated,
                                @JsonProperty("level") Integer level) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacWildcardDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacWildcardDTO.java
@@ -46,13 +46,12 @@ public class IsaacWildcardDTO extends ContentDTO {
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("version") boolean published, @JsonProperty("tags") Set<String> tags,
-            @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("level") Integer level, @JsonProperty("src") String src,
             @JsonProperty("altText") String altText, @JsonProperty("emailAddress") String emailAddress,
             @JsonProperty("image") Image image, @JsonProperty("description") String description,
             @JsonProperty("url") String url) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
 
         this.description = description;
         this.url = url;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/ContentDTO.java
@@ -15,16 +15,16 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto.content;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Sets;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Content Class (Data Transfer Object) This class represents a majority of content types within the Content Management
@@ -44,7 +44,6 @@ public class ContentDTO extends ContentBaseDTO {
     protected String attribution;
     protected List<ContentSummaryDTO> relatedContent;
     protected Boolean published;
-    protected Boolean deprecated;
     protected Integer level;
     protected Boolean expandable;
 
@@ -56,7 +55,7 @@ public class ContentDTO extends ContentBaseDTO {
             @JsonProperty("layout") String layout, @JsonProperty("children") List<ContentBaseDTO> children,
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
-            @JsonProperty("published") Boolean published, @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("published") Boolean published,
             @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
         this.id = id;
         this.title = title;
@@ -70,7 +69,6 @@ public class ContentDTO extends ContentBaseDTO {
         this.attribution = attribution;
         this.relatedContent = relatedContent;
         this.published = published;
-        this.deprecated = deprecated;
         this.children = children;
         this.tags = tags;
         this.level = level;
@@ -205,14 +203,6 @@ public class ContentDTO extends ContentBaseDTO {
      */
     public void setPublished(final Boolean published) {
         this.published = published;
-    }
-
-    public Boolean getDeprecated() {
-        return deprecated;
-    }
-
-    public void setDeprecated(Boolean deprecated) {
-        this.deprecated = deprecated;
     }
 
     public Integer getLevel() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/EmailTemplateDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/EmailTemplateDTO.java
@@ -52,17 +52,16 @@ public class EmailTemplateDTO extends ContentDTO {
      * @param attribution
      * @param relatedContent
      * @param published
-     * @param deprecated
      * @param tags
      * @param level
      */
     public EmailTemplateDTO(final String _id, final String id, final String title, final String subtitle,
             final String type, final String author, final String encoding, final String canonicalSourceFile,
             final String layout, final List<ContentBaseDTO> children, final String value, final String attribution,
-            final List<ContentSummaryDTO> relatedContent, final Boolean published, final Boolean deprecated,
+            final List<ContentSummaryDTO> relatedContent, final Boolean published,
             final Set<String> tags, final Integer level) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/SeguePageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/SeguePageDTO.java
@@ -15,12 +15,12 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dto.content;
 
-import java.util.List;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * DTO representing a segue page.
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class SeguePageDTO extends ContentDTO {
     private String summary;
+    private Boolean deprecated;
+    private String supersededBy;
 
     @JsonCreator
     public SeguePageDTO(@JsonProperty("id") String id,
@@ -38,10 +40,14 @@ public class SeguePageDTO extends ContentDTO {
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("published") Boolean published, @JsonProperty("deprecated") Boolean deprecated,
+            @JsonProperty("supersededBy") String supersededBy,
             @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, tags, level);
+                attribution, relatedContent, published, tags, level);
+
+        this.deprecated = deprecated;
+        this.supersededBy = supersededBy;
 
     }
 
@@ -71,5 +77,21 @@ public class SeguePageDTO extends ContentDTO {
     @JsonIgnore(false) // Override the parent class decorator!
     public String getCanonicalSourceFile() {
         return this.canonicalSourceFile;
+    }
+
+    public Boolean getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(Boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    public String getSupersededBy() {
+        return supersededBy;
+    }
+
+    public void setSupersededBy(String supersededBy) {
+        this.supersededBy = supersededBy;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -34,6 +34,7 @@ import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.QuestionDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.SeguePageDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
@@ -196,7 +197,7 @@ public class StatisticsManager implements IStatisticsManager {
         Map<Stage, Map<Difficulty, Integer>> questionsCorrectByStageAndDifficultyStats = Maps.newHashMap();
         Map<String, Integer> questionAttemptsByTypeStats = Maps.newHashMap();
         Map<String, Integer> questionsCorrectByTypeStats = Maps.newHashMap();
-        List<ContentDTO> incompleteQuestionPages = Lists.newArrayList();
+        List<IsaacQuestionPageDTO> incompleteQuestionPages = Lists.newArrayList();
         Queue<ContentDTO> mostRecentlyAttemptedQuestionPages = new CircularFifoQueue<>(PROGRESS_MAX_RECENT_QUESTIONS);
 
         LocalDate now = LocalDate.now();
@@ -368,7 +369,7 @@ public class StatisticsManager implements IStatisticsManager {
                 .stream().map(contentSummarizerService::extractContentSummary).collect(Collectors.toList());
         Collections.reverse(mostRecentlyAttemptedQuestionsList);  // We want most-recent first order and streams cannot reverse.
         List<ContentSummaryDTO> questionsNotCompleteList = incompleteQuestionPages.stream()
-            .sorted(Comparator.comparing(ContentDTO::getDeprecated, Comparator.nullsFirst(Comparator.naturalOrder())))
+            .sorted(Comparator.comparing(SeguePageDTO::getDeprecated, Comparator.nullsFirst(Comparator.naturalOrder())))
             .limit(PROGRESS_MAX_RECENT_QUESTIONS)
             .map(contentSummarizerService::extractContentSummary).collect(Collectors.toList());
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -1219,7 +1219,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Provides
     @Singleton
     private static GameboardPersistenceManager getGameboardPersistenceManager(final PostgresSqlDb database,
-                                                                              final GitContentManager contentManager, final MapperFacade mapper, final ObjectMapper objectMapper,
+                                                                              final GitContentManager contentManager, final MapperFacade mapper, final ContentMapper objectMapper,
                                                                               final URIManager uriManager) {
         if (null == gameboardPersistenceManager) {
             gameboardPersistenceManager = new GameboardPersistenceManager(database, contentManager, mapper,

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -164,14 +164,14 @@ public class IsaacTest {
         quizSection2.setId("studentQuiz|section2");
         quizSection2.setChildren(ImmutableList.of(question2, question3));
 
-        studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
-        studentQuizPreQuizAnswerChange = new IsaacQuizDTO("studentQuizPreQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
-        studentQuizPostQuizAnswerChange = new IsaacQuizDTO("studentQuizPostQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
-        teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, false, ImmutableList.of("STUDENT"), null, null);
-        otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, null, null, null, true, null, QuizFeedbackMode.DETAILED_FEEDBACK, null);
+        studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
+        studentQuizPreQuizAnswerChange = new IsaacQuizDTO("studentQuizPreQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
+        studentQuizPostQuizAnswerChange = new IsaacQuizDTO("studentQuizPostQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, true, null, QuizFeedbackMode.OVERALL_MARK, null);
+        teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, false, ImmutableList.of("STUDENT"), null, null);
+        otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, null, null, null, null, true, null, QuizFeedbackMode.DETAILED_FEEDBACK, null);
 
         // A bit scrappy, but hopefully sufficient.
-        studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, true, null, null);
+        studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, true, null, null);
 
         student = new RegisteredUserDTO("Some", "Student", "test-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false);
         student.setRole(Role.STUDENT);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
@@ -318,7 +318,7 @@ public abstract class IsaacIntegrationTest {
         PgUserGroupPersistenceManager pgUserGroupPersistenceManager = new PgUserGroupPersistenceManager(postgresSqlDb);
         IAssignmentPersistenceManager assignmentPersistenceManager = new PgAssignmentPersistenceManager(postgresSqlDb, mapperFacade);
 
-        GameboardPersistenceManager gameboardPersistenceManager = new GameboardPersistenceManager(postgresSqlDb, contentManager, mapperFacade, objectMapper, new URIManager(properties));
+        GameboardPersistenceManager gameboardPersistenceManager = new GameboardPersistenceManager(postgresSqlDb, contentManager, mapperFacade, contentMapper, new URIManager(properties));
         gameManager = new GameManager(contentManager, gameboardPersistenceManager, mapperFacade, questionManager);
         groupManager = new GroupManager(pgUserGroupPersistenceManager, userAccountManager, gameManager, mapperFacade);
         userAssociationManager = new UserAssociationManager(pgAssociationDataManager, userAccountManager, groupManager);

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/dao/GitContentManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/dao/GitContentManagerTest.java
@@ -87,7 +87,7 @@ public class GitContentManagerTest {
 	private Content createEmptyContentElement(final List<ContentBase> children,
 			final String id) {
 		return new Content(id, "", "", "", "", "", "", "", children, "",
-				"", new LinkedList<String>(), false, false, new HashSet<String>(), 1);
+				"", new LinkedList<String>(), false, new HashSet<String>(), 1);
 	}
 
 	/**

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexerTest.java
@@ -427,7 +427,7 @@ public class ContentIndexerTest {
     private Content createEmptyContentElement(final List<ContentBase> children,
                                               final String id) {
         return new Content(id, "", "", "", "", "", "", "", children, "",
-                "", new LinkedList<>(), false, false, new HashSet<>(), 1);
+                "", new LinkedList<>(), false, new HashSet<>(), 1);
     }
 
     /**


### PR DESCRIPTION
This is a change from _any_ content being able to be deprecated, to just top-level page types (i.e. those that extend SeguePage). We did not do anything with deprecated set on any other content, so this change is safe to make and reflects the actual behaviour.
This also moves supersededBy to the SeguePage and subclasses, so that more than just question pages can be superseded.
It also tidies up other classes that had one or both of these properties but where we were not using them. A similar change to the frontend types exists to demonstrate that we only used these for SeguePage level objects.

I have tested that this has not broken any existing content, and also verified that ContentSummaryDTOs still get the two properties mapped across as expected.