### PR TITLE
Add utm_source parameter to notification emails

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/AssignmentManager.java
@@ -150,8 +150,7 @@ public class AssignmentManager implements IAssignmentLike.Details<AssignmentDTO>
         newAssignment.setId(this.assignmentPersistenceManager.saveAssignment(newAssignment));
 
         GameboardDTO gameboard = newAssignment.getGameboard();
-        final String gameboardURL = String.format("https://%s/assignment/%s", properties.getProperty(HOST_NAME),
-                gameboard.getId());
+        final String gameboardURL = getAssignmentLikeUrl(newAssignment);
 
         // If there is no date to schedule the assignment for, or the start date is in the past...
         if (null == newAssignment.getScheduledStartDate()) {
@@ -241,7 +240,7 @@ public class AssignmentManager implements IAssignmentLike.Details<AssignmentDTO>
 
     @Override
     public String getAssignmentLikeUrl(AssignmentDTO existingAssignment) {
-        return String.format("https://%s/assignment/%s",
+        return String.format("https://%s/assignment/%s?utm_source=notification-email",
                         properties.getProperty(HOST_NAME),
                         existingAssignment.getGameboardId());
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizAssignmentManager.java
@@ -205,7 +205,7 @@ public class QuizAssignmentManager implements IAssignmentLike.Details<QuizAssign
 
     @Override
     public String getAssignmentLikeUrl(QuizAssignmentDTO assignment) {
-        return String.format("https://%s/test/assignment/%s",
+        return String.format("https://%s/test/assignment/%s?utm_source=notification-email",
             properties.getProperty(HOST_NAME),
             assignment.getId());
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/jobs/ScheduledAssignmentsEmailJob.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/jobs/ScheduledAssignmentsEmailJob.java
@@ -49,8 +49,8 @@ public class ScheduledAssignmentsEmailJob implements Job {
         if (sendAssignmentEmail) {
             try {
                 GameboardDTO gameboard = this.gameManager.getGameboard(assignment.getGameboardId());
-                final String gameboardURL = String.format("https://%s/assignment/%s", this.properties.getProperty(HOST_NAME),
-                        gameboard.getId());
+                final String gameboardURL = String.format("https://%s/assignment/%s?utm_source=notification-email",
+                        this.properties.getProperty(HOST_NAME), gameboard.getId());
                 this.emailService.sendAssignmentEmailToGroup(assignment, gameboard, ImmutableMap.of("gameboardURL", gameboardURL),
                         "email-template-group-assignment");
             } catch (SegueDatabaseException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/jobs/ScheduledQuizAssignmentsEmailJob.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/scheduler/jobs/ScheduledQuizAssignmentsEmailJob.java
@@ -50,7 +50,7 @@ public class ScheduledQuizAssignmentsEmailJob implements Job {
         if (sendAssignmentEmail) {
             try {
                 IsaacQuizDTO quiz = quizManager.findQuiz(quizAssignment.getQuizId());
-                String quizURL = String.format("https://%s/test/assignment/%s", properties.getProperty(HOST_NAME), quizAssignment.getId());
+                String quizURL = String.format("https://%s/test/assignment/%s?utm_source=notification-email", properties.getProperty(HOST_NAME), quizAssignment.getId());
                 emailService.sendAssignmentEmailToGroup(quizAssignment, quiz, ImmutableMap.of("quizURL", quizURL),
                         "email-template-group-quiz-assignment");
             } catch (SegueDatabaseException | ContentManagerException e) {


### PR DESCRIPTION
It might have been possible to do this in the content template, but this feels more reliable. This will help judge traffic from assignment, test, and group join notification emails