### PR TITLE
Support anonymous users in question finder

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -75,7 +75,11 @@ public final class Constants {
     public enum CompletionState {
         ALL_CORRECT, IN_PROGRESS, NOT_ATTEMPTED;
 
-        public static final Set<CompletionState> ALL_STATES = Set.of(CompletionState.values());
+        private static final Set<CompletionState> allStates = Set.of(CompletionState.values());
+
+        public static Set<CompletionState> getAllStates() {
+            return allStates;
+        }
     }
 
     public enum QuestionPartState {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -73,7 +73,9 @@ public final class Constants {
     }
 
     public enum CompletionState {
-        ALL_CORRECT, IN_PROGRESS, NOT_ATTEMPTED
+        ALL_CORRECT, IN_PROGRESS, NOT_ATTEMPTED;
+
+        public static final Set<CompletionState> ALL_STATES = Set.of(CompletionState.values());
     }
 
     public enum QuestionPartState {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -389,8 +389,10 @@ public class PagesFacade extends AbstractIsaacFacade {
 
         try {
             if (null == statuses) {
+                // If statuses isn't a URL param, we won't augment or filter!
                 filterByStatuses = null;
             } else if (statuses.isEmpty()) {
+                // If statuses is blank, that shouldn't mean "please match nothing at all"; make it match everything.
                 filterByStatuses = CompletionState.getAllStates();
             } else {
                 filterByStatuses = Arrays.stream(statuses.split(","))

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -404,12 +404,14 @@ public class PagesFacade extends AbstractIsaacFacade {
 
         String validatedSearchString = searchString.isBlank() ? null : searchString;
 
-        // Show content tagged as "nofilter" if the user is staff
-        boolean showNoFilterContent;
+        // Show content tagged as "nofilter" if the user is staff:
+        boolean showNoFilterContent = false;
         try {
-            showNoFilterContent = isUserStaff(userManager, httpServletRequest);
+            if (user instanceof RegisteredUserDTO) {
+                showNoFilterContent = isUserStaff(userManager, (RegisteredUserDTO) user);
+            }
         } catch (NoUserLoggedInException e) {
-            showNoFilterContent = false;
+            // This cannot happen!
         }
 
         List<ContentSummaryDTO> combinedResults = new ArrayList<>();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -391,7 +391,7 @@ public class PagesFacade extends AbstractIsaacFacade {
             if (null == statuses) {
                 filterByStatuses = null;
             } else if (statuses.isEmpty()) {
-                filterByStatuses = CompletionState.ALL_STATES;
+                filterByStatuses = CompletionState.getAllStates();
             } else {
                 filterByStatuses = Arrays.stream(statuses.split(","))
                         .map(CompletionState::valueOf)
@@ -445,7 +445,7 @@ public class PagesFacade extends AbstractIsaacFacade {
                     // Only augment when filtering by statuses:
                     summarizedResults = userAttemptManager.augmentContentSummaryListWithAttemptInformation(user, summarizedResults);
                     // Optimise out unnecessary filtering:
-                    if (!filterByStatuses.equals(CompletionState.ALL_STATES)) {
+                    if (!filterByStatuses.equals(CompletionState.getAllStates())) {
                         summarizedResults = summarizedResults.stream()
                                 .filter(q -> filterByStatuses.contains(q.getState()))
                                 .collect(Collectors.toList());


### PR DESCRIPTION
This PR is mostly to add support for anonymous users in question finder augmentation and filtering behaviour.

There are some performance optimisations (don't load the user multiple times, avoid filtering if the filter is equivalent "everything"), and one key behavior change (don't augment results if `statuses` is not specified, which restores the old behaviour useful for the gameboard builder).