### PR TITLE
Allow event leaders to set notes on assignments

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -987,13 +987,13 @@ public class AssignmentFacade extends AbstractIsaacFacade {
 
             // Assert user is allowed to set assignments - tutors and above are allowed to do so
             boolean userIsTutorOrAbove = isUserTutorOrAbove(userManager, currentlyLoggedInUser);
-            boolean userIsStaff = isUserStaff(userManager, currentlyLoggedInUser);
+            boolean userIsStaffOrEventLeader = isUserStaffOrEventLeader(userManager, currentlyLoggedInUser);
             if (!userIsTutorOrAbove) {
                 return new SegueErrorResponse(Status.FORBIDDEN, "You need a tutor or teacher account to create groups and set assignments!").toResponse();
             }
 
             // Assert that there is at least one assignment, and that multiple assignments are only set by staff
-            if (assignmentDTOsFromClient.size() == 0) {
+            if (assignmentDTOsFromClient.isEmpty()) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "You need to specify at least one assignment to set.").toResponse();
             }
 
@@ -1007,9 +1007,10 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                     continue;
                 }
 
-                // Staff can set assignment notes up to a max length of MAX_NOTE_CHAR_LENGTH, teachers cannot set notes.
+                // Staff and event leaders can set assignment notes up to a max length of MAX_NOTE_CHAR_LENGTH,
+                // teachers cannot set notes.
                 boolean notesIsNullOrEmpty = null == assignmentDTO.getNotes() || assignmentDTO.getNotes().isEmpty();
-                if (userIsStaff) {
+                if (userIsStaffOrEventLeader) {
                     boolean notesIsTooLong = null != assignmentDTO.getNotes() && assignmentDTO.getNotes().length() > MAX_NOTE_CHAR_LENGTH;
                     if (notesIsTooLong) {
                         assigmentStatuses.add(new AssignmentStatusDTO(assignmentDTO.getGroupId(), "Your assignment notes exceed the maximum allowed length of "

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AbstractSegueFacade.java
@@ -302,6 +302,23 @@ public abstract class AbstractSegueFacade {
     }
 
     /**
+     * Is the current user in a staff or event leader role.
+     *
+     * @param userManager
+     *            - Instance of User Manager
+     * @param userDTO
+     *            - for the user of interest
+     * @return true if user is logged in as an admin or event leader, false otherwise.
+     * @throws NoUserLoggedInException
+     *             - if we are unable to tell because they are not logged in.
+     */
+    public static boolean isUserStaffOrEventLeader(final UserAccountManager userManager, final RegisteredUserDTO userDTO)
+        throws NoUserLoggedInException {
+        return userManager.checkUserRole(userDTO,
+                Arrays.asList(Role.ADMIN, Role.EVENT_MANAGER, Role.CONTENT_EDITOR, Role.EVENT_LEADER));
+    }
+
+    /**
      * Is the current user anything other than a tutor or a student.
      *
      * @param userManager


### PR DESCRIPTION
It would be worth looking to restrict which assignments event leaders can put notes on, specifically restricting it only those assignments which are part of the relevant event.