### PR TITLE
Correctly capitalise LLM acronym in class and type names

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacLLMFreeTextQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacLLMFreeTextQuestion.java
@@ -2,24 +2,24 @@ package uk.ac.cam.cl.dtg.isaac.dos;
 
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
-import uk.ac.cam.cl.dtg.isaac.dos.content.LlmFreeTextMarkSchemeEntry;
-import uk.ac.cam.cl.dtg.isaac.dos.content.LlmFreeTextMarkedExample;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMFreeTextMarkSchemeEntry;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMFreeTextMarkedExample;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
-import uk.ac.cam.cl.dtg.isaac.dto.IsaacLlmFreeTextQuestionDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacLLMFreeTextQuestionDTO;
 
 import java.util.List;
 
-@DTOMapping(IsaacLlmFreeTextQuestionDTO.class)
-@JsonContentType("isaacLlmFreeTextQuestion")
-public class IsaacLlmFreeTextQuestion extends Question {
+@DTOMapping(IsaacLLMFreeTextQuestionDTO.class)
+@JsonContentType("isaacLLMFreeTextQuestion")
+public class IsaacLLMFreeTextQuestion extends Question {
     private String promptInstructionOverride;
-    private List<LlmFreeTextMarkSchemeEntry> markScheme;
+    private List<LLMFreeTextMarkSchemeEntry> markScheme;
     private Integer maxMarks;
     private String additionalMarkingInstructions;
     private String markCalculationInstructions;
-    private List<LlmFreeTextMarkedExample> markedExamples;
+    private List<LLMFreeTextMarkedExample> markedExamples;
 
-    public IsaacLlmFreeTextQuestion() {
+    public IsaacLLMFreeTextQuestion() {
     }
 
     public String getPromptInstructionOverride() {
@@ -29,10 +29,10 @@ public class IsaacLlmFreeTextQuestion extends Question {
         this.promptInstructionOverride = promptInstructionOverride;
     }
 
-    public List<LlmFreeTextMarkSchemeEntry> getMarkScheme() {
+    public List<LLMFreeTextMarkSchemeEntry> getMarkScheme() {
         return markScheme;
     }
-    public void setMarkScheme(List<LlmFreeTextMarkSchemeEntry> markScheme) {
+    public void setMarkScheme(List<LLMFreeTextMarkSchemeEntry> markScheme) {
         this.markScheme = markScheme;
     }
 
@@ -57,10 +57,10 @@ public class IsaacLlmFreeTextQuestion extends Question {
         this.markCalculationInstructions = markCalculationInstructions;
     }
 
-    public List<LlmFreeTextMarkedExample> getMarkedExamples() {
+    public List<LLMFreeTextMarkedExample> getMarkedExamples() {
         return markedExamples;
     }
-    public void setMarkedExamples(List<LlmFreeTextMarkedExample> markedExamples) {
+    public void setMarkedExamples(List<LLMFreeTextMarkedExample> markedExamples) {
         this.markedExamples = markedExamples;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMFreeTextMarkSchemeEntry.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMFreeTextMarkSchemeEntry.java
@@ -1,11 +1,11 @@
 package uk.ac.cam.cl.dtg.isaac.dos.content;
 
-public class LlmFreeTextMarkSchemeEntry {
+public class LLMFreeTextMarkSchemeEntry {
     private String jsonField;
     private String shortDescription;
     private Integer marks;
 
-    public LlmFreeTextMarkSchemeEntry() {
+    public LLMFreeTextMarkSchemeEntry() {
     }
 
     public String getJsonField() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMFreeTextMarkedExample.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMFreeTextMarkedExample.java
@@ -2,12 +2,12 @@ package uk.ac.cam.cl.dtg.isaac.dos.content;
 
 import java.util.Map;
 
-public class LlmFreeTextMarkedExample {
+public class LLMFreeTextMarkedExample {
     private String answer;
     private Map<String, Integer> marks;
     private Integer marksAwarded;
 
-    public LlmFreeTextMarkedExample() {
+    public LLMFreeTextMarkedExample() {
     }
 
     public String getAnswer() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacLLMFreeTextQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacLLMFreeTextQuestionDTO.java
@@ -3,7 +3,7 @@ package uk.ac.cam.cl.dtg.isaac.dto;
 import uk.ac.cam.cl.dtg.isaac.dto.content.QuestionDTO;
 
 //@ValidatesWith(/* LLM Free-Text Validator.class */)
-public class IsaacLlmFreeTextQuestionDTO extends QuestionDTO {
-    public IsaacLlmFreeTextQuestionDTO() {
+public class IsaacLLMFreeTextQuestionDTO extends QuestionDTO {
+    public IsaacLLMFreeTextQuestionDTO() {
     }
 }


### PR DESCRIPTION
Update naming of classes containing the LLM acronym to align with the codebase's convention.