### PR TITLE
Fix inline question marking for content summaries

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -30,6 +30,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuickQuestionDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
@@ -776,30 +777,9 @@ public class GitContentManager {
      *                The values of this instance could be changed by this method.
      */
     private static void generateDerivedSummaryValues(final ContentDTO content, final ContentSummaryDTO summary) {
-        List<String> questionPartIds = Lists.newArrayList();
-        GitContentManager.collateQuestionPartIds(content, questionPartIds);
+        List<QuestionDTO> questionParts = GameManager.getAllMarkableQuestionPartsDFSOrder(content);
+        List<String> questionPartIds = questionParts.stream().map(QuestionDTO::getId).collect(Collectors.toList());
         summary.setQuestionPartIds(questionPartIds);
-    }
-
-    /**
-     * Recursively walk through the content object and its children to populate the questionPartIds list with the IDs
-     * of any content of type QuestionDTO.
-     * @param content the content page and, on recursive invocations, its children.
-     * @param questionPartIds a list to track the question part IDs in the content and its children.
-     */
-    private static void collateQuestionPartIds(final ContentDTO content, final List<String> questionPartIds) {
-        if (content instanceof QuestionDTO && !(content instanceof IsaacQuickQuestionDTO)) {
-            questionPartIds.add(content.getId());
-        }
-        List<ContentBaseDTO> children = content.getChildren();
-        if (children != null) {
-            for (ContentBaseDTO child : children) {
-                if (child instanceof ContentDTO) {
-                    ContentDTO childContent = (ContentDTO) child;
-                    collateQuestionPartIds(childContent, questionPartIds);
-                }
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
We (still) have two different ways of working out whether a question has been answered correctly. This removes some of the duplication, to fix an issue where inline regions were overlooked when marking a question using the content summary way of marking.

The gameboard-based methods had already been updated to include inline regions, but `collateQuestionPartIds(...)` did not include them in its collation.