### PR TITLE
Sort users in groups more consistently with Excel

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -217,15 +217,15 @@ public class GroupManager {
      */
     private void orderUsersByName(final List<RegisteredUserDTO> users) {
         // Remove apostrophes so that string containing them are ordered in the same way as in Excel.
-        // I.e. we want that "O'Aaa" < "Obbb" < "O'ccc"
+        // I.e. we want that "O'Aaa" < "Obbb" < "O'Ccc"
         Comparator<String> excelStringOrder = Comparator.nullsLast((String a, String b) ->
                 String.CASE_INSENSITIVE_ORDER.compare(a.replaceAll("'", ""), b.replaceAll("'", "")));
 
-        // If two names differ only by an apostrophe (i.e. "O'A" and "Oa"), this will leave them in whatever order
-        // they started in, which may not be desired.
+        // If names differ only by an apostrophe (i.e. "O'A" and "Oa"), break ties using name including any apostrophes:
         users.sort(Comparator
                 .comparing(RegisteredUserDTO::getFamilyName, excelStringOrder)
-                .thenComparing(RegisteredUserDTO::getGivenName, excelStringOrder));
+                .thenComparing(RegisteredUserDTO::getGivenName, excelStringOrder)
+                .thenComparing(RegisteredUserDTO::getFamilyName));
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -181,7 +181,8 @@ public class GroupManager {
 
         List<RegisteredUserDTO> users = userManager.findUsers(groupMemberIds);
         // Sort the users by name
-        return this.orderUsersByName(users);
+        this.orderUsersByName(users);
+        return users;
     }
 
     /**
@@ -214,15 +215,17 @@ public class GroupManager {
      * @param users
      *            - list of users.
      */
-    private List<RegisteredUserDTO> orderUsersByName(final List<RegisteredUserDTO> users) {
-        // Replaces apostrophes with tildes so that string containing them are ordered in the same way as in
-        // Excel. i.e. we want that "O'Sully" > "Ogbobby"
+    private void orderUsersByName(final List<RegisteredUserDTO> users) {
+        // Remove apostrophes so that string containing them are ordered in the same way as in Excel.
+        // I.e. we want that "O'Aaa" < "Obbb" < "O'ccc"
         Comparator<String> excelStringOrder = Comparator.nullsLast((String a, String b) ->
-                String.CASE_INSENSITIVE_ORDER.compare(a.replaceAll("'", "~"), b.replaceAll("'", "~")));
-        return users.stream()
-                .sorted(Comparator.comparing(RegisteredUserDTO::getGivenName, excelStringOrder))
-                .sorted(Comparator.comparing(RegisteredUserDTO::getFamilyName, excelStringOrder))
-                .collect(Collectors.toList());
+                String.CASE_INSENSITIVE_ORDER.compare(a.replaceAll("'", ""), b.replaceAll("'", "")));
+
+        // If two names differ only by an apostrophe (i.e. "O'A" and "Oa"), this will leave them in whatever order
+        // they started in, which may not be desired.
+        users.sort(Comparator
+                .comparing(RegisteredUserDTO::getFamilyName, excelStringOrder)
+                .thenComparing(RegisteredUserDTO::getGivenName, excelStringOrder));
     }
 
     /**

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GroupManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/GroupManagerTest.java
@@ -30,20 +30,26 @@ public class GroupManagerTest extends AbstractManagerTest {
     @Test
     public void orderUsersByName_ordersBySurnamePrimarily() throws Exception {
         List<RegisteredUserDTO> users = Stream.of(
-                new RegisteredUserDTO("A", "Ab", "aab@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
-                new RegisteredUserDTO("B", "Ar", "bar@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null, false),
-                new RegisteredUserDTO("C", "Ax", "caz@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
-                new RegisteredUserDTO(null, "Ax", "NONEax@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null, false),
-                new RegisteredUserDTO("A", "Ba", "dba@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null, false),
-                new RegisteredUserDTO("B", "Bb", "ebb@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
-                new RegisteredUserDTO("C", "Bf", "fbf@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null, false),
-                new RegisteredUserDTO("A", null, "aNONE@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null, false)
+                new RegisteredUserDTO("A",  "Ab",  "a1@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("B",  "Ar",  "a2@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("C",  "Ax",  "a3@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO(null, "Ax",  "a4@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("A",  "Ba",  "b1@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("B",  "Bb",  "b2@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("C",  "Bf",  "b3@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("A",  "O'A", "o1@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("A",  "Obe", "o2@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("A",  "O'c", "o3@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("A",  "Oc",  "o4@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO("A",  null,  "-1@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false),
+                new RegisteredUserDTO(null, null,  "--@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false)
         ).peek(user -> user.setId((long) ("" + user.getGivenName() + user.getFamilyName()).hashCode())).collect(Collectors.toList());
 
         List<RegisteredUserDTO> shuffledUsers = new ArrayList<>(users);
         Collections.shuffle(shuffledUsers);
 
-        List<RegisteredUserDTO> sortedUsers = Whitebox.invokeMethod(groupManager, "orderUsersByName", shuffledUsers);
-        assertEquals(users, sortedUsers);
+        assertNotEquals(users, shuffledUsers);
+        Whitebox.invokeMethod(groupManager, "orderUsersByName", shuffledUsers);
+        assertEquals(users, shuffledUsers);
     }
 }


### PR DESCRIPTION
This isn't the _right_ fix, which would involve using collations correctly and working out what language we wanted to sort using. But assuming most people are using Excel in English, this fixes the most common case where sort does not match; apostrophes in names. Just removing the character does not lead to a consistent sort, however, so it may be worth reviewing that if people notice.

This goes back to the in-place approach from [the original PR](https://github.com/isaacphysics/isaac-api/pull/508), since comparator chaining like this is nicer.

Neaten the tests, add more test cases for the apostrophe cases.
