### PR TITLE
Avoid double-loading full gameboard each request

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -232,7 +232,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
 
             AbstractSegueUserDTO randomUser = this.userManager.getCurrentUser(httpServletRequest);
 
-            GameboardDTO unAugmentedGameboard = gameManager.getGameboard(gameboardId);
+            GameboardDTO unAugmentedGameboard = gameManager.getLiteGameboard(gameboardId);
             if (null == unAugmentedGameboard) {
                 return new SegueErrorResponse(Status.NOT_FOUND, "No Gameboard found for the id specified.")
                         .toResponse();


### PR DESCRIPTION
We load the gameboard initially not just to check it exists but also to load the question IDs; these are used to speed up loading question attempts a lot.
However, the full gameboard requires going to ElasticSearch and then mapping a bunch of objects between classes. Since we never use anything from these objects that is not in a Lite (unaugmented) gameboard this is entirely wasted work.
The end effect is minor since loading question attempts and the full gameboard still dominate, but I still think worthwhile.