### PR TITLE
Support multiple correct choices in cloze questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacClozeValidator.java
@@ -168,8 +168,11 @@ public class IsaacClozeValidator implements IValidator {
                     itemMatches.add(itemMatch);
                 }
 
-                // If this is the first correct choice, the status of each item might be useful feedback:
-                if (null == itemsCorrect && itemChoice.isCorrect() && detailedItemFeedback) {
+                // Set the 'list of correctness of each item' to match the feedback corresponding to the ItemChoice
+                // that matches the most items.
+                if (detailedItemFeedback && itemChoice.isCorrect() && (null == itemsCorrect
+                        || itemsCorrect.stream().filter(i -> i).count() < itemMatches.stream().filter(i -> i).count()
+                    )) {
                     itemsCorrect = itemMatches;
                 }
 


### PR DESCRIPTION
If `detailedItemFeedback` is set, Cloze questions will now return feedback corresponding to the *most correct* choice rather than the first, as determined by the number of correct items. 
