### PR TITLE
Add substring strategy for questions query

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -442,19 +442,19 @@ public class GitContentManager {
 
                 // Search term matches
                 .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms)
-                        .priority(Priority.HIGH).strategy(Strategy.SIMPLE))
+                        .priority(Priority.HIGH).strategy(Strategy.SUBSTRING))
                 .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms)
-                        .priority(Priority.HIGH).strategy(Strategy.SIMPLE))
+                        .priority(Priority.HIGH).strategy(Strategy.SUBSTRING))
                 .searchFor(new SearchInField(Constants.SUBTITLE_FIELDNAME, searchTerms)
-                        .priority(Priority.HIGH).strategy(Strategy.SIMPLE))
+                        .priority(Priority.HIGH).strategy(Strategy.SUBSTRING))
                 .searchFor(new SearchInField(Constants.SUMMARY_FIELDNAME, searchTerms)
-                        .priority(Priority.HIGH).strategy(Strategy.SIMPLE))
+                        .priority(Priority.HIGH).strategy(Strategy.SUBSTRING))
                 .searchFor(new SearchInField(Constants.TAGS_FIELDNAME, searchTerms)
-                        .priority(Priority.HIGH).strategy(Strategy.SIMPLE))
+                        .priority(Priority.HIGH).strategy(Strategy.SUBSTRING))
                 .searchFor(new SearchInField(Constants.PRIORITISED_SEARCHABLE_CONTENT_FIELDNAME, searchTerms)
-                        .priority(Priority.HIGH).strategy(Strategy.SIMPLE))
+                        .priority(Priority.HIGH).strategy(Strategy.SUBSTRING))
                 .searchFor(new SearchInField(Constants.SEARCHABLE_CONTENT_FIELDNAME, searchTerms)
-                        .strategy(Strategy.SIMPLE));
+                        .strategy(Strategy.SUBSTRING));
 
         // Add a required filtering rule for each field that has a value
         for (Map.Entry<String, Set<String>> entry : filterFieldNamesToValues.entrySet()) {
@@ -467,7 +467,7 @@ public class GitContentManager {
                 } else if (Arrays.asList(SUBJECTS_FIELDNAME, FIELDS_FIELDNAME, TOPICS_FIELDNAME)
                         .contains(entry.getKey())) {
                     searchInstructionBuilder.searchFor(new SearchInField(TAGS_FIELDNAME, entry.getValue())
-                            .strategy(Strategy.SIMPLE)
+                            .strategy(Strategy.SUBSTRING)
                             .atLeastOne(true));
                 } else {
                     boolean applyOrFilterBetweenValues = ID_FIELDNAME.equals(entry.getKey());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
@@ -69,7 +69,8 @@ public class IsaacSearchInstructionBuilder {
     public enum Strategy {
         SIMPLE,
         DEFAULT,
-        FUZZY
+        FUZZY,
+        SUBSTRING
     }
 
 
@@ -343,6 +344,15 @@ public class IsaacSearchInstructionBuilder {
                                 new MatchInstruction(searchInField.getField(), term, boost, false));
                         generatedSubInstructions.add(
                                 new MatchInstruction(searchInField.getField(), term, fuzzyBoost, true));
+
+                    } else if (searchInField.getStrategy() == Strategy.SUBSTRING) {
+                        Long boost = searchInField.getPriority() == Priority.HIGH
+                                ? HIGH_PRIORITY_FIELD_BOOST : FIELD_BOOST;
+
+                        generatedSubInstructions.add(
+                                new MatchInstruction(searchInField.getField(), term, boost, false));
+                        generatedSubInstructions.add(
+                                new WildcardInstruction(searchInField.getField(), "*" + term + "*", boost));
 
                     } else if (searchInField.getStrategy() == Strategy.FUZZY) {
                         Long boost = searchInField.getPriority() == Priority.HIGH


### PR DESCRIPTION
This adds a new ElasticSearch query strategy for substring matching.
This is used by the new question finder and the teacher gameboard builder.

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
