### PR TITLE
Extend CoordinateItem and CoordinateQuestion model to n dimensions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCoordinateQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCoordinateQuestion.java
@@ -1,11 +1,12 @@
 package uk.ac.cam.cl.dtg.isaac.dos;
 
-
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacCoordinateQuestionDTO;
 import uk.ac.cam.cl.dtg.isaac.quiz.IsaacCoordinateValidator;
 import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
+
+import java.util.List;
 
 /**
  * Content DO for IsaacCoordinateQuestions.
@@ -16,13 +17,15 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 @ValidatesWith(IsaacCoordinateValidator.class)
 public class IsaacCoordinateQuestion extends IsaacQuestionBase {
 
-    // If no number of coordinates is specified, we assume any number of coordinates in a choice is valid.
-    private Integer numberOfCoordinates;
+    private Integer numberOfCoordinates;  // If not specified, we assume any number of coordinates is allowed.
+    private Integer numberOfDimensions;
 
-    // If ordered is true, then the order of the coordinates in a choice matters.
-    private Boolean ordered;
+    private Boolean ordered;  // If true, the order of the coordinates in a choice matters.
+    @Deprecated
     private String placeholderXValue;
+    @Deprecated
     private String placeholderYValue;
+    private List<String> placeholderValues;
     private Integer significantFiguresMin;
     private Integer significantFiguresMax;
 
@@ -32,6 +35,14 @@ public class IsaacCoordinateQuestion extends IsaacQuestionBase {
 
     public void setNumberOfCoordinates(final Integer numberOfCoordinates) {
         this.numberOfCoordinates = numberOfCoordinates;
+    }
+
+    public Integer getNumberOfDimensions() {
+        return numberOfDimensions;
+    }
+
+    public void setNumberOfDimensions(Integer numberOfDimensions) {
+        this.numberOfDimensions = numberOfDimensions;
     }
 
     public Boolean getOrdered() {
@@ -80,19 +91,31 @@ public class IsaacCoordinateQuestion extends IsaacQuestionBase {
         this.significantFiguresMax = significantFigures;
     }
 
+    @Deprecated
     public String getPlaceholderXValue() {
         return placeholderXValue;
     }
 
+    @Deprecated
     public void setPlaceholderXValue(String placeholderXValue) {
         this.placeholderXValue = placeholderXValue;
     }
 
+    @Deprecated
     public String getPlaceholderYValue() {
         return placeholderYValue;
     }
 
+    @Deprecated
     public void setPlaceholderYValue(String placeholderYValue) {
         this.placeholderYValue = placeholderYValue;
+    }
+
+    public List<String> getPlaceholderValues() {
+        return placeholderValues;
+    }
+
+    public void setPlaceholderValues(List<String> placeholderValues) {
+        this.placeholderValues = placeholderValues;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CoordinateItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CoordinateItem.java
@@ -2,10 +2,16 @@ package uk.ac.cam.cl.dtg.isaac.dos.content;
 
 import uk.ac.cam.cl.dtg.isaac.dto.content.CoordinateItemDTO;
 
+import java.util.List;
+import java.util.Objects;
+
 @DTOMapping(CoordinateItemDTO.class)
 @JsonContentType("coordinateItem")
 public class CoordinateItem extends Item {
+    private List<String> coordinates;
+    @Deprecated
     private String x;
+    @Deprecated
     private String y;
 
     /**
@@ -18,6 +24,7 @@ public class CoordinateItem extends Item {
      * @param x
      * @param y
      */
