### PR TITLE
Allows equivalent answers with different "requiresExactMatch" values to have different feedback

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
@@ -214,6 +214,10 @@ public class IsaacSymbolicLogicValidator implements IValidator {
                     closestMatch = logicFormulaChoice;
                     closestMatchType = MatchType.EXACT;
                     break;
+                } else if (matchType == MatchType.SYMBOLIC && !logicFormulaChoice.getRequiresExactMatch() && logicFormulaChoice.isCorrect()) {
+                    closestMatch = logicFormulaChoice;
+                    closestMatchType = MatchType.SYMBOLIC;
+                    break;
                 } else if (matchType.compareTo(closestMatchType) > 0) {
                     if (logicFormulaChoice.getRequiresExactMatch() && logicFormulaChoice.isCorrect()) {
                         closestMatch = logicFormulaChoice;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
@@ -214,10 +214,9 @@ public class IsaacSymbolicLogicValidator implements IValidator {
                     closestMatch = logicFormulaChoice;
                     closestMatchType = MatchType.EXACT;
                     break;
-                } else if (matchType == MatchType.SYMBOLIC && !logicFormulaChoice.getRequiresExactMatch() && logicFormulaChoice.isCorrect()) {
+                } else if (matchType == MatchType.SYMBOLIC && !logicFormulaChoice.getRequiresExactMatch()) {
                     closestMatch = logicFormulaChoice;
                     closestMatchType = MatchType.SYMBOLIC;
-                    break;
                 } else if (matchType.compareTo(closestMatchType) > 0) {
                     if (logicFormulaChoice.getRequiresExactMatch() && logicFormulaChoice.isCorrect()) {
                         closestMatch = logicFormulaChoice;


### PR DESCRIPTION
Currently a `SYMBOLIC` match to an `EXACT` answer will supersede all later matches to all other `logicFormulaChoice`s (therefore always providing the default feedback). 

This change allows for a special case with custom feedback to be given on questions with both `"requiresExactMatch": true` and `"requiresExactMatch": false` choices with the same answer.

e.g. [Regression Test Page](https://staging.isaacphysics.org/questions/_regression_test_?stage=all) (Part H)