### PR TITLE
Add lock on anonymous user ID when attempting questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
@@ -47,6 +47,7 @@ import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseLockTimoutException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
@@ -342,6 +343,12 @@ public class QuestionFacade extends AbstractSegueFacade {
         } catch (IllegalArgumentException e) {
             SegueErrorResponse error = new SegueErrorResponse(Status.BAD_REQUEST, "Bad request - " + e.getMessage(), e);
             log.error(error.getErrorMessage(), e);
+            return error.toResponse();
+        } catch (SegueDatabaseLockTimoutException e) {
+            // This error isn't great, but it's not bad enough for the full-page error:
+            SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Unable to save question attempt. Try again later!");
+            error.setBypassGenericSiteErrorPage(true);
+            log.warn("Lock timeout attempting to save anonymous user question attempt!");
             return error.toResponse();
         } catch (SegueDatabaseException e) {
             SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Unable to save question attempt. Try again later!");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/SegueDatabaseLockTimoutException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/SegueDatabaseLockTimoutException.java
@@ -1,0 +1,10 @@
+package uk.ac.cam.cl.dtg.segue.dao;
+
+/**
+ *   A subclass of SegueDatabaseException specifically for lock timeouts.
+ */
+public class SegueDatabaseLockTimoutException extends SegueDatabaseException {
+    public SegueDatabaseLockTimoutException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Since anonymous accounts' question attempts are stored as a single row in postgres, if two threads simultaneously try to write (in this case, caused by simultaneous submission of inline parts), a race condition occurs and writes can be lost. This meant all attempt values returned correctly to the frontend on submission, but since they were not saved in the database some updates were lost on reload.

This commit adds a `pg_advisory_xact_lock` on the anonymous user ID to prevent the race.