### PR TITLE
Allow coordinate questions to have n dimensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <segue.version>v3.16.17</segue.version>
+        <segue.version>v3.16.18-SNAPSHOT</segue.version>
         <log4j.version>2.23.1</log4j.version>
         <resteasy.version>6.2.9.Final</resteasy.version>
         <guice.version>7.0.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <segue.version>v3.16.17-SNAPSHOT</segue.version>
+        <segue.version>v3.16.17</segue.version>
         <log4j.version>2.23.1</log4j.version>
         <resteasy.version>6.2.9.Final</resteasy.version>
         <guice.version>7.0.0</guice.version>

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCoordinateQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCoordinateQuestion.java
@@ -1,11 +1,12 @@
 package uk.ac.cam.cl.dtg.isaac.dos;
 
-
 import uk.ac.cam.cl.dtg.isaac.dos.content.DTOMapping;
 import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacCoordinateQuestionDTO;
 import uk.ac.cam.cl.dtg.isaac.quiz.IsaacCoordinateValidator;
 import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
+
+import java.util.List;
 
 /**
  * Content DO for IsaacCoordinateQuestions.
@@ -16,13 +17,15 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 @ValidatesWith(IsaacCoordinateValidator.class)
 public class IsaacCoordinateQuestion extends IsaacQuestionBase {
 
-    // If no number of coordinates is specified, we assume any number of coordinates in a choice is valid.
-    private Integer numberOfCoordinates;
+    private Integer numberOfCoordinates;  // If not specified, we assume any number of coordinates is allowed.
+    private Integer numberOfDimensions;
 
-    // If ordered is true, then the order of the coordinates in a choice matters.
-    private Boolean ordered;
+    private Boolean ordered;  // If true, the order of the coordinates in a choice matters.
+    @Deprecated
     private String placeholderXValue;
+    @Deprecated
     private String placeholderYValue;
+    private List<String> placeholderValues;
     private Integer significantFiguresMin;
     private Integer significantFiguresMax;
 
@@ -32,6 +35,14 @@ public class IsaacCoordinateQuestion extends IsaacQuestionBase {
 
     public void setNumberOfCoordinates(final Integer numberOfCoordinates) {
         this.numberOfCoordinates = numberOfCoordinates;
+    }
+
+    public Integer getNumberOfDimensions() {
+        return numberOfDimensions;
+    }
+
+    public void setNumberOfDimensions(Integer numberOfDimensions) {
+        this.numberOfDimensions = numberOfDimensions;
     }
 
     public Boolean getOrdered() {
@@ -80,19 +91,31 @@ public class IsaacCoordinateQuestion extends IsaacQuestionBase {
         this.significantFiguresMax = significantFigures;
     }
 
+    @Deprecated
     public String getPlaceholderXValue() {
         return placeholderXValue;
     }
 
+    @Deprecated
     public void setPlaceholderXValue(String placeholderXValue) {
         this.placeholderXValue = placeholderXValue;
     }
 
+    @Deprecated
     public String getPlaceholderYValue() {
         return placeholderYValue;
     }
 
+    @Deprecated
     public void setPlaceholderYValue(String placeholderYValue) {
         this.placeholderYValue = placeholderYValue;
+    }
+
+    public List<String> getPlaceholderValues() {
+        return placeholderValues;
+    }
+
+    public void setPlaceholderValues(List<String> placeholderValues) {
+        this.placeholderValues = placeholderValues;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CoordinateItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CoordinateItem.java
@@ -2,10 +2,16 @@ package uk.ac.cam.cl.dtg.isaac.dos.content;
 
 import uk.ac.cam.cl.dtg.isaac.dto.content.CoordinateItemDTO;
 
+import java.util.List;
+import java.util.Objects;
+
 @DTOMapping(CoordinateItemDTO.class)
 @JsonContentType("coordinateItem")
 public class CoordinateItem extends Item {
+    private List<String> coordinates;
+    @Deprecated
     private String x;
+    @Deprecated
     private String y;
 
     /**
@@ -18,6 +24,7 @@ public class CoordinateItem extends Item {
      * @param x
      * @param y
      */
+    @Deprecated
     public CoordinateItem(final String x, final String y) {
         this.x = x;
         this.y = y;
@@ -26,6 +33,7 @@ public class CoordinateItem extends Item {
     /**
      * @return the x
      */
+    @Deprecated
     public String getX() {
         return x;
     }
@@ -33,6 +41,7 @@ public class CoordinateItem extends Item {
     /**
      * @param x the x to set
      */
+    @Deprecated
     public void setX(final String x) {
         this.x = x;
     }
@@ -40,6 +49,7 @@ public class CoordinateItem extends Item {
     /**
      * @return the y
      */
+    @Deprecated
     public String getY() {
         return y;
     }
@@ -47,7 +57,38 @@ public class CoordinateItem extends Item {
     /**
      * @param y the y to set
      */
+    @Deprecated
     public void setY(final String y) {
         this.y = y;
+    }
+
+    public List<String> getCoordinates() {
+        return coordinates;
+    }
+
+    public void setCoordinates(List<String> coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    public CoordinateItem(List<String> coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CoordinateItem)) {
+            return false;
+        }
+        CoordinateItem that = (CoordinateItem) o;
+        // We only care about equality of the coordinates, and only for unit testing.
+        return Objects.equals(coordinates, that.coordinates);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), coordinates);
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCoordinateQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCoordinateQuestionDTO.java
@@ -1,14 +1,21 @@
 package uk.ac.cam.cl.dtg.isaac.dto;
 
+import java.util.List;
+
 public class IsaacCoordinateQuestionDTO extends IsaacQuestionBaseDTO {
 
     // If no number of coordinates is specified, we assume any number of coordinates in a choice is valid.
     private Integer numberOfCoordinates;
+    private Integer numberOfDimensions;
 
     // If ordered is true, then the order of the coordinates in a choice matters.
     private Boolean ordered;
 
+    private List<String> placeholderValues;
+
+    @Deprecated
     private String placeholderXValue;
+    @Deprecated
     private String placeholderYValue;
 
     public Integer getNumberOfCoordinates() {
@@ -19,6 +26,14 @@ public class IsaacCoordinateQuestionDTO extends IsaacQuestionBaseDTO {
         this.numberOfCoordinates = numberOfCoordinates;
     }
 
+    public Integer getNumberOfDimensions() {
+        return numberOfDimensions;
+    }
+
+    public void setNumberOfDimensions(Integer numberOfDimensions) {
+        this.numberOfDimensions = numberOfDimensions;
+    }
+
     public Boolean getOrdered() {
         return ordered;
     }
@@ -27,19 +42,31 @@ public class IsaacCoordinateQuestionDTO extends IsaacQuestionBaseDTO {
         this.ordered = ordered;
     }
 
+    @Deprecated
     public String getPlaceholderXValue() {
         return placeholderXValue;
     }
 
+    @Deprecated
     public void setPlaceholderXValue(String placeholderXValue) {
         this.placeholderXValue = placeholderXValue;
     }
 
+    @Deprecated
     public String getPlaceholderYValue() {
         return placeholderYValue;
     }
 
+    @Deprecated
     public void setPlaceholderYValue(String placeholderYValue) {
         this.placeholderYValue = placeholderYValue;
+    }
+
+    public List<String> getPlaceholderValues() {
+        return placeholderValues;
+    }
+
+    public void setPlaceholderValues(List<String> placeholderValues) {
+        this.placeholderValues = placeholderValues;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CoordinateItemDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CoordinateItemDTO.java
@@ -1,7 +1,12 @@
 package uk.ac.cam.cl.dtg.isaac.dto.content;
 
+import java.util.List;
+
 public class CoordinateItemDTO extends ItemDTO {
+    private List<String> coordinates;
+    @Deprecated
     private String x;
+    @Deprecated
     private String y;
 
     /**
@@ -14,6 +19,7 @@ public class CoordinateItemDTO extends ItemDTO {
      * @param x
      * @param y
      */
+    @Deprecated
     public CoordinateItemDTO(final String x, final String y) {
         this.x = x;
         this.y = y;
@@ -22,6 +28,7 @@ public class CoordinateItemDTO extends ItemDTO {
     /**
      * @return the x
      */
+    @Deprecated
     public String getX() {
         return x;
     }
@@ -29,6 +36,7 @@ public class CoordinateItemDTO extends ItemDTO {
     /**
      * @param x the x to set
      */
+    @Deprecated
     public void setX(final String x) {
         this.x = x;
     }
@@ -36,6 +44,7 @@ public class CoordinateItemDTO extends ItemDTO {
     /**
      * @return the y
      */
+    @Deprecated
     public String getY() {
         return y;
     }
@@ -43,7 +52,20 @@ public class CoordinateItemDTO extends ItemDTO {
     /**
      * @param y the y to set
      */
+    @Deprecated
     public void setY(final String y) {
         this.y = y;
+    }
+
+    public CoordinateItemDTO(List<String> coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    public List<String> getCoordinates() {
+        return coordinates;
+    }
+
+    public void setCoordinates(List<String> coordinates) {
+        this.coordinates = coordinates;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -1,6 +1,5 @@
 package uk.ac.cam.cl.dtg.isaac.quiz;
 
-import com.google.common.collect.Streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacCoordinateQuestion;
@@ -50,9 +49,13 @@ public class IsaacCoordinateValidator implements IValidator {
         // STEP 0: Is it even possible to answer this question?
 
         if (null == coordinateQuestion.getChoices() || coordinateQuestion.getChoices().isEmpty()) {
-            log.error("Question does not have any answers. " + question.getId() + " src: "
-                    + question.getCanonicalSourceFile());
+            log.error("Question ({}) does not have any answers. src: {}", question.getId(), question.getCanonicalSourceFile());
             feedback = new Content(FEEDBACK_NO_CORRECT_ANSWERS);
+        }
+
+        if (null == coordinateQuestion.getNumberOfDimensions() || coordinateQuestion.getNumberOfDimensions() < 1) {
+            log.error("Question ({}) does not have dimensions set. src: {}", question.getId(), question.getCanonicalSourceFile());
+            feedback = new Content("This question cannot be answered correctly.");
         }
 
         // STEP 1: Did they provide a valid answer?
@@ -64,8 +67,7 @@ public class IsaacCoordinateValidator implements IValidator {
         // Check that all the items in the submitted answer are CoordinateItems.
         for (Object item : submittedChoice.getItems()) {
             if (!(item instanceof CoordinateItem)) {
-                log.error("Expected list of CoordinateItems, but found a different type of item in choice for question id: "
-                        + coordinateQuestion.getId());
+                log.warn("User submitted unexpected item type for coordinate question ({}).", coordinateQuestion.getId());
                 feedback = new Content(FEEDBACK_UNRECOGNISED_ITEMS);
                 break;
             }
@@ -79,18 +81,18 @@ public class IsaacCoordinateValidator implements IValidator {
         List<CoordinateItem> submittedItems = submittedChoice.getItems().stream().map(i -> (CoordinateItem) i).collect(Collectors.toList());
 
         // Check if any coordinates are missing
-        if (submittedItems.stream().anyMatch(i -> null == i.getX() || null == i.getY())) {
-            feedback = new Content("You did not provide a complete answer.");
+        if (submittedItems.stream().anyMatch(i -> null == i.getCoordinates() || i.getCoordinates().size() != coordinateQuestion.getNumberOfDimensions())) {
+            feedback = new Content("You did not provide the expected number of dimensions in your answer.");
         }
 
         if (null != coordinateQuestion.getNumberOfCoordinates() && submittedItems.size() != coordinateQuestion.getNumberOfCoordinates()) {
-            feedback = new Content("You did not provide the required number of coordinates.");
+            feedback = new Content("You did not provide the correct number of coordinates.");
         }
 
         // STEP 2: If they did, does their answer match a known answer?
 
         if (null == feedback) {
-            // Sort the choices so that we match incorrect choices last, taking precedence over correct ones.
+            // Sort the choices so that we match incorrect choices last, giving precedence to correct ones.
             List<Choice> orderedChoices = getOrderedChoices(coordinateQuestion.getChoices());
 
             // For all the choices on this question...
@@ -98,9 +100,7 @@ public class IsaacCoordinateValidator implements IValidator {
 
                 // ... that are of the CoordinateChoice type, ...
                 if (!(c instanceof CoordinateChoice)) {
-                    log.error(String.format(
-                            "Validator for question (%s) expected there to be an CoordinateChoice. Instead it found a %s.",
-                            coordinateQuestion.getId(), c.getClass().toString()));
+                    log.error("Expected CoordinateChoice for question ({}). Instead found {}.", coordinateQuestion.getId(), c.getClass());
                     continue;
                 }
 
@@ -108,8 +108,7 @@ public class IsaacCoordinateValidator implements IValidator {
 
                 // ... and that contain items ...
                 if (null == coordinateChoice.getItems() || coordinateChoice.getItems().isEmpty()) {
-                    log.error("Expected list of CoordinateItems, but none found in choice for question id: "
-                            + coordinateQuestion.getId());
+                    log.error("Expected list of CoordinateItems, but none found in choice for question ({})", coordinateQuestion.getId());
                     continue;
                 }
 
@@ -122,8 +121,7 @@ public class IsaacCoordinateValidator implements IValidator {
                 // Ensure that all items in the choice are CoordinateItems.
                 boolean allCoordinateItems = coordinateChoice.getItems().stream().allMatch(i -> i instanceof CoordinateItem);
                 if (!allCoordinateItems) {
-                    log.error("Expected list of CoordinateItems, but found a different type of item in choice for question id: "
-                            + coordinateQuestion.getId());
+                    log.error("Expected list of CoordinateItems, but found different type in choice for question ({})", coordinateQuestion.getId());
                     // Hopefully another choice will be better...
                     continue;
                 }
@@ -137,36 +135,30 @@ public class IsaacCoordinateValidator implements IValidator {
                     submittedItems = orderCoordinates(submittedItems);
                 }
 
-                // Zip the two lists together and check that the items match.
-                boolean allItemsMatch = Streams.zip(
-                        choiceItems.stream(),
-                        submittedItems.stream(),
-                        (choiceItem, submittedItem) -> {
-                            Integer xSigFigs = ValidationUtils.numberOfSignificantFiguresToValidateWith(
-                                submittedItem.getX(),
-                                significantFiguresMin,
-                                significantFiguresMax,
-                                log
-                            );
-                            Integer ySigFigs = ValidationUtils.numberOfSignificantFiguresToValidateWith(
-                                submittedItem.getY(),
-                                significantFiguresMin,
-                                significantFiguresMax,
-                                log
-                            );
-                            return ValidationUtils.numericValuesMatch(
-                                choiceItem.getX(),
-                                submittedItem.getX(),
-                                xSigFigs,
-                                log
-                            ) && ValidationUtils.numericValuesMatch(
-                                choiceItem.getY(),
-                                submittedItem.getY(),
-                                ySigFigs,
-                                log
-                            );
+                boolean allItemsMatch = true;
+
+                // For each coordinate in the list of coordinates:
+                //    (labelled loop to allow short circuiting)
+                outerloop: for (int coordIndex = 0; coordIndex < choiceItems.size(); coordIndex++) {
+                    CoordinateItem choiceItem = choiceItems.get(coordIndex);
+                    CoordinateItem submittedItem = submittedItems.get(coordIndex);
+                    // Check that each dimension has the same coordinate value as the choice:
+                    for (int dimensionIndex = 0; dimensionIndex < coordinateQuestion.getNumberOfDimensions(); dimensionIndex++) {
+                        String choiceValue = choiceItem.getCoordinates().get(dimensionIndex);
+                        String submittedValue = submittedItem.getCoordinates().get(dimensionIndex);
+
+                        Integer sigFigs = ValidationUtils.numberOfSignificantFiguresToValidateWith(submittedValue,
+                                significantFiguresMin, significantFiguresMax, log);
+
+                        boolean valuesMatch = ValidationUtils.numericValuesMatch(choiceValue, submittedValue, sigFigs, log);
+
+                        if (!valuesMatch) {
+                            allItemsMatch = false;
+                            // Exit early on mismatch:
+                            break outerloop;
                         }
-                    ).allMatch(b -> b);
+                    }
+                }
 
                 if (allItemsMatch) {
                     responseCorrect = coordinateChoice.isCorrect();
@@ -185,17 +177,26 @@ public class IsaacCoordinateValidator implements IValidator {
     }
 
     /**
-     * Numerically order the items in the list by their x coordinate, then by their y coordinate.
-     * @param items     The list of coordinate items to order
+     * Numerically order CoordinateItems in a list by first-coordinate, then by second-coordinate, etc.
+     *
+     * This allows for comparisons where the coordinates do not need to be provided in a specified order,
+     * since this imposes a consistent order.
+     *
+     * @param items     The list of CoordinateItems to order.
+     *
      * @return          The (numerically) ordered list of coordinate items
      */
-    private List<CoordinateItem> orderCoordinates(final List<CoordinateItem> items) {
+    List<CoordinateItem> orderCoordinates(final List<CoordinateItem> items) {
         return items.stream().sorted((a, b) -> {
-            if (ValidationUtils.compareNumericValues(a.getX(), b.getX(), 3, ValidationUtils.ComparisonType.EQUAL_TO, log)) {
-                return ValidationUtils.compareNumericValues(a.getY(), b.getY(), 3, ValidationUtils.ComparisonType.LESS_THAN, log) ? -1 : 1;
-            } else {
-                return ValidationUtils.compareNumericValues(a.getX(), b.getX(), 3, ValidationUtils.ComparisonType.LESS_THAN, log) ? -1 : 1;
+            int numDimensions = Math.min(a.getCoordinates().size(), b.getCoordinates().size());
+            for (int i = 0; i < numDimensions; i++) {
+                String valueA = a.getCoordinates().get(i);
+                String valueB = b.getCoordinates().get(i);
+                if (!ValidationUtils.compareNumericValues(valueA, valueB, 3, ValidationUtils.ComparisonType.EQUAL_TO, log)) {
+                    return ValidationUtils.compareNumericValues(valueA, valueB, 3, ValidationUtils.ComparisonType.LESS_THAN, log) ? -1 : 1;
+                }
             }
+            return 0;
         }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacCard;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacCardDeck;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacClozeQuestion;
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacCoordinateQuestion;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacEventPage;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacNumericQuestion;
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuestionBase;
@@ -1145,6 +1146,26 @@ public class ContentIndexer {
                         continue;
                     }
                     numberItems = items;
+                }
+            }
+        }
+
+        if (content instanceof IsaacCoordinateQuestion) {
+            IsaacCoordinateQuestion q = (IsaacCoordinateQuestion) content;
+
+            if (null == q.getSignificantFiguresMin() ^ null == q.getSignificantFiguresMax()) {
+                // Both bounds need to be present, or both not present
+                this.registerContentProblem(content, String.format("Coordinate Question: %s has only one significant figure bound."
+                        + " Sig figs will be ignored for this question; add both min and max to fix this.", q.getId()),
+                        indexProblemCache);
+            } else if (null != q.getSignificantFiguresMin() && null != q.getSignificantFiguresMax()) {
+                // Upper bound must be above or equal to the lower bound, and both bounds must be more than 1
+                if (q.getSignificantFiguresMin() < 1 || q.getSignificantFiguresMax() < 1
+                        || q.getSignificantFiguresMax() < q.getSignificantFiguresMin()) {
+                    this.registerContentProblem(content, "Coordinate Question: " + q.getId() + " has broken "
+                            + "significant figure rules! The upper bound may be below the lower bound, or "
+                            + "either bound might be less than 1 - the question will be unanswerable unless "
+                            + "this is fixed.", indexProblemCache);
                 }
             }
         }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2024 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.quiz;
+
+import com.google.api.client.util.Lists;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.cam.cl.dtg.isaac.dos.IsaacCoordinateQuestion;
+import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
+import uk.ac.cam.cl.dtg.isaac.dos.content.CoordinateChoice;
+import uk.ac.cam.cl.dtg.isaac.dos.content.CoordinateItem;
+import uk.ac.cam.cl.dtg.isaac.dos.content.ItemChoice;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class IsaacCoordinateValidatorTest {
+
+    private IsaacCoordinateValidator validator;
+    private IsaacCoordinateQuestion someCoordinateQuestion;
+
+    private final CoordinateItem item1 = new CoordinateItem(List.of("1", "2"));
+    private final CoordinateItem item2 = new CoordinateItem(List.of("2", "1"));
+    private final CoordinateItem item3 = new CoordinateItem(List.of("1", "3"));
+    private final CoordinateItem item2Again = new CoordinateItem(List.of("2", "1"));  // Ensure no == comparisons.
+
+    private final Content someIncorrectExplanation = new Content("Some incorrect explanation.");
+
+    /**
+     * Initial configuration of tests.
+     */
+    @Before
+    public final void setUp() {
+        validator = new IsaacCoordinateValidator();
+
+        // Set up the question object:
+        someCoordinateQuestion = new IsaacCoordinateQuestion();
+        someCoordinateQuestion.setNumberOfDimensions(2);
+        someCoordinateQuestion.setOrdered(true);
+
+        List<Choice> answerList = Lists.newArrayList();
+        ItemChoice someIncorrectChoice = new CoordinateChoice();
+        ItemChoice someCorrectChoice = new CoordinateChoice();
+
+        // Correct and incorrect choices:
+        someCorrectChoice.setItems(List.of(item1, item2));
+        someCorrectChoice.setCorrect(true);
+        someIncorrectChoice.setItems(ImmutableList.of(item3, item1));
+        someIncorrectChoice.setCorrect(false);
+        someIncorrectChoice.setExplanation(someIncorrectExplanation);
+
+        // Add both choices to question, incorrect first:
+        answerList.add(someIncorrectChoice);
+        answerList.add(someCorrectChoice);
+        someCoordinateQuestion.setChoices(answerList);
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestCorrectAnswer() {
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1, item2Again));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertTrue(response.isCorrect());
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestCompletelyIncorrectAnswer() {
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item3, item2));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestWrongOrderAnswer() {
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item2, item1));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestKnownWrongAnswer() {
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item3, item1));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertEquals(someIncorrectExplanation, response.getExplanation());
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestMismatchedNumberOfCoordinates_ExpectNoExplanation() {
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1, item2, item3));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());  // If the number is not set, there is no feedback to the user.
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestWrongNumberOfCoordinatesForQuestion_ExpectFeedback() {
+        IsaacCoordinateQuestion coordinateQuestion = new IsaacCoordinateQuestion();
+        coordinateQuestion.setNumberOfDimensions(2);
+        coordinateQuestion.setNumberOfCoordinates(1);  // If this is set, expect feedback on mismatch.
+
+        CoordinateChoice correctChoice = new CoordinateChoice();
+        correctChoice.setItems(List.of(item1));
+        correctChoice.setCorrect(true);
+        coordinateQuestion.setChoices(List.of(correctChoice));
+
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1, item2));
+        QuestionValidationResponse response = validator.validateQuestionResponse(coordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("did not provide the correct number of coordinates"));
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestWrongNumberOfDimensions() {
+        CoordinateItem ci = new CoordinateItem(List.of("1"));  // 1D not 2D
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(ci, ci));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("did not provide the expected number of dimensions"));
+    }
+
+    // Test the internals of the item-ordering:
+
+    @Test
+    public final void isaacCoordinateValidator_TestCoordinateNumericOrdering() {
+        CoordinateItem itemA = new CoordinateItem(List.of("1", "2", "0"));
+        CoordinateItem itemB = new CoordinateItem(List.of("1", "2", "3"));
+        CoordinateItem itemC = new CoordinateItem(List.of("1", "2", "5"));
+        CoordinateItem itemD = new CoordinateItem(List.of("010", "02", "03"));
+
+        List<CoordinateItem> unsorted = List.of(itemC, itemB, itemD, itemA);
+        List<CoordinateItem> sorted = List.of(itemA, itemB, itemC, itemD);
+        List<CoordinateItem> test = validator.orderCoordinates(unsorted);
+        assertEquals(sorted, test);
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestCoordinateSigFigOrdering() {
+        CoordinateItem itemA = new CoordinateItem(List.of("1.00", "2.000", "0"));
+        CoordinateItem itemB = new CoordinateItem(List.of("1.00000000", "2", "3"));
+        CoordinateItem itemC = new CoordinateItem(List.of("1", "2.000000", "5"));
+
+        List<CoordinateItem> unsorted = List.of(itemC, itemB, itemA);
+        List<CoordinateItem> sorted = List.of(itemA, itemB, itemC);
+        List<CoordinateItem> test = validator.orderCoordinates(unsorted);
+        assertEquals(sorted, test);
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestCoordinateNegativeOrdering() {
+        CoordinateItem itemA = new CoordinateItem(List.of("-1", "-2"));
+        CoordinateItem itemB = new CoordinateItem(List.of("-1", "2"));
+        CoordinateItem itemC = new CoordinateItem(List.of("1", "-2"));
+        CoordinateItem itemD = new CoordinateItem(List.of("1", "2"));
+
+        List<CoordinateItem> unsorted = List.of(itemC, itemD, itemB, itemA);
+        List<CoordinateItem> sorted = List.of(itemA, itemB, itemC, itemD);
+        List<CoordinateItem> test = validator.orderCoordinates(unsorted);
+        assertEquals(sorted, test);
+    }
+}

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
@@ -56,6 +56,7 @@ public class IsaacCoordinateValidatorTest {
         // Set up the question object:
         someCoordinateQuestion = new IsaacCoordinateQuestion();
         someCoordinateQuestion.setNumberOfDimensions(2);
+        someCoordinateQuestion.setSignificantFiguresMin(1);
         someCoordinateQuestion.setOrdered(true);
 
         List<Choice> answerList = Lists.newArrayList();
@@ -134,6 +135,7 @@ public class IsaacCoordinateValidatorTest {
         IsaacCoordinateQuestion coordinateQuestion = new IsaacCoordinateQuestion();
         coordinateQuestion.setNumberOfDimensions(2);
         coordinateQuestion.setNumberOfCoordinates(1);  // If this is set, expect feedback on mismatch.
+        coordinateQuestion.setSignificantFiguresMin(1);
 
         CoordinateChoice correctChoice = new CoordinateChoice();
         correctChoice.setItems(List.of(item1));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -30,7 +30,6 @@ import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Quantity;
-import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -1014,19 +1013,18 @@ public class IsaacNumericValidatorTest {
      * @throws Exception - if we can't execute the private method.
      */
     private void verifyCorrectNumberOfSigFigsNoRange(List<String> numbersToTest, List<Integer> sigFigsToPass, List<Integer> sigFigsToFail) throws Exception {
-        IsaacNumericValidator test = new IsaacNumericValidator();
         for (String number : numbersToTest) {
 
             for (Integer sigFig : sigFigsToPass) {
-                boolean tooFew = Whitebox.<Boolean>invokeMethod(test, "tooFewSignificantFigures", number, sigFig);
+                boolean tooFew = ValidationUtils.tooFewSignificantFigures(number, sigFig, (Logger) Whitebox.getField(validator.getClass(), "log").get(validator));
                 assertFalse("Unexpected too few sig fig for " + number + " @ " + sigFig + "sf", tooFew);
-                boolean tooMany = Whitebox.<Boolean>invokeMethod(test, "tooManySignificantFigures", number, sigFig);
+                boolean tooMany = ValidationUtils.tooManySignificantFigures(number, sigFig, (Logger) Whitebox.getField(validator.getClass(), "log").get(validator));
                 assertFalse("Unexpected too many sig fig for " + number + " @ " + sigFig + "sf", tooMany);
             }
 
             for (Integer sigFig : sigFigsToFail) {
-                boolean tooFew = Whitebox.<Boolean>invokeMethod(test, "tooFewSignificantFigures", number, sigFig);
-                boolean tooMany = Whitebox.<Boolean>invokeMethod(test, "tooManySignificantFigures", number, sigFig);
+                boolean tooFew = ValidationUtils.tooFewSignificantFigures(number, sigFig, (Logger) Whitebox.getField(validator.getClass(), "log").get(validator));
+                boolean tooMany = ValidationUtils.tooManySignificantFigures(number, sigFig, (Logger) Whitebox.getField(validator.getClass(), "log").get(validator));
                 boolean incorrectSigFig = tooMany || tooFew;
                 assertTrue("Expected incorrect sig fig for " + number + " @ " + sigFig + "sf", incorrectSigFig);
             }

--- a/src/test/resources/isaac-test-es-data.tar.gz
+++ b/src/test/resources/isaac-test-es-data.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:467e6dc21cdec03f35f19edec252098181c92057ee52f7f1d26f782718866d52
-size 2865642
+oid sha256:191a795a7cbe7bb5c37bb77622cbccc32eafdc1f1a026a1dd9f38e9719a3bf81
+size 2989790


### PR DESCRIPTION
This moves the validator to use the new list-of-strings representation of coordinates to allow an arbitrary number of dimensions in a coordinate.
There are some subtleties, because "ordering" the coordinates for comparison is complicated - as is the quadratic nature of the checking algorithm.

It also cleans up some log messages and comments for clarity, and adds unit tests.

https://github.com/isaacphysics/isaac-api/pull/662 should be merged first, and deployed before this can safely be merged.
