### PR TITLE
Load question attempts via page_id index

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
@@ -252,6 +252,8 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
 
             try (ResultSet results = pst.executeQuery()) {
                 return resultsToMapLightweightValidationResponseByUserPagePart(results);
+            } finally {
+                userIdArray.free();
             }
         } catch (SQLException e) {
             throw new SegueDatabaseException("Postgres exception", e);
@@ -292,6 +294,7 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
                     return resultsToMapLightweightValidationResponseByUserPagePart(results);
                 } finally {
                     userIdArray.free();
+                    pageIdArray.free();
                 }
             }
         } catch (SQLException e) {


### PR DESCRIPTION
Before we were using prefix matching on the question_id column, which sometimes meant that the index could not be used, or caused issues with questions like "book_c1_q1" where there are dozens of other questions which start with the same prefix ("book_c1_q10", etc) that were loaded
unnecessarily.
The repeated "OR question_id LIKE ..." did not perform well for large numbers of question IDs, either.
The page_id column is easy to match with an equals match of the page IDs, and the new index is much smaller than the question_id index which should help it perform better too.

---

This cannot be merged until all the existing question attempts have the `page_id` value backfilled and the index is created, which I am working on.