### PR TITLE
Reduce database queries when bulk assigning

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
@@ -125,16 +125,17 @@ public class AssignmentManager implements IAssignmentLike.Details<AssignmentDTO>
     
 
     /**
-     * create Assignment.
-     * 
-     * @param newAssignment
-     *            - to create - will be modified to include new id.
+     * Create an Assignment.
+     *
+     * @param newAssignment - will be modified to include new id. It must contain the gameboard being assigned,
+     *                        and should contain the ownerSummaryDTO.
      * @return the assignment object now with the id field populated.
      * @throws SegueDatabaseException
      *             - if we cannot complete a required database operation.
      */
     public AssignmentDTO createAssignment(final AssignmentDTO newAssignment) throws SegueDatabaseException {
         Validate.isTrue(newAssignment.getId() == null, "The id field must be empty.");
+        Validate.isTrue(newAssignment.getGameboard() != null);
         Objects.requireNonNull(newAssignment.getGameboardId());
         Objects.requireNonNull(newAssignment.getGroupId());
 
@@ -148,8 +149,7 @@ public class AssignmentManager implements IAssignmentLike.Details<AssignmentDTO>
         newAssignment.setCreationDate(new Date());
         newAssignment.setId(this.assignmentPersistenceManager.saveAssignment(newAssignment));
 
-        // Get assignment gameboard in order to generate URL which will be added to the notification email
-        GameboardDTO gameboard = gameManager.getGameboard(newAssignment.getGameboardId());
+        GameboardDTO gameboard = newAssignment.getGameboard();
         final String gameboardURL = String.format("https://%s/assignment/%s", properties.getProperty(HOST_NAME),
                 gameboard.getId());
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
@@ -235,6 +235,7 @@ public class AssignmentDTO implements IAssignmentLike {
      * Gets the assignerSummary.
      * @return the assignerSummary
      */
+    @Override
     public UserSummaryDTO getAssignerSummary() {
         return assignerSummary;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IAssignmentLike.java
@@ -14,6 +14,8 @@ public interface IAssignmentLike {
 
     Long getOwnerUserId();
 
+    UserSummaryDTO getAssignerSummary();
+
     void setAssignerSummary(UserSummaryDTO userSummaryDTO);
 
     Date getCreationDate();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAssignmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/QuizAssignmentDTO.java
@@ -176,6 +176,7 @@ public class QuizAssignmentDTO implements IAssignmentLike, IHasQuizSummary {
      * Gets the assignerSummary.
      * @return the assignerSummary
      */
+    @Override
     public UserSummaryDTO getAssignerSummary() {
         return assignerSummary;
     }


### PR DESCRIPTION
The bulk_assign endpoint currently makes a lot of repeated database queries, potentially more than `13*N` where N is the number of assignments created in one go. (It's at least `11*N`, but I now think it is `13*N`). 
This is ... _bad_.

The user making the request was loaded at least three times per assignment (twice when getting the group in different places, once for the email), the group was loaded twice per assignment along with all manager and owner user data, and the gameboard was loaded once per assignment (even though the UI only supports setting the _same_ gameboard to multiple groups right now).

This potentially reduces the number of queries by a factor of nearly 3, by:
 - loading each gameboard at most once and passing it down inside the assignment,
 - loading the full group objects only once,
 - not loading full groups when only the group name is required,
 - passing the owner data down inside the assignment and using it if present when sending emails.

There are still ~5 queries per assignment, partly because we do need to do several things (check user has permission, check no existing one, save, send email) and partly because the separation into managers makes it tricky to do any more data-reuse.