### PR TITLE
Handle partial postcodes in admin user search

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
@@ -199,7 +199,7 @@ public class PostCodeIOLocationResolver implements PostCodeLocationResolver {
             }
         }
 
-        if (completePostCodes.size() > POSTCODEIO_MAX_REQUESTS) {
+        if (completePostCodes.size() + outCodes.size() > POSTCODEIO_MAX_REQUESTS) {
             throw new IllegalArgumentException(String.format("Number of postcodes cannot be bigger than %d!",
                     POSTCODEIO_MAX_REQUESTS));
         }


### PR DESCRIPTION
If a valid first part of a postcode (e.g. CB3) is provided, treat the centroid of this region as the postcode location.