### PR TITLE
Make book a required field in QF search

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/IsaacController.java
@@ -189,7 +189,7 @@ public class IsaacController extends AbstractIsaacFacade {
             }
 
             ResultsWrapper<ContentDTO> searchResults = this.contentManager.searchForContent(
-                    searchString, null, null, null, null, null, null,
+                    searchString, null, null, null, null, null, null, null,
                     new HashSet<>(documentTypes), startIndex, limit, showNoFilterContent);
 
             ImmutableMap<String, String> logMap = new ImmutableMap.Builder<String, String>()

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -308,7 +308,7 @@ public class PagesFacade extends AbstractIsaacFacade {
             @QueryParam("ids") final String ids, @QueryParam("searchString") final String searchString,
             @QueryParam("tags") final String tags, @QueryParam("levels") final String level,
             @QueryParam("stages") final String stages, @QueryParam("difficulties") final String difficulties,
-            @QueryParam("examBoards") final String examBoards,
+            @QueryParam("examBoards") final String examBoards, @QueryParam("books") final String books,
             @DefaultValue("false") @QueryParam("fasttrack") final Boolean fasttrack,
             @DefaultValue(DEFAULT_START_INDEX_AS_STRING) @QueryParam("start_index") final Integer startIndex,
             @DefaultValue(DEFAULT_RESULTS_LIMIT_AS_STRING) @QueryParam("limit") final Integer limit) {
@@ -346,6 +346,7 @@ public class PagesFacade extends AbstractIsaacFacade {
         Map<String, String> fieldNameToValues = new HashMap<>() {
             {
                 this.put(TAGS_FIELDNAME, tags);
+                this.put(BOOKS_FIELDNAME, books);
                 this.put(LEVEL_FIELDNAME, level);
                 this.put(STAGE_FIELDNAME, stages);
                 this.put(DIFFICULTY_FIELDNAME, difficulties);
@@ -388,6 +389,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                     validatedSearchString,
                     fieldsToMatch.get(ID_FIELDNAME),
                     fieldsToMatch.get(TAGS_FIELDNAME),
+                    fieldsToMatch.get(BOOKS_FIELDNAME),
                     fieldsToMatch.get(LEVEL_FIELDNAME),
                     fieldsToMatch.get(STAGE_FIELDNAME),
                     fieldsToMatch.get(DIFFICULTY_FIELDNAME),

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -439,6 +439,7 @@ public final class Constants {
     public static final String SUBTITLE_FIELDNAME = "subtitle";
     public static final String TYPE_FIELDNAME = "type";
     public static final String TAGS_FIELDNAME = "tags";
+    public static final String BOOKS_FIELDNAME = "books";
     public static final String LEVEL_FIELDNAME = "level";
     public static final String SUMMARY_FIELDNAME = "summary";
     public static final String DATE_FIELDNAME = "date";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -321,9 +321,10 @@ public class GitContentManager {
 
     public final ResultsWrapper<ContentDTO> searchForContent(
             @Nullable final String searchString,
-            @Nullable final Set<String> ids, @Nullable final Set<String> tags, @Nullable Set<String> levels,
-            @Nullable Set<String> stages, @Nullable Set<String> difficulties, @Nullable Set<String> examBoards,
-            final Set<String> contentTypes, final Integer startIndex, final Integer limit, final boolean showNoFilterContent
+            @Nullable final Set<String> ids, @Nullable final Set<String> tags, @Nullable final Set<String> books,
+            @Nullable Set<String> levels, @Nullable Set<String> stages, @Nullable Set<String> difficulties,
+            @Nullable Set<String> examBoards, final Set<String> contentTypes, final Integer startIndex,
+            final Integer limit, final boolean showNoFilterContent
     ) throws ContentManagerException {
 
         // Create a set of search terms from the initial search string
@@ -361,6 +362,7 @@ public class GitContentManager {
         Map<String, Set<String>> filterFieldNamesToValues = new HashMap<>() {{
             this.put(ID_FIELDNAME, ids);
             this.put(TAGS_FIELDNAME, tags);
+            this.put(BOOKS_FIELDNAME, books);
             this.put(LEVEL_FIELDNAME, levels);
             this.put(STAGE_FIELDNAME, stages);
             this.put(DIFFICULTY_FIELDNAME, difficulties);
@@ -369,10 +371,18 @@ public class GitContentManager {
         // Add a required filtering rule for each field that has a value
         for (Map.Entry<String, Set<String>> entry : filterFieldNamesToValues.entrySet()) {
             if (entry.getValue() != null && !entry.getValue().isEmpty()) {
-                boolean applyOrFilterBetweenValues = Constants.ID_FIELDNAME.equals(entry.getKey());
-                searchInstructionBuilder.searchFor(new SearchInField(entry.getKey(), entry.getValue())
-                        .strategy(Strategy.SIMPLE)
-                        .required(!applyOrFilterBetweenValues));
+                if (BOOKS_FIELDNAME.equals(entry.getKey())) {
+                    // books are stored as a type of tag, but unlike other tags are required fields in the search
+                    // FIXME when content team want multiple tags per question page, extend this to support "required tags" vs "optional tags"
+                    searchInstructionBuilder.searchFor(new SearchInField(TAGS_FIELDNAME, entry.getValue())
+                            .strategy(Strategy.SIMPLE)
+                            .required(true));
+                } else {
+                    boolean applyOrFilterBetweenValues = Constants.ID_FIELDNAME.equals(entry.getKey());
+                    searchInstructionBuilder.searchFor(new SearchInField(entry.getKey(), entry.getValue())
+                            .strategy(Strategy.SIMPLE)
+                            .required(!applyOrFilterBetweenValues));
+                }
             }
         }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
@@ -68,7 +68,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", false, 0, -1);
+                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -94,7 +94,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                ITConstants.SEARCH_TEST_CONCEPT_ID, "", "", "", "", "", "", false, 0, -1);
+                ITConstants.SEARCH_TEST_CONCEPT_ID, "", "", "", "", "", "", "", false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -120,7 +120,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", true, 0, -1);
+                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", true, 0, -1);
 
         // Assert
         // check status code is OK
@@ -147,7 +147,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
                 String.format("%s,%s", ITConstants.REGRESSION_TEST_PAGE_ID, ITConstants.ASSIGNMENT_TEST_PAGE_ID), "",
-                "", "", "", "", "", false, 0, -1);
+                "", "", "", "", "", "", false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -173,7 +173,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                "", "Regression Test Page", "", "", "", "", "", false, 0, -1);
+                "", "Regression Test Page", "", "", "", "", "", "", false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -199,7 +199,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                "", "Regression Test Page", "", "", "", "", "", false, 0, 1);
+                "", "Regression Test Page", "", "", "", "", "", "",false, 0, 1);
 
         // Assert
         // check status code is OK


### PR DESCRIPTION
- Edits the question search endpoint to allow a nullable books field;
- Makes these books, if present, a required field; that is, if a (set of) book(s) is provided, all results will be from this;
- Other tags remain unchanged and unrequired.