### PR TITLE
Add LLM marking formula AST classes

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacLLMFreeTextQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacLLMFreeTextQuestion.java
@@ -4,6 +4,7 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dos.content.LLMFreeTextMarkSchemeEntry;
 import uk.ac.cam.cl.dtg.isaac.dos.content.LLMFreeTextMarkedExample;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingExpression;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacLLMFreeTextQuestionDTO;
 import uk.ac.cam.cl.dtg.isaac.quiz.IsaacLLMFreeTextValidator;
@@ -23,6 +24,7 @@ public class IsaacLLMFreeTextQuestion extends Question {
     private String additionalMarkingInstructions;
     private String markCalculationInstructions;
     private List<LLMFreeTextMarkedExample> markedExamples;
+    private LLMMarkingExpression markingFormula;
 
     public IsaacLLMFreeTextQuestion() {
     }
@@ -68,5 +70,11 @@ public class IsaacLLMFreeTextQuestion extends Question {
     public void setMarkedExamples(List<LLMFreeTextMarkedExample> markedExamples) {
         this.markedExamples = markedExamples;
     }
-}
 
+    public LLMMarkingExpression getMarkingFormula() {
+        return markingFormula;
+    }
+    public void setMarkingFormula(LLMMarkingExpression markingFormula) {
+        this.markingFormula = markingFormula;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingConstant.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingConstant.java
@@ -1,0 +1,24 @@
+package uk.ac.cam.cl.dtg.isaac.dos.content;
+
+@JsonContentType("LLMMarkingConstant")
+public class LLMMarkingConstant extends LLMMarkingExpression {
+    private String type;
+    private String value;
+
+    public LLMMarkingConstant() {
+    }
+
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingConstant.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingConstant.java
@@ -6,7 +6,7 @@ package uk.ac.cam.cl.dtg.isaac.dos.content;
 @JsonContentType("LLMMarkingConstant")
 public class LLMMarkingConstant extends LLMMarkingExpression {
     private String type;
-    private String value;
+    private Integer value;
 
     public LLMMarkingConstant() {
     }
@@ -20,10 +20,10 @@ public class LLMMarkingConstant extends LLMMarkingExpression {
         this.type = type;
     }
 
-    public String getValue() {
+    public Integer getValue() {
         return value;
     }
-    public void setValue(String value) {
+    public void setValue(Integer value) {
         this.value = value;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingConstant.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingConstant.java
@@ -1,5 +1,8 @@
 package uk.ac.cam.cl.dtg.isaac.dos.content;
 
+/**
+ * LLM Marking Constants represent numeric values to be used by the LLM marking formulae.
+ */
 @JsonContentType("LLMMarkingConstant")
 public class LLMMarkingConstant extends LLMMarkingExpression {
     private String type;
@@ -8,9 +11,11 @@ public class LLMMarkingConstant extends LLMMarkingExpression {
     public LLMMarkingConstant() {
     }
 
+    @Override
     public String getType() {
         return type;
     }
+    @Override
     public void setType(String type) {
         this.type = type;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingExpression.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingExpression.java
@@ -5,4 +5,5 @@ package uk.ac.cam.cl.dtg.isaac.dos.content;
  */
 public abstract class LLMMarkingExpression {
     abstract String getType();
+    abstract void setType(String type);
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingExpression.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingExpression.java
@@ -1,0 +1,8 @@
+package uk.ac.cam.cl.dtg.isaac.dos.content;
+
+/**
+ * Abstract class to represent the fomulae for marking LLM questions.
+ */
+public abstract class LLMMarkingExpression {
+    abstract String getType();
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingFunction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingFunction.java
@@ -2,6 +2,9 @@ package uk.ac.cam.cl.dtg.isaac.dos.content;
 
 import java.util.List;
 
+/**
+ * LLM marking functions represent the functions that can be applied to the arguments in the LLM marking formulae.
+ */
 @JsonContentType("LLMMarkingFunction")
 public class LLMMarkingFunction extends LLMMarkingExpression {
     private String type;
@@ -11,9 +14,11 @@ public class LLMMarkingFunction extends LLMMarkingExpression {
     public LLMMarkingFunction() {
     }
 
+    @Override
     public String getType() {
         return type;
     }
+    @Override
     public void setType(String type) {
         this.type = type;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingFunction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingFunction.java
@@ -7,8 +7,12 @@ import java.util.List;
  */
 @JsonContentType("LLMMarkingFunction")
 public class LLMMarkingFunction extends LLMMarkingExpression {
+    public enum FunctionName {
+        SUM, MIN, MAX
+    }
+
     private String type;
-    private String name;
+    private FunctionName name;
     private List<LLMMarkingExpression> arguments;
 
     public LLMMarkingFunction() {
@@ -23,10 +27,10 @@ public class LLMMarkingFunction extends LLMMarkingExpression {
         this.type = type;
     }
 
-    public String getName() {
+    public FunctionName getName() {
         return name;
     }
-    public void setName(String name) {
+    public void setName(FunctionName name) {
         this.name = name;
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingFunction.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingFunction.java
@@ -1,0 +1,34 @@
+package uk.ac.cam.cl.dtg.isaac.dos.content;
+
+import java.util.List;
+
+@JsonContentType("LLMMarkingFunction")
+public class LLMMarkingFunction extends LLMMarkingExpression {
+    private String type;
+    private String name;
+    private List<LLMMarkingExpression> arguments;
+
+    public LLMMarkingFunction() {
+    }
+
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<LLMMarkingExpression> getArguments() {
+        return arguments;
+    }
+    public void setArguments(List<LLMMarkingExpression> arguments) {
+        this.arguments = arguments;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingVariable.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingVariable.java
@@ -1,5 +1,10 @@
 package uk.ac.cam.cl.dtg.isaac.dos.content;
 
+/**
+ * LLM marking variables represent the identifiers for the json fields returned by the LLM for each mark or the maxMarks
+ * value specified by the question. When evaluated, these variables will be replaced with the actual values from the
+ * current context - the numeric value awarded for that specific mark by the LLM for the student's answer.
+ */
 @JsonContentType("LLMMarkingVariable")
 public class LLMMarkingVariable extends LLMMarkingExpression {
     private String type;
@@ -8,9 +13,11 @@ public class LLMMarkingVariable extends LLMMarkingExpression {
     public LLMMarkingVariable() {
     }
 
+    @Override
     public String getType() {
         return type;
     }
+    @Override
     public void setType(String type) {
         this.type = type;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingVariable.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingVariable.java
@@ -1,0 +1,24 @@
+package uk.ac.cam.cl.dtg.isaac.dos.content;
+
+@JsonContentType("LLMMarkingVariable")
+public class LLMMarkingVariable extends LLMMarkingExpression {
+    private String type;
+    private String name;
+
+    public LLMMarkingVariable() {
+    }
+
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
@@ -36,6 +36,7 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.ContentBase;
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Item;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingExpression;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
@@ -343,6 +344,9 @@ public class ContentMapper {
      * @return ObjectMapper that has been configured to handle the segue recursive object model.
      */
     public ObjectMapper generateNewPreconfiguredContentMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
         ContentBaseDeserializer contentDeserializer = new ContentBaseDeserializer();
         contentDeserializer.registerTypeMap(jsonTypes);
 
@@ -353,10 +357,10 @@ public class ContentMapper {
         ChoiceDeserializer choiceDeserializer = new ChoiceDeserializer(contentDeserializer, itemDeserializer);
 
         QuestionValidationResponseDeserializer validationResponseDeserializer 
-            = new QuestionValidationResponseDeserializer(
-                contentDeserializer, choiceDeserializer);
+            = new QuestionValidationResponseDeserializer(contentDeserializer, choiceDeserializer);
 
-        IsaacQuestionBaseDeserializer isaacQuestionBaseDeserializer = new IsaacQuestionBaseDeserializer(contentDeserializer);
+        IsaacQuestionBaseDeserializer isaacQuestionBaseDeserializer =
+                new IsaacQuestionBaseDeserializer(contentDeserializer);
 
         SimpleModule contentDeserializerModule = new SimpleModule("ContentDeserializerModule");
         contentDeserializerModule.addDeserializer(ContentBase.class, contentDeserializer);
@@ -364,9 +368,9 @@ public class ContentMapper {
         contentDeserializerModule.addDeserializer(Choice.class, choiceDeserializer);
         contentDeserializerModule.addDeserializer(Item.class, itemDeserializer);
         contentDeserializerModule.addDeserializer(QuestionValidationResponse.class, validationResponseDeserializer);
+        contentDeserializerModule.addDeserializer(
+                LLMMarkingExpression.class, new LLMMarkingExpressionDeserializer(objectMapper));
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.registerModule(contentDeserializerModule);
         
         return objectMapper;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
@@ -344,9 +344,6 @@ public class ContentMapper {
      * @return ObjectMapper that has been configured to handle the segue recursive object model.
      */
     public ObjectMapper generateNewPreconfiguredContentMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-
         ContentBaseDeserializer contentDeserializer = new ContentBaseDeserializer();
         contentDeserializer.registerTypeMap(jsonTypes);
 
@@ -368,9 +365,10 @@ public class ContentMapper {
         contentDeserializerModule.addDeserializer(Choice.class, choiceDeserializer);
         contentDeserializerModule.addDeserializer(Item.class, itemDeserializer);
         contentDeserializerModule.addDeserializer(QuestionValidationResponse.class, validationResponseDeserializer);
-        contentDeserializerModule.addDeserializer(
-                LLMMarkingExpression.class, new LLMMarkingExpressionDeserializer(objectMapper));
+        contentDeserializerModule.addDeserializer(LLMMarkingExpression.class, new LLMMarkingExpressionDeserializer());
 
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.registerModule(contentDeserializerModule);
         
         return objectMapper;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/LLMMarkingExpressionDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/LLMMarkingExpressionDeserializer.java
@@ -1,0 +1,48 @@
+package uk.ac.cam.cl.dtg.segue.dao.content;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingConstant;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingExpression;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingFunction;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingVariable;
+
+import java.io.IOException;
+
+public class LLMMarkingExpressionDeserializer extends JsonDeserializer<LLMMarkingExpression> {
+    private final ObjectMapper objectMapper;
+
+    public LLMMarkingExpressionDeserializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public LLMMarkingExpression deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext)
+            throws IOException {
+        ObjectNode root = objectMapper.readTree(jsonParser);
+
+        if (null == root.get("type")) {
+            throw new JsonMappingException(
+                    "Error: unable to parse content as there is no type property within the json input.");
+        }
+
+        String contentType = root.get("type").textValue();
+
+        switch (contentType) {
+            case "LLMMarkingFunction":
+                return objectMapper.readValue(root.toString(), LLMMarkingFunction.class);
+            case "LLMMarkingVariable":
+                return objectMapper.readValue(root.toString(), LLMMarkingVariable.class);
+            case "LLMMarkingConstant":
+                return objectMapper.readValue(root.toString(), LLMMarkingConstant.class);
+            default:
+                throw new JsonMappingException(
+                        String.format("Error: unable to parse LLM marking expression. Unhandled type: %s", contentType));
+        }
+    }
+
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/LLMMarkingExpressionDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/LLMMarkingExpressionDeserializer.java
@@ -21,8 +21,8 @@ public class LLMMarkingExpressionDeserializer extends JsonDeserializer<LLMMarkin
         ObjectNode root = objectMapper.readTree(jsonParser);
 
         if (null == root.get("type")) {
-            throw new JsonMappingException(
-                    "Error: unable to parse content as there is no type property within the json input.");
+            throw JsonMappingException.from(
+                    jsonParser, "Error: unable to parse content - no type property within the json input.");
         }
 
         String contentType = root.get("type").textValue();
@@ -35,7 +35,8 @@ public class LLMMarkingExpressionDeserializer extends JsonDeserializer<LLMMarkin
             case "LLMMarkingConstant":
                 return objectMapper.readValue(root.toString(), LLMMarkingConstant.class);
             default:
-                throw new JsonMappingException(
+                throw JsonMappingException.from(
+                        jsonParser,
                         String.format("Error: unable to parse LLM marking expression. Unhandled type: %s", contentType));
         }
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/LLMMarkingExpressionDeserializer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/LLMMarkingExpressionDeserializer.java
@@ -14,15 +14,10 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingVariable;
 import java.io.IOException;
 
 public class LLMMarkingExpressionDeserializer extends JsonDeserializer<LLMMarkingExpression> {
-    private final ObjectMapper objectMapper;
-
-    public LLMMarkingExpressionDeserializer(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
-
     @Override
     public LLMMarkingExpression deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext)
             throws IOException {
+        ObjectMapper objectMapper = (ObjectMapper) jsonParser.getCodec();
         ObjectNode root = objectMapper.readTree(jsonParser);
 
         if (null == root.get("type")) {


### PR DESCRIPTION
This PR will need to go in at least one release cycle before we add the classical computing method of summing LLM question marks so that our two running APIs and ETL can process the new content schema.

If there are concerns with the approach, I could write an ADR and we can discuss as a group sometime this week. The question type is live and functioning, it would just be an improved experience once we take away the LLM's requirement to do basic maths!

---

**Pull Request Check List**
- ~Unit Tests & Regression Tests Added (Optional)~
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Access Control - Check authorisation on every new endpoint
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
