### PR TITLE
Add char limit to QF search

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -379,6 +379,10 @@ public class PagesFacade extends AbstractIsaacFacade {
             }
         }
 
+        if (searchString.length() > SEARCH_TEXT_CHAR_LIMIT) {
+            return SegueErrorResponse.getBadRequestResponse(
+                    String.format("Search string exceeded %s character limit.", SEARCH_TEXT_CHAR_LIMIT));
+        }
         String validatedSearchString = searchString.isBlank() ? null : searchString;
 
         // Show content tagged as "nofilter" if the user is staff


### PR DESCRIPTION
Apply the 1000 character limit from the main search to the new question finder search.