### PR TITLE
Require passwords at least 8 characters in length

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -319,6 +319,7 @@ public final class Constants {
     public static final String RASPBERRYPI_LOCAL_IDP_METADATA_PATH = "RASPBERRYPI_LOCAL_IDP_METADATA_PATH";
 
     // Local authentication specific stuff
+    public static final int MINIMUM_PASSWORD_LENGTH = 8;
     public static final String LOCAL_AUTH_EMAIL_FIELDNAME = "email";
     public static final String LOCAL_AUTH_EMAIL_VERIFICATION_TOKEN_FIELDNAME = "emailVerificationToken";
     public static final String LOCAL_AUTH_GROUP_MANAGER_INITIATED_FIELDNAME = "groupManagerInitiated";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -747,8 +747,8 @@ public class UserAuthenticationManager {
             throw new InvalidPasswordException("Empty passwords are not allowed if using local authentication.");
         }
 
-        if (newPassword.length() < 6) {
-            throw new InvalidPasswordException("Password must be at least 6 characters in length.");
+        if (newPassword.length() < MINIMUM_PASSWORD_LENGTH) {
+            throw InvalidPasswordException.getPasswordLengthException(MINIMUM_PASSWORD_LENGTH);
         }
 
         IPasswordAuthenticator authenticator = (IPasswordAuthenticator) this.registeredAuthProviders

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
@@ -244,8 +244,8 @@ public class SegueLocalAuthenticator implements IPasswordAuthenticator {
             throw new InvalidPasswordException("Invalid password. You cannot have an empty password.");
         }
 
-        if (password.length() < 6) {
-            throw new InvalidPasswordException("Password must be at least 6 characters in length.");
+        if (password.length() < MINIMUM_PASSWORD_LENGTH) {
+            throw InvalidPasswordException.getPasswordLengthException(MINIMUM_PASSWORD_LENGTH);
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidPasswordException.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/exceptions/InvalidPasswordException.java
@@ -34,4 +34,16 @@ public class InvalidPasswordException extends Exception {
     public InvalidPasswordException(final String message) {
         super(message);
     }
+
+    /**
+     * Generate a consistent error message for password length exceptions.
+     *
+     * @param minLength - the minimum required password length.
+     * @return an InvalidPasswordException with an error message stating the length requirement.
+     */
+    public static InvalidPasswordException getPasswordLengthException(final int minLength) {
+        return new InvalidPasswordException(
+                String.format("Password must be at least %s characters in length.", minLength)
+        );
+    }
 }


### PR DESCRIPTION
This was already enforced in the frontend for Ada CS, but Isaac retained the 6 character minimum.