### PR TITLE
Remove Chemistry elements mismatch feedback

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -392,7 +392,6 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                 if (closestResponse.get("sameElements").equals(false)) {
 
                     // Wrong element/compound
-                    feedback = new Content("");
 
                     // Temporarily disabled
                     // feedback = new Content("Check that you have all the correct atoms present and in the right place!");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -392,7 +392,10 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                 if (closestResponse.get("sameElements").equals(false)) {
 
                     // Wrong element/compound
-                    feedback = new Content("Check that you have all the correct atoms present and in the right place!");
+                    feedback = new Content("");
+
+                    // Temporarily disabled
+                    // feedback = new Content("Check that you have all the correct atoms present and in the right place!");
 
                 } else if (closestResponse.get("sameCoefficient").equals(false)) {
 


### PR DESCRIPTION
Temporarily replaces `"Check that you have all the correct atoms present and in the right place!"` with blank feedback, as it was sometimes displaying at incorrect times for questions with multiple correct answer configurations in the markscheme.

---

From a quick look, the problem actually causing this should be fixed by disabling list comparison permutations when `allowPermutations = false` in the Checker (which should be fairly easy), and reconfiguring the answer match prioritisation code in the API (which is probably not so easy) - certainly probably enough work to be saved for next release.