### PR TITLE
Add migration to set default assignment email preference

### DIFF
--- a/src/main/resources/db_scripts/migrations/2024-08-set_default_email_preference_ada.sql
+++ b/src/main/resources/db_scripts/migrations/2024-08-set_default_email_preference_ada.sql
@@ -1,0 +1,7 @@
+INSERT INTO public.user_preferences (user_id, preference_type, preference_name, preference_value, last_updated)
+SELECT DISTINCT user_id, 'EMAIL_PREFERENCE' AS preference_type, 'ASSIGNMENTS' AS preference_name, true AS preference_value, now() as last_updated
+FROM public.user_preferences
+WHERE user_id NOT IN (
+    SELECT user_id FROM public.user_preferences
+    WHERE preference_type = 'EMAIL_PREFERENCE'
+);


### PR DESCRIPTION
---

**Pull Request Check List**
- ~~Unit Tests & Regression Tests Added (Optional)~~
- ~~Removed Unnecessary Logs/System.Outs/Comments/TODOs~~
- ~~Added enough Logging to monitor expected behaviour change~~
- ~~Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped~~
- ~~Security - Data Exposure - PII is not stored or sent unencrypted~~
- ~~Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)~~
- ~~Security - Access Control - Check authorisation on every new endpoint~~
- ~~Security - New dependency - configured sensibly not relying on defaults~~
- ~~Security - New dependency - Searched for any know vulnerabilities~~
- ~~Security - New dependency - Signed up team to mailing list~~
- ~~Security - New dependency - Added to dependency list~~
- ~~DB schema changes - postgres-rutherford-create-script updated~~
- ~~DB schema changes - upgrade script created matching create script~~
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
