### PR TITLE
Only email active group users

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/EmailService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/EmailService.java
@@ -125,8 +125,8 @@ public class EmailService {
                     .filter(user -> GroupMembershipStatus.ACTIVE.equals(userMembershipMapforGroup.get(user.getId()).getStatus()))
                     .collect(Collectors.toList());
 
-            // Send the email using MailGun if owner on list:
-            if (this.userInMailGunBetaList(assignmentOwnerDTO)) {
+            // Send the email using MailGun if owner on list or if scheduled:
+            if (this.userInMailGunBetaList(assignmentOwnerDTO) || assignment.getScheduledStartDate() != null) {
                 Iterables.partition(usersToEmail, MAILGUN_BATCH_SIZE)
                     .forEach(userBatch -> mailGunEmailManager.sendBatchEmails(
                         userBatch,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/EmailService.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/services/EmailService.java
@@ -42,7 +42,9 @@ import jakarta.annotation.Nullable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
@@ -116,8 +118,16 @@ public class EmailService {
             // Get email template
             EmailTemplateDTO emailTemplate = emailManager.getEmailTemplateDTO(templateName);
 
+            // Only email users active in the group:
+            Map<Long, GroupMembershipDTO> userMembershipMapforGroup = this.groupManager.getUserMembershipMapForGroup(userGroupDTO.getId());
+            List<RegisteredUserDTO> usersToEmail = groupManager.getUsersInGroup(userGroupDTO).stream()
+                    // filter users so those who are inactive in the group aren't emailed
+                    .filter(user -> GroupMembershipStatus.ACTIVE.equals(userMembershipMapforGroup.get(user.getId()).getStatus()))
+                    .collect(Collectors.toList());
+
+            // Send the email using MailGun if owner on list:
             if (this.userInMailGunBetaList(assignmentOwnerDTO)) {
-                Iterables.partition(groupManager.getUsersInGroup(userGroupDTO), MAILGUN_BATCH_SIZE)
+                Iterables.partition(usersToEmail, MAILGUN_BATCH_SIZE)
                     .forEach(userBatch -> mailGunEmailManager.sendBatchEmails(
                         userBatch,
                         emailTemplate,
@@ -126,19 +136,14 @@ public class EmailService {
                         null)
                     );
             } else {
-                // If user is not in the MailGun assignment emails beta list, use our standard email method
-                Map<Long, GroupMembershipDTO> userMembershipMapforGroup = this.groupManager.getUserMembershipMapForGroup(userGroupDTO.getId());
-                groupManager.getUsersInGroup(userGroupDTO).stream()
-                        // filter users so those who are inactive in the group aren't emailed
-                        .filter(user -> GroupMembershipStatus.ACTIVE.equals(userMembershipMapforGroup.get(user.getId()).getStatus()))
-                        // send an assignment email to each active user
-                        .forEach(user -> {
-                            try {
-                                emailManager.sendTemplatedEmailToUser(user, emailTemplate, variables, EmailType.ASSIGNMENTS);
-                            } catch (ContentManagerException | SegueDatabaseException e) {
-                                log.error(String.format("Problem sending assignment email for user %s.", user.getId()), e);
-                            }
-                        });
+                // Otherwise, use our standard email method:
+                usersToEmail.forEach(user -> {
+                    try {
+                        emailManager.sendTemplatedEmailToUser(user, emailTemplate, variables, EmailType.ASSIGNMENTS);
+                    } catch (ContentManagerException | SegueDatabaseException e) {
+                        log.error(String.format("Problem sending assignment email for user %s.", user.getId()), e);
+                    }
+                });
             }
         } catch (NoUserException e) {
             log.error("Could not send assignment email because owner did not exist.", e);


### PR DESCRIPTION
When using MailGun to send batched emails, we were not filtering by the user's status in the group. Inactive users were receiving assignment notifications that they then could not see in their assignments.

This PR also moved to sending all scheduled emails via MailGun, to avoid spikes on the hour.