### PR TITLE
Add reason for deletion to confirmation request

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/EmailFacade.java
@@ -353,7 +353,8 @@ public class EmailFacade extends AbstractSegueFacade {
                description = "The user must be logged in to the account to delete to complete this action.")
     public Response completeAccountDeletion(@Context final HttpServletRequest request,
                                             @Context final HttpServletResponse response,
-                                            @QueryParam("token") final String token) {
+                                            @QueryParam("token") final String token,
+                                            final Map<String, String> additionalInfo) {
         try {
             RegisteredUserDTO currentUser = userManager.getCurrentRegisteredUser(request);
 
@@ -361,7 +362,9 @@ public class EmailFacade extends AbstractSegueFacade {
 
             userManager.logUserOut(request, response);
 
-            this.getLogManager().logEvent(currentUser, request, SegueServerLogType.ACCOUNT_DELETION_REQUEST_COMPLETE, Maps.newHashMap());
+            Map<String, String> logData = ImmutableMap.of("reason", additionalInfo.get("reason"));
+
+            this.getLogManager().logEvent(currentUser, request, SegueServerLogType.ACCOUNT_DELETION_REQUEST_COMPLETE, logData);
 
             return Response.noContent().build();
         } catch (NoUserLoggedInException | NoUserException e) {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SelfDeletionIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SelfDeletionIT.java
@@ -1,5 +1,6 @@
 package uk.ac.cam.cl.dtg.isaac.api;
 
+import com.google.common.collect.ImmutableMap;
 import org.easymock.Capture;
 import org.junit.jupiter.api.Test;
 import uk.ac.cam.cl.dtg.segue.api.EmailFacade;
@@ -44,7 +45,7 @@ public class SelfDeletionIT extends IsaacIntegrationTest {
                 contentManager, misuseMonitor);
 
         // Attempt to use a valid token:
-        Response apiResponse = emailFacade.completeAccountDeletion(deletionConfirmationRequest, response, ALICE_STUDENT_VALID_DELETION_TOKEN);
+        Response apiResponse = emailFacade.completeAccountDeletion(deletionConfirmationRequest, response, ALICE_STUDENT_VALID_DELETION_TOKEN, ImmutableMap.of("reason", "other"));
 
         // Check request succeeded:
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), apiResponse.getStatus());
@@ -84,7 +85,7 @@ public class SelfDeletionIT extends IsaacIntegrationTest {
                 contentManager, misuseMonitor);
 
         // Attempt to use a expired token:
-        Response apiResponse = emailFacade.completeAccountDeletion(deletionConfirmationRequest, response, BOB_STUDENT_EXPIRED_DELETION_TOKEN);
+        Response apiResponse = emailFacade.completeAccountDeletion(deletionConfirmationRequest, response, BOB_STUDENT_EXPIRED_DELETION_TOKEN, ImmutableMap.of("reason", "other"));
 
         // Check request did nothing:
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), apiResponse.getStatus());
@@ -113,7 +114,7 @@ public class SelfDeletionIT extends IsaacIntegrationTest {
                 contentManager, misuseMonitor);
 
         // Attempt to use someone else's valid token:
-        Response apiResponse = emailFacade.completeAccountDeletion(deletionConfirmationRequest, response, ALICE_STUDENT_VALID_DELETION_TOKEN);
+        Response apiResponse = emailFacade.completeAccountDeletion(deletionConfirmationRequest, response, ALICE_STUDENT_VALID_DELETION_TOKEN, ImmutableMap.of("reason", "other"));
 
         // Check request did nothing:
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), apiResponse.getStatus());


### PR DESCRIPTION
Takes an extra `additionalInfo` parameter in the confirmation of deletion endpoint to track the reason for account deletion.