### PR TITLE
Add data objects for LLM free-text questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacLlmFreeTextQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacLlmFreeTextQuestion.java
@@ -1,0 +1,66 @@
+package uk.ac.cam.cl.dtg.isaac.dos;
+
+import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
+import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LlmFreeTextMarkSchemeEntry;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LlmFreeTextMarkedExample;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacLlmFreeTextQuestionDTO;
+
+import java.util.List;
+
+@DTOMapping(IsaacLlmFreeTextQuestionDTO.class)
+@JsonContentType("isaacLlmFreeTextQuestion")
+public class IsaacLlmFreeTextQuestion extends Question {
+    private String promptInstructionOverride;
+    private List<LlmFreeTextMarkSchemeEntry> markScheme;
+    private Integer maxMarks;
+    private String additionalMarkingInstructions;
+    private String markCalculationInstructions;
+    private List<LlmFreeTextMarkedExample> markedExamples;
+
+    public IsaacLlmFreeTextQuestion() {
+    }
+
+    public String getPromptInstructionOverride() {
+        return promptInstructionOverride;
+    }
+    public void setPromptInstructionOverride(String promptInstructionOverride) {
+        this.promptInstructionOverride = promptInstructionOverride;
+    }
+
+    public List<LlmFreeTextMarkSchemeEntry> getMarkScheme() {
+        return markScheme;
+    }
+    public void setMarkScheme(List<LlmFreeTextMarkSchemeEntry> markScheme) {
+        this.markScheme = markScheme;
+    }
+
+    public Integer getMaxMarks() {
+        return maxMarks;
+    }
+    public void setMaxMarks(Integer maxMarks) {
+        this.maxMarks = maxMarks;
+    }
+
+    public String getAdditionalMarkingInstructions() {
+        return additionalMarkingInstructions;
+    }
+    public void setAdditionalMarkingInstructions(String additionalMarkingInstructions) {
+        this.additionalMarkingInstructions = additionalMarkingInstructions;
+    }
+
+    public String getMarkCalculationInstructions() {
+        return markCalculationInstructions;
+    }
+    public void setMarkCalculationInstructions(String markCalculationInstructions) {
+        this.markCalculationInstructions = markCalculationInstructions;
+    }
+
+    public List<LlmFreeTextMarkedExample> getMarkedExamples() {
+        return markedExamples;
+    }
+    public void setMarkedExamples(List<LlmFreeTextMarkedExample> markedExamples) {
+        this.markedExamples = markedExamples;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LlmFreeTextMarkSchemeEntry.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LlmFreeTextMarkSchemeEntry.java
@@ -1,0 +1,31 @@
+package uk.ac.cam.cl.dtg.isaac.dos.content;
+
+public class LlmFreeTextMarkSchemeEntry {
+    private String jsonField;
+    private String shortDescription;
+    private Integer marks;
+
+    public LlmFreeTextMarkSchemeEntry() {
+    }
+
+    public String getJsonField() {
+        return jsonField;
+    }
+    public void setJsonField(String jsonField) {
+        this.jsonField = jsonField;
+    }
+
+    public String getShortDescription() {
+        return shortDescription;
+    }
+    public void setShortDescription(String shortDescription) {
+        this.shortDescription = shortDescription;
+    }
+
+    public Integer getMarks() {
+        return marks;
+    }
+    public void setMarks(Integer marks) {
+        this.marks = marks;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LlmFreeTextMarkedExample.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LlmFreeTextMarkedExample.java
@@ -1,0 +1,33 @@
+package uk.ac.cam.cl.dtg.isaac.dos.content;
+
+import java.util.Map;
+
+public class LlmFreeTextMarkedExample {
+    private String answer;
+    private Map<String, Integer> marks;
+    private Integer marksAwarded;
+
+    public LlmFreeTextMarkedExample() {
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    public Map<String, Integer> getMarks() {
+        return marks;
+    }
+    public void setMarks(Map<String, Integer> marks) {
+        this.marks = marks;
+    }
+
+    public Integer getMarksAwarded() {
+        return marksAwarded;
+    }
+    public void setMarksAwarded(Integer marksAwarded) {
+        this.marksAwarded = marksAwarded;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacLlmFreeTextQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacLlmFreeTextQuestionDTO.java
@@ -1,0 +1,9 @@
+package uk.ac.cam.cl.dtg.isaac.dto;
+
+import uk.ac.cam.cl.dtg.isaac.dto.content.QuestionDTO;
+
+//@ValidatesWith(/* LLM Free-Text Validator.class */)
+public class IsaacLlmFreeTextQuestionDTO extends QuestionDTO {
+    public IsaacLlmFreeTextQuestionDTO() {
+    }
+}


### PR DESCRIPTION
This PR adds a few extra data objects so that ETL  can handle the new LLM questions while we trial them on dev.

---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- ~Added enough Logging to monitor expected behaviour change~
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