+    @Deprecated
     public CoordinateItem(final String x, final String y) {
         this.x = x;
         this.y = y;
@@ -26,6 +33,7 @@ public class CoordinateItem extends Item {
     /**
      * @return the x
      */
+    @Deprecated
     public String getX() {
         return x;
     }
@@ -33,6 +41,7 @@ public class CoordinateItem extends Item {
     /**
      * @param x the x to set
      */
+    @Deprecated
     public void setX(final String x) {
         this.x = x;
     }
@@ -40,6 +49,7 @@ public class CoordinateItem extends Item {
     /**
      * @return the y
      */
+    @Deprecated
     public String getY() {
         return y;
     }
@@ -47,7 +57,38 @@ public class CoordinateItem extends Item {
     /**
      * @param y the y to set
      */
+    @Deprecated
     public void setY(final String y) {
         this.y = y;
+    }
+
+    public List<String> getCoordinates() {
+        return coordinates;
+    }
+
+    public void setCoordinates(List<String> coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    public CoordinateItem(List<String> coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CoordinateItem)) {
+            return false;
+        }
+        CoordinateItem that = (CoordinateItem) o;
+        // We only care about equality of the coordinates, and only for unit testing.
+        return Objects.equals(coordinates, that.coordinates);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), coordinates);
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCoordinateQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCoordinateQuestionDTO.java
@@ -1,14 +1,21 @@
 package uk.ac.cam.cl.dtg.isaac.dto;
 
+import java.util.List;
+
 public class IsaacCoordinateQuestionDTO extends IsaacQuestionBaseDTO {
 
     // If no number of coordinates is specified, we assume any number of coordinates in a choice is valid.
     private Integer numberOfCoordinates;
+    private Integer numberOfDimensions;
 
     // If ordered is true, then the order of the coordinates in a choice matters.
     private Boolean ordered;
 
+    private List<String> placeholderValues;
+
+    @Deprecated
     private String placeholderXValue;
+    @Deprecated
     private String placeholderYValue;
 
     public Integer getNumberOfCoordinates() {
@@ -19,6 +26,14 @@ public class IsaacCoordinateQuestionDTO extends IsaacQuestionBaseDTO {
         this.numberOfCoordinates = numberOfCoordinates;
     }
 
+    public Integer getNumberOfDimensions() {
+        return numberOfDimensions;
+    }
+
+    public void setNumberOfDimensions(Integer numberOfDimensions) {
+        this.numberOfDimensions = numberOfDimensions;
+    }
+
     public Boolean getOrdered() {
         return ordered;
     }
@@ -27,19 +42,31 @@ public class IsaacCoordinateQuestionDTO extends IsaacQuestionBaseDTO {
         this.ordered = ordered;
     }
 
+    @Deprecated
     public String getPlaceholderXValue() {
         return placeholderXValue;
     }
 
+    @Deprecated
     public void setPlaceholderXValue(String placeholderXValue) {
         this.placeholderXValue = placeholderXValue;
     }
 
+    @Deprecated
     public String getPlaceholderYValue() {
         return placeholderYValue;
     }
 
+    @Deprecated
     public void setPlaceholderYValue(String placeholderYValue) {
         this.placeholderYValue = placeholderYValue;
+    }
+
+    public List<String> getPlaceholderValues() {
+        return placeholderValues;
+    }
+
+    public void setPlaceholderValues(List<String> placeholderValues) {
+        this.placeholderValues = placeholderValues;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CoordinateItemDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CoordinateItemDTO.java
@@ -1,7 +1,12 @@
 package uk.ac.cam.cl.dtg.isaac.dto.content;
 
+import java.util.List;
+
 public class CoordinateItemDTO extends ItemDTO {
+    private List<String> coordinates;
+    @Deprecated
     private String x;
+    @Deprecated
     private String y;
 
     /**
@@ -14,6 +19,7 @@ public class CoordinateItemDTO extends ItemDTO {
      * @param x
      * @param y
      */
+    @Deprecated
     public CoordinateItemDTO(final String x, final String y) {
         this.x = x;
         this.y = y;
@@ -22,6 +28,7 @@ public class CoordinateItemDTO extends ItemDTO {
     /**
      * @return the x
      */
+    @Deprecated
     public String getX() {
         return x;
     }
@@ -29,6 +36,7 @@ public class CoordinateItemDTO extends ItemDTO {
     /**
      * @param x the x to set
      */
+    @Deprecated
     public void setX(final String x) {
         this.x = x;
     }
@@ -36,6 +44,7 @@ public class CoordinateItemDTO extends ItemDTO {
     /**
      * @return the y
      */
+    @Deprecated
     public String getY() {
         return y;
     }
@@ -43,7 +52,20 @@ public class CoordinateItemDTO extends ItemDTO {
     /**
      * @param y the y to set
      */
+    @Deprecated
     public void setY(final String y) {
         this.y = y;
+    }
+
+    public CoordinateItemDTO(List<String> coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    public List<String> getCoordinates() {
+        return coordinates;
+    }
+
+    public void setCoordinates(List<String> coordinates) {
+        this.coordinates = coordinates;
     }
 }


### PR DESCRIPTION
Instead of a hardcoded x and y value, now use a list of Strings to represent the coordinates. This also requires the placeholders to be a list of values too.

In order not to break existing questions whilst the changes are deployed, we leave the existing x, y values in the model. Then the content can be updated with both, and we can remove the deprecated values in a later change.

This does not change the validator at this stage.