### PR TITLE
Skip quick questions for question completeness

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -28,10 +28,10 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.h2.schema.Constant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
+import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuickQuestionDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
@@ -785,7 +785,7 @@ public class GitContentManager {
      * @param questionPartIds a list to track the question part IDs in the content and its children.
      */
     private static void collateQuestionPartIds(final ContentDTO content, final List<String> questionPartIds) {
-        if (content instanceof QuestionDTO) {
+        if (content instanceof QuestionDTO && !(content instanceof IsaacQuickQuestionDTO)) {
             questionPartIds.add(content.getId());
         }
         List<ContentBaseDTO> children = content.getChildren();


### PR DESCRIPTION
We already do this in other methods that work out whether a question is complete or not.
See e.g. `GameManager::getAllMarkableDOQuestionPartsDFSOrder` which has a filter method to remove quick questions explicitly.

This has been broken, mainly for related questions where this code originally lived, since it was introduced in fa636643a2af7e985e3e214473aa89a4d9a36ce8. Since the new question finder started using it in #607, this edge case involving quick questions has become more obvious.

This is a hotfix, pending a more thorough review of and/or rewrite to combine the multiple ways of computing whether a question is complete or not.