### PR TITLE
Support pagination and attempt data in question finder

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -119,6 +119,7 @@ public final class Constants {
     public static final String ALL_BOARDS = "ALL";
     public static final Integer DEFAULT_GAMEBOARDS_RESULTS_LIMIT = 6;
     public static final Integer MAX_PODS_TO_RETURN = 12;
+    public static final Integer SEARCH_RESULTS_PER_PAGE = 30;
     public static final Integer SEARCH_MAX_WINDOW_SIZE = 10000;
     public static final Integer GAMEBOARD_MAX_TITLE_LENGTH = 255;
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -432,7 +432,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                     }
                 }
 
-                combinedResults.addAll(summarizedResults.subList(0, Math.min(summarizedResults.size(), SEARCH_RESULTS_PER_PAGE - combinedResults.size())));
+                combinedResults.addAll(summarizedResults.subList(0, Math.min(summarizedResults.size(), Math.min(SEARCH_RESULTS_PER_PAGE, newLimit) - combinedResults.size())));
                 totalResults = c.getTotalResults();
 
             } catch (ContentManagerException e1) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -388,7 +388,7 @@ public class PagesFacade extends AbstractIsaacFacade {
         List<ContentSummaryDTO> summarizedResults = null;
         int resultsReturnedByThisSearch = 0;
 
-        for (int iterationLimit = 5; iterationLimit > 0 && combinedResults.size() < SEARCH_RESULTS_PER_PAGE && combinedResults.size() < newLimit && (summarizedResults == null || resultsReturnedByThisSearch != 0); iterationLimit--) {
+        for (int iterationLimit = 5; iterationLimit > 0 && combinedResults.size() < SEARCH_RESULTS_PER_PAGE && (newLimit < 0 || combinedResults.size() < newLimit) && (summarizedResults == null || resultsReturnedByThisSearch != 0); iterationLimit--) {
             try {
                 ResultsWrapper<ContentDTO> c;
                 c = contentManager.searchForContent(
@@ -432,7 +432,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                     }
                 }
 
-                combinedResults.addAll(summarizedResults.subList(0, 1 + Math.min(summarizedResults.size(), Math.min(SEARCH_RESULTS_PER_PAGE, newLimit) - combinedResults.size())));
+                combinedResults.addAll(summarizedResults.subList(0, Math.min(summarizedResults.size(), 1 + (newLimit >= 0 ? Math.min(SEARCH_RESULTS_PER_PAGE, newLimit) : SEARCH_RESULTS_PER_PAGE) - combinedResults.size())));
                 totalResults = c.getTotalResults();
 
             } catch (ContentManagerException e1) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -432,7 +432,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                     }
                 }
 
-                combinedResults.addAll(summarizedResults.subList(0, Math.min(summarizedResults.size(), 1 + Math.min(SEARCH_RESULTS_PER_PAGE, newLimit) - combinedResults.size())));
+                combinedResults.addAll(summarizedResults.subList(0, 1 + Math.min(summarizedResults.size(), Math.min(SEARCH_RESULTS_PER_PAGE, newLimit) - combinedResults.size())));
                 totalResults = c.getTotalResults();
 
             } catch (ContentManagerException e1) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -388,7 +388,7 @@ public class PagesFacade extends AbstractIsaacFacade {
         List<ContentSummaryDTO> summarizedResults = null;
         int resultsReturnedByThisSearch = 0;
 
-        for (int iterationLimit = 5; iterationLimit > 0 && combinedResults.size() < SEARCH_RESULTS_PER_PAGE && (summarizedResults == null || resultsReturnedByThisSearch != 0); iterationLimit--) {
+        for (int iterationLimit = 5; iterationLimit > 0 && combinedResults.size() < SEARCH_RESULTS_PER_PAGE && combinedResults.size() < newLimit && (summarizedResults == null || resultsReturnedByThisSearch != 0); iterationLimit--) {
             try {
                 ResultsWrapper<ContentDTO> c;
                 c = contentManager.searchForContent(

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -422,16 +422,22 @@ public class PagesFacade extends AbstractIsaacFacade {
                     break;
                 }
 
-                nextSearchStartIndex += summarizedResults.size(); // add the total number of returned results, including any we will filter out
-
                 if (user instanceof RegisteredUserDTO) {
-                    summarizedResults = userAttemptManager.augmentContentSummaryListWithAttemptInformation((RegisteredUserDTO) user, summarizedResults, hideCompleted);
+                    summarizedResults = userAttemptManager.augmentContentSummaryListWithAttemptInformation((RegisteredUserDTO) user, summarizedResults);
+                    if (hideCompleted) {
+                        summarizedResults = summarizedResults.stream()
+                                .filter(q -> q.getCorrect() == null || !q.getCorrect())
+                                .collect(Collectors.toList());
+                    }
                 }
 
                 if (newLimit < 0 || combinedResults.size() + summarizedResults.size() <= newLimit) {
                     combinedResults.addAll(summarizedResults);
+                    nextSearchStartIndex += summarizedResults.size();
                 } else {
-                    combinedResults.addAll(summarizedResults.subList(0, 1 + newLimit - combinedResults.size()));
+                    int remainingResults = 1 + newLimit - combinedResults.size();
+                    combinedResults.addAll(summarizedResults.subList(0, remainingResults));
+                    nextSearchStartIndex += remainingResults;
                 }
                 totalResults = c.getTotalResults();
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -432,7 +432,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                     }
                 }
 
-                combinedResults.addAll(summarizedResults.subList(0, Math.min(summarizedResults.size(), Math.min(SEARCH_RESULTS_PER_PAGE, newLimit) - combinedResults.size())));
+                combinedResults.addAll(summarizedResults.subList(0, Math.min(summarizedResults.size(), 1 + Math.min(SEARCH_RESULTS_PER_PAGE, newLimit) - combinedResults.size())));
                 totalResults = c.getTotalResults();
 
             } catch (ContentManagerException e1) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -958,6 +958,7 @@ public class PagesFacade extends AbstractIsaacFacade {
         // try auto-mapping
         ContentSummaryDTO contentInfo = mapper.map(content, ContentSummaryDTO.class);
         contentInfo.setUrl(uriManager.generateApiUrl(content));
+        GitContentManager.populateContentSummaryValues(content, contentInfo);
 
         return contentInfo;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -382,11 +382,13 @@ public class PagesFacade extends AbstractIsaacFacade {
         }
 
         List<ContentSummaryDTO> combinedResults = new ArrayList<>();
-        List<ContentSummaryDTO> summarizedResults = null;
         int nextSearchStartIndex = newStartIndex;
         Long totalResults = 0L;
 
-        for (int iterationLimit = 5; iterationLimit > 0 && combinedResults.size() < SEARCH_RESULTS_PER_PAGE && (summarizedResults == null || !summarizedResults.isEmpty()); iterationLimit--) {
+        List<ContentSummaryDTO> summarizedResults = null;
+        int resultsReturnedByThisSearch = 0;
+
+        for (int iterationLimit = 5; iterationLimit > 0 && combinedResults.size() < SEARCH_RESULTS_PER_PAGE && (summarizedResults == null || resultsReturnedByThisSearch != 0); iterationLimit--) {
             try {
                 ResultsWrapper<ContentDTO> c;
                 c = contentManager.searchForContent(
@@ -408,7 +410,8 @@ public class PagesFacade extends AbstractIsaacFacade {
                 );
 
                 summarizedResults = this.extractContentSummaryFromList(c.getResults());
-                nextSearchStartIndex += summarizedResults.size(); // add the total number of returned results, including any we will filter out
+                resultsReturnedByThisSearch = summarizedResults.size();
+                nextSearchStartIndex += resultsReturnedByThisSearch; // add the total number of returned results, including any we will filter out
 
                 if (user instanceof RegisteredUserDTO) {
                     RegisteredUserDTO registeredUser = (RegisteredUserDTO) user;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -842,18 +842,19 @@ public class GameManager {
      */
     public List<GameboardItem> getGameboardItemProgress(
             @NotNull final List<ContentDTO> questions,
-            final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>> userQuestionAttempts,
+            final Map<String, ? extends Map<String, ? extends List<QuestionValidationResponse>>> userQuestionAttempts,
             @Nullable final GameFilter gameFilter) {
 
         return questions.stream()
                 .map(q -> this.gameboardPersistenceManager.convertToGameboardItem(
                         q, new GameboardContentDescriptor(q.getId(), QUESTION_TYPE, AudienceContext.fromFilter(gameFilter))))
-                .peek(questionItem -> {
+                .map(questionItem -> {
                     try {
                         this.augmentGameItemWithAttemptInformation(questionItem, userQuestionAttempts);
                     } catch (ContentManagerException | ResourceNotFoundException e) {
                         log.error("Unable to augment '" + questionItem.getId() + "' with user attempt information");
                     }
+                    return questionItem;
                 }).collect(Collectors.toList());
     }
 
@@ -1134,7 +1135,7 @@ public class GameManager {
      * @throws ResourceNotFoundException
      *             - if we cannot find the question specified.
      */
-    public void augmentGameItemWithAttemptInformation(
+    private void augmentGameItemWithAttemptInformation(
             final GameboardItem gameItem,
             final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>>
                     questionAttemptsFromUser)

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -842,19 +842,18 @@ public class GameManager {
      */
     public List<GameboardItem> getGameboardItemProgress(
             @NotNull final List<ContentDTO> questions,
-            final Map<String, Map<String, List<QuestionValidationResponse>>> userQuestionAttempts,
+            final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>> userQuestionAttempts,
             @Nullable final GameFilter gameFilter) {
 
         return questions.stream()
                 .map(q -> this.gameboardPersistenceManager.convertToGameboardItem(
                         q, new GameboardContentDescriptor(q.getId(), QUESTION_TYPE, AudienceContext.fromFilter(gameFilter))))
-                .map(questionItem -> {
+                .peek(questionItem -> {
                     try {
                         this.augmentGameItemWithAttemptInformation(questionItem, userQuestionAttempts);
                     } catch (ContentManagerException | ResourceNotFoundException e) {
                         log.error("Unable to augment '" + questionItem.getId() + "' with user attempt information");
                     }
-                    return questionItem;
                 }).collect(Collectors.toList());
     }
 
@@ -1135,7 +1134,7 @@ public class GameManager {
      * @throws ResourceNotFoundException
      *             - if we cannot find the question specified.
      */
-    private void augmentGameItemWithAttemptInformation(
+    public void augmentGameItemWithAttemptInformation(
             final GameboardItem gameItem,
             final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>>
                     questionAttemptsFromUser)

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/UserAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/UserAttemptManager.java
@@ -85,11 +85,10 @@ public class UserAttemptManager {
      * Augment a list of content summary objects with user attempt information.
      * @param user the user to augment the content summary list for.
      * @param summarizedResults the content summary list to augment.
-     * @param hideCompleted whether to filter out completed content.
      * @return the augmented content summary list.
      * @throws SegueDatabaseException if there is an error retrieving question attempts.
      */
-    public List<ContentSummaryDTO> augmentContentSummaryListWithAttemptInformation(RegisteredUserDTO user, List<ContentSummaryDTO> summarizedResults, boolean hideCompleted) throws SegueDatabaseException {
+    public List<ContentSummaryDTO> augmentContentSummaryListWithAttemptInformation(RegisteredUserDTO user, List<ContentSummaryDTO> summarizedResults) throws SegueDatabaseException {
         List<String> questionPageIds = summarizedResults.stream().map(ContentSummaryDTO::getId).collect(Collectors.toList());
 
         Map<String, Map<String, List<LightweightQuestionValidationResponse>>> questionAttempts =
@@ -98,12 +97,6 @@ public class UserAttemptManager {
 
         for (ContentSummaryDTO result : summarizedResults) {
             augmentContentSummaryWithAttemptInformation(result, questionAttempts);
-        }
-
-        if (hideCompleted) {
-            summarizedResults = summarizedResults.stream()
-                    .filter(q -> q.getCorrect() == null || !q.getCorrect())
-                    .collect(Collectors.toList());
         }
 
         return summarizedResults;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/UserAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/UserAttemptManager.java
@@ -1,0 +1,111 @@
+package uk.ac.cam.cl.dtg.isaac.api.managers;
+
+import com.google.inject.Inject;
+import uk.ac.cam.cl.dtg.isaac.dos.LightweightQuestionValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A class to augment content with user attempt information.
+ */
+public class UserAttemptManager {
+    private final QuestionManager questionManager;
+
+    @Inject
+    public UserAttemptManager(final QuestionManager questionManager) {
+        this.questionManager = questionManager;
+    }
+
+    /**
+     * A method which augments related questions with attempt information.
+     *
+     * i.e. sets whether the related content summary has been completed.
+     *
+     * @param content the content to be augmented.
+     * @param usersQuestionAttempts the user's question attempts.
+     */
+    public void augmentRelatedQuestionsWithAttemptInformation(
+            final ContentDTO content,
+            final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>> usersQuestionAttempts) {
+        // Check if all question parts have been answered
+        List<ContentSummaryDTO> relatedContentSummaries = content.getRelatedContent();
+        if (relatedContentSummaries != null) {
+            for (ContentSummaryDTO relatedContentSummary : relatedContentSummaries) {
+                augmentContentSummaryWithAttemptInformation(relatedContentSummary, usersQuestionAttempts);
+            }
+        }
+        // for all children recurse
+        List<ContentBaseDTO> children = content.getChildren();
+        if (children != null) {
+            for (ContentBaseDTO child : children) {
+                if (child instanceof ContentDTO) {
+                    ContentDTO childContent = (ContentDTO) child;
+                    augmentRelatedQuestionsWithAttemptInformation(childContent, usersQuestionAttempts);
+                }
+            }
+        }
+    }
+
+    private void augmentContentSummaryWithAttemptInformation(
+            final ContentSummaryDTO contentSummary,
+            final Map<String, ? extends Map<String, ? extends List<? extends LightweightQuestionValidationResponse>>> usersQuestionAttempts) {
+        String questionId = contentSummary.getId();
+        Map<String, ? extends List<? extends LightweightQuestionValidationResponse>> questionAttempts = usersQuestionAttempts.get(questionId);
+        boolean questionAnsweredCorrectly = false;
+        if (questionAttempts != null) {
+            for (String relatedQuestionPartId : contentSummary.getQuestionPartIds()) {
+                questionAnsweredCorrectly = false;
+                List<? extends LightweightQuestionValidationResponse> questionPartAttempts = questionAttempts.get(relatedQuestionPartId);
+                if (questionPartAttempts != null) {
+                    for (LightweightQuestionValidationResponse partAttempt : questionPartAttempts) {
+                        questionAnsweredCorrectly = partAttempt.isCorrect();
+                        if (questionAnsweredCorrectly) {
+                            break; // exit on first correct attempt
+                        }
+                    }
+                }
+                if (!questionAnsweredCorrectly) {
+                    break; // exit on first false question part
+                }
+            }
+        }
+        contentSummary.setCorrect(questionAnsweredCorrectly);
+    }
+
+    /**
+     * Augment a list of content summary objects with user attempt information.
+     * @param user the user to augment the content summary list for.
+     * @param summarizedResults the content summary list to augment.
+     * @param hideCompleted whether to filter out completed content.
+     * @return the augmented content summary list.
+     * @throws SegueDatabaseException if there is an error retrieving question attempts.
+     */
+    public List<ContentSummaryDTO> augmentContentSummaryListWithAttemptInformation(RegisteredUserDTO user, List<ContentSummaryDTO> summarizedResults, boolean hideCompleted) throws SegueDatabaseException {
+        List<String> questionPageIds = summarizedResults.stream().map(ContentSummaryDTO::getId).collect(Collectors.toList());
+
+        Map<String, Map<String, List<LightweightQuestionValidationResponse>>> questionAttempts =
+                questionManager.getMatchingLightweightQuestionAttempts(Collections.singletonList(user), questionPageIds)
+                        .getOrDefault(user.getId(), Collections.emptyMap());
+
+        for (ContentSummaryDTO result : summarizedResults) {
+            augmentContentSummaryWithAttemptInformation(result, questionAttempts);
+        }
+
+        if (hideCompleted) {
+            summarizedResults = summarizedResults.stream()
+                    .filter(q -> q.getCorrect() == null || !q.getCorrect())
+                    .collect(Collectors.toList());
+        }
+
+        return summarizedResults;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/SearchResultsWrapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/SearchResultsWrapper.java
@@ -1,0 +1,54 @@
+package uk.ac.cam.cl.dtg.isaac.dto;
+
+import java.util.List;
+
+/**
+ * A generic DO / DTO wrapper that can be used to return results from one layer of the application to another or indeed
+ * as a DTO.
+ *
+ *
+ * @param <T>
+ *            - The type of result that can be held in the Wrapper.
+ */
+public class SearchResultsWrapper<T> extends ResultsWrapper<T> {
+    private int nextSearchOffset;
+
+    /**
+     * Default constructor for constructing an empty search results wrapper.
+     */
+    public SearchResultsWrapper() {
+        super();
+        this.nextSearchOffset = 0;
+    }
+
+    /**
+     * The most commonly used constructor.
+     *
+     * @param results - a list of results to wrap
+     * @param totalResults - the total results which could be requested by the server - assuming that the results
+     *                     returned is a subset of all results that could be returned.
+     * @param nextSearchOffset - the offset to use for the next search.
+     */
+    public SearchResultsWrapper(final List<T> results, final Long totalResults, final int nextSearchOffset) {
+        super(results, totalResults);
+        this.nextSearchOffset = nextSearchOffset;
+    }
+
+    /**
+     * Get the offset to use for the next search.
+     *
+     * @return the offset to use for the next search.
+     */
+    public int getNextSearchOffset() {
+        return nextSearchOffset;
+    }
+
+    /**
+     * Set the offset to use for the next search.
+     *
+     * @param nextSearchOffset - the offset to use for the next search.
+     */
+    public void setNextSearchOffset(int nextSearchOffset) {
+        this.nextSearchOffset = nextSearchOffset;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -459,6 +459,8 @@ public final class Constants {
     public static final String STAGE_FIELDNAME = "audience.stage";
     public static final String DIFFICULTY_FIELDNAME = "audience.difficulty";
     public static final String EXAM_BOARD_FIELDNAME = "audience.examBoard";
+    public static final String HIDE_COMPLETED_FIELDNAME = "hideCompleted";
+    public static final String START_INDEX_FIELDNAME = "startIndex";
     public static final Set<String> NESTED_QUERY_FIELDS =
             ImmutableSet.of(STAGE_FIELDNAME, DIFFICULTY_FIELDNAME, EXAM_BOARD_FIELDNAME);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -634,6 +634,11 @@ public class GitContentManager {
         return contentDTO;
     }
 
+    public static ContentSummaryDTO populateContentSummaryValues(ContentDTO content, ContentSummaryDTO summary) {
+        generateDerivedSummaryValues(content, summary);
+        return summary;
+    }
+
     public String getCurrentContentSHA() {
         GetResponse shaResponse = contentShaCache.getIfPresent(contentIndex);
         try {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
@@ -20,6 +20,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 import uk.ac.cam.cl.dtg.isaac.api.managers.AssignmentManager;
+import uk.ac.cam.cl.dtg.isaac.api.managers.UserAttemptManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.EventBookingManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.QuizAssignmentManager;
@@ -152,6 +153,7 @@ public abstract class IsaacIntegrationTest {
     protected static QuestionManager questionManager;
     protected static QuizManager quizManager;
     protected static PgPasswordDataManager passwordDataManager;
+    protected static UserAttemptManager userAttemptManager;
 
     // Manager dependencies
     protected static IQuizAssignmentPersistenceManager quizAssignmentPersistenceManager;
@@ -335,6 +337,7 @@ public abstract class IsaacIntegrationTest {
         quizAttemptManager = new QuizAttemptManager(quizAttemptPersistenceManager);
         quizQuestionAttemptPersistenceManager = new PgQuizQuestionAttemptPersistenceManager(postgresSqlDb, contentMapper);
         quizQuestionManager = new QuizQuestionManager(questionManager, contentMapper, quizQuestionAttemptPersistenceManager, quizManager, quizAttemptManager);
+        userAttemptManager = new UserAttemptManager(questionManager);
 
         misuseMonitor = new InMemoryMisuseMonitor();
         misuseMonitor.registerHandler(GroupManagerLookupMisuseHandler.class.getSimpleName(), new GroupManagerLookupMisuseHandler(emailManager, properties));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
@@ -57,7 +57,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
+        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
                 ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", false, false, 0, -1);
 
         // Assert
@@ -83,7 +83,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
+        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
                 ITConstants.SEARCH_TEST_CONCEPT_ID, "", "", "", "", "", "", "", "", "", "", false, false, 0, -1);
 
         // Assert
@@ -109,7 +109,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
+        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
                 ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", true, false, 0, -1);
 
         // Assert
@@ -135,7 +135,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
+        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
                 String.format("%s,%s", ITConstants.REGRESSION_TEST_PAGE_ID, ITConstants.ASSIGNMENT_TEST_PAGE_ID), "",
                 "", "", "", "", "", "", "", "", "", false, false, 0, -1);
 
@@ -162,7 +162,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
+        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
                 "", "Regression Test Page", "", "", "", "", "", "", "", "", "", false, false, 0, -1);
 
         // Assert
@@ -188,7 +188,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
+        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
                 "", "Regression Test Page", "", "", "", "", "", "", "", "", "",false, false, 0, 1);
 
         // Assert

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
@@ -58,7 +58,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", false, 0, -1);
+                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", false, false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -84,7 +84,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                ITConstants.SEARCH_TEST_CONCEPT_ID, "", "", "", "", "", "", "", "", "", "", false, 0, -1);
+                ITConstants.SEARCH_TEST_CONCEPT_ID, "", "", "", "", "", "", "", "", "", "", false, false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -110,7 +110,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", true, 0, -1);
+                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", true, false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -137,7 +137,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
                 String.format("%s,%s", ITConstants.REGRESSION_TEST_PAGE_ID, ITConstants.ASSIGNMENT_TEST_PAGE_ID), "",
-                "", "", "", "", "", "", "", "", "", false, 0, -1);
+                "", "", "", "", "", "", "", "", "", false, false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -163,7 +163,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                "", "Regression Test Page", "", "", "", "", "", "", "", "", "", false, 0, -1);
+                "", "Regression Test Page", "", "", "", "", "", "", "", "", "", false, false, 0, -1);
 
         // Assert
         // check status code is OK
@@ -189,7 +189,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
         // Act
         // make request
         Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), createNiceMock(HttpServletRequest.class),
-                "", "Regression Test Page", "", "", "", "", "", "", "", "", "",false, 0, 1);
+                "", "Regression Test Page", "", "", "", "", "", "", "", "", "",false, false, 0, 1);
 
         // Assert
         // check status code is OK

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
@@ -43,7 +43,7 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
     @BeforeEach
     public void setUp() {
         this.pagesFacade = new PagesFacade(new ContentService(contentManager), properties, logManager,
-                mapperFacade, contentManager, userAccountManager, new URIManager(properties), questionManager, gameManager);
+                mapperFacade, contentManager, userAccountManager, new URIManager(properties), questionManager, gameManager, userAttemptManager);
     }
 
     @Test


### PR DESCRIPTION
- Augment search results for the new question finder with question attempt information;
- Support pagination, looping up to 5 times to try to pull `SEARCH_RESULTS_PER_PAGE = 30` questions in an attempt to match filters which cannot otherwise be checked for exclusively in ES.