### PR TITLE
Bugfix/question search filter fix

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -446,7 +446,7 @@ public class GitContentManager {
 
                 // Search term matches
                 .searchFor(new SearchInField(Constants.ID_FIELDNAME, searchTerms)
-                        .priority(Priority.HIGH).strategy(Strategy.SUBSTRING))
+                        .priority(Priority.HIGH).strategy(Strategy.SIMPLE))
                 .searchFor(new SearchInField(Constants.TITLE_FIELDNAME, searchTerms)
                         .priority(Priority.HIGH).strategy(Strategy.SUBSTRING))
                 .searchFor(new SearchInField(Constants.SUBTITLE_FIELDNAME, searchTerms)

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -474,7 +474,7 @@ public class GitContentManager {
                 } else if (Arrays.asList(SUBJECTS_FIELDNAME, FIELDS_FIELDNAME, TOPICS_FIELDNAME, CATEGORIES_FIELDNAME)
                         .contains(entry.getKey())) {
                     searchInstructionBuilder.searchFor(new SearchInField(TAGS_FIELDNAME, entry.getValue())
-                            .strategy(Strategy.SUBSTRING)
+                            .strategy(Strategy.SIMPLE)
                             .atLeastOne(true));
                 } else {
                     boolean applyOrFilterBetweenValues = ID_FIELDNAME.equals(entry.getKey());


### PR DESCRIPTION
Fix a problem where 'biochemistry' questions were being returned when the 'chemistry' subject was selected as a filter. This was caused by the search strategy for subjects, fields and topics was `SUBSTRING` rather than `SIMPLE` (exact match).

This PR also changes the search query matching and ranking for `id`s to exact-match - a feature that the content team find useful.

It does not change the search query matching and ranking for `tags` to exact match. If the user only uses the search field (an approach encouraged by the design of the new question finder) with the query "chem", they would expect chemistry questions to be ranked higher than questions tagged for other topics, for example.

---

**Pull Request Check List**
- [ ] ~Unit Tests & Regression Tests Added (Optional)~
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [x] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
