### PR TITLE
Feature/llm marking formula

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingExpression.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/LLMMarkingExpression.java
@@ -4,6 +4,6 @@ package uk.ac.cam.cl.dtg.isaac.dos.content;
  * Abstract class to represent the fomulae for marking LLM questions.
  */
 public abstract class LLMMarkingExpression {
-    abstract String getType();
-    abstract void setType(String type);
+    public abstract String getType();
+    public abstract void setType(String type);
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
@@ -10,6 +10,7 @@ import com.azure.ai.openai.models.ChatRequestUserMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacLLMFreeTextQuestion;
@@ -49,7 +50,7 @@ public class IsaacLLMFreeTextValidator implements IValidator {
             "",
             "asdkvnarl ifuvbnerpi vunkbjnrirutnblkrjnhbsiusdpocmscd dcj dciujnargybae"
     );
-    private static final Map<String, Integer> zeroMarkResult = Map.of(MARK_TOTAL_FIELD_NAME, 0);
+    private static final Map<String, Integer> zeroMarkResult = ImmutableMap.of(MARK_TOTAL_FIELD_NAME, 0);
 
     private final AbstractConfigLoader configLoader;
     private final ObjectMapper mapper;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
@@ -20,6 +20,10 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.LLMFreeTextChoice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.LLMFreeTextMarkSchemeEntry;
 import uk.ac.cam.cl.dtg.isaac.dos.content.LLMFreeTextMarkedExample;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingConstant;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingExpression;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingFunction;
+import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingVariable;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
@@ -92,9 +96,6 @@ public class IsaacLLMFreeTextValidator implements IValidator {
             + "  for each mark in the mark scheme:\n"
             + "    if the attempt meets the criteria of the mark: # taking into consideration any ADDITIONAL MARKING INSTRUCTIONS\n"
             + "      record an entry in the JSON response indicating the field and the numeric mark value, i.e. `\"abbreviatedSnakeCaseMarkDescriptor\": 1`.\n"
-            + "\n"
-            + String.format("finally add a field `%s` to the JSON object ", MARKS_AWARDED_FIELD_NAME)
-            + "with the value equal to the sum of the earned marks while never exceeding the question's `maxMarks`.\n"
             + "```\n"
             + "Here is the question and mark scheme that you're currently marking against.\n\n";
 
@@ -204,7 +205,6 @@ public class IsaacLLMFreeTextValidator implements IValidator {
 
             List<String> validFieldNames = question.getMarkScheme().stream()
                     .map(LLMFreeTextMarkSchemeEntry::getJsonField).collect(Collectors.toList());
-            validFieldNames.add(MARKS_AWARDED_FIELD_NAME);
 
             return validFieldNames.stream().collect(Collectors.toMap(
                     field -> field,
@@ -217,6 +217,50 @@ public class IsaacLLMFreeTextValidator implements IValidator {
     }
 
     /**
+     * Recursively evaluates a marking expression/formula to determine the total marks awarded for a question.
+     * @param expression the marking expression to evaluate.
+     * @param marks the marks awarded for each field in the mark scheme according to the LLM response.
+     * @return the total marks awarded for the question.
+     */
+    private int evaluateMarkingExpression(final LLMMarkingExpression expression, final Map<String, Integer> marks) {
+        if (expression instanceof LLMMarkingConstant) {
+            return ((LLMMarkingConstant) expression).getValue();
+        } else if (expression instanceof LLMMarkingVariable) {
+            return marks.getOrDefault(((LLMMarkingVariable) expression).getName(), 0);
+        } else if (expression instanceof LLMMarkingFunction) {
+            LLMMarkingFunction function = (LLMMarkingFunction) expression;
+            List<LLMMarkingExpression> args = function.getArguments();
+            switch (function.getName()) {
+                case SUM:
+                    return args.stream().mapToInt(arg -> evaluateMarkingExpression(arg, marks)).sum();
+                case MAX:
+                    return args.stream().mapToInt(arg -> evaluateMarkingExpression(arg, marks)).max().orElse(0);
+                case MIN:
+                    return args.stream().mapToInt(arg -> evaluateMarkingExpression(arg, marks)).min().orElse(0);
+                default:
+                    throw new IllegalArgumentException("Unknown marking function: " + function.getName());
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown marking expression type: " + expression.getType());
+        }
+    }
+
+    /**
+     * Evaluates the total marks awarded for a question based on the awarded marks for each field in the mark scheme.
+     * If a marking formula is provided, we evaluate the expression and return the result.
+     * Otherwise, we sum the awarded marks and return the minimum of the sum and the maximum marks for the question.
+     * @param question the question being marked.
+     * @param awardedMarks the marks awarded for each field in the mark scheme according to the LLM response.
+     * @return the total marks awarded for the question.
+     */
+    private int evaluateMarkTotal(final IsaacLLMFreeTextQuestion question, final Map<String, Integer> awardedMarks) {
+        if (question.getMarkingFormula() == null) {
+            return Math.min(awardedMarks.values().stream().mapToInt(Integer::intValue).sum(), question.getMaxMarks());
+        }
+        return evaluateMarkingExpression(question.getMarkingFormula(), awardedMarks);
+    }
+
+    /**
      * Generates a response to the user's attempt at the question.
      * As we don't want to pass the mark scheme with the question DTO, we respond with a full copy of the mark scheme
      * with every response (with the awarded marks, for each, filled in).
@@ -226,9 +270,9 @@ public class IsaacLLMFreeTextValidator implements IValidator {
      * @return a response to the user's attempt at the question.
      */
     private LLMFreeTextQuestionValidationResponse generateQuestionValidationResponse(
-            final IsaacLLMFreeTextQuestion question, final Choice answer, final Map<String, Integer> awardedMarks) {
-        int marksAwarded = awardedMarks.getOrDefault(MARKS_AWARDED_FIELD_NAME, 0);
-        boolean isConsideredCorrect = marksAwarded > 0;
+            final IsaacLLMFreeTextQuestion question, final Choice answer,
+            final Map<String, Integer> awardedMarks, final int markTotal) {
+        boolean isConsideredCorrect = markTotal > 0;
 
         // We create a fresh copy of the mark scheme with the full description and the awarded mark values.
         List<LLMFreeTextMarkSchemeEntry> markBreakdown = question.getMarkScheme().stream().map(mark -> {
@@ -242,10 +286,9 @@ public class IsaacLLMFreeTextValidator implements IValidator {
         LLMFreeTextQuestionValidationResponse validationResponse = new LLMFreeTextQuestionValidationResponse(
                 question.getId(), answer, isConsideredCorrect, null, new Date());
         validationResponse.setMaxMarks(question.getMaxMarks());
-        validationResponse.setMarksAwarded(marksAwarded);
+        validationResponse.setMarksAwarded(markTotal);
         validationResponse.setMarkBreakdown(markBreakdown);
         validationResponse.setAdditionalMarkingInstructions(question.getAdditionalMarkingInstructions());
-        validationResponse.setMarkCalculationInstructions(question.getMarkCalculationInstructions());
         return validationResponse;
     }
 
@@ -268,6 +311,8 @@ public class IsaacLLMFreeTextValidator implements IValidator {
 
         Map<String, Integer> awardedMarks = extractValidatedMarks(freeTextLLMQuestion, chatCompletions);
 
-        return generateQuestionValidationResponse(freeTextLLMQuestion, answer, awardedMarks);
+        int markTotal = evaluateMarkTotal(freeTextLLMQuestion, awardedMarks);
+
+        return generateQuestionValidationResponse(freeTextLLMQuestion, answer, awardedMarks, markTotal);
     }
 }


### PR DESCRIPTION
This PR builds upon the content types introduced in https://github.com/isaacphysics/isaac-api/pull/638
and, instead of getting the LLM to calculate the total marks for the question, we evaluate an expression representing the marking formula to compute the total marks. This is in response to users reporting inconsistencies between the mark breakdown and the total marks. Mathematical computation is not a strength of the smaller large language models that we are using so we extract that task.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
