### PR TITLE
Use lightweight validation responses for progress stats

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IQuestionAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IQuestionAttemptManager.java
@@ -1,14 +1,14 @@
 package uk.ac.cam.cl.dtg.isaac.quiz;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import uk.ac.cam.cl.dtg.segue.api.Constants.TimeInterval;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.isaac.dos.LightweightQuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
+import uk.ac.cam.cl.dtg.segue.api.Constants.*;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * IQuestionAttemptManager. Objects implementing this interface are responsible for recording question attempts
@@ -44,6 +44,18 @@ public interface IQuestionAttemptManager {
      *             - If there is a database error.
      */
     Map<String, Map<String, List<QuestionValidationResponse>>> getQuestionAttempts(final Long userId)
+            throws SegueDatabaseException;
+
+    /**
+     * Get a users question attempts in lightweight form, without full answer data.
+     *
+     * @param userId
+     *            - the id of the user to search for.
+     * @return the questionAttempts map or an empty map if the user has not yet registered any attempts.
+     * @throws SegueDatabaseException
+     *             - If there is a database error.
+     */
+    Map<String, Map<String, List<LightweightQuestionValidationResponse>>> getLightweightQuestionAttempts(final Long userId)
             throws SegueDatabaseException;
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java
@@ -264,7 +264,7 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
                      + " WHERE user_id = ANY(?) ORDER BY \"timestamp\" ASC";
 
         Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>> mapToReturn
-                = userIds.stream().collect(Collectors.toMap(Function.identity(), k -> Maps.newHashMap()));
+                = userIds.stream().collect(Collectors.toMap(Function.identity(), k -> Maps.newLinkedHashMap()));
 
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement(query)) {
@@ -282,7 +282,12 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
             throw new SegueDatabaseException("Postgres exception", e);
         }
     }
-    
+
+    @Override
+    public Map<String, Map<String, List<LightweightQuestionValidationResponse>>> getLightweightQuestionAttempts(Long userId) throws SegueDatabaseException {
+        return this.getLightweightQuestionAttemptsByUsers(Collections.singletonList(userId)).getOrDefault(userId, Collections.emptyMap());
+    }
+
     @Override
     public Map<Long, Map<String, Map<String, List<LightweightQuestionValidationResponse>>>>
         getMatchingLightweightQuestionAttempts(final List<Long> userIds, final List<String> allQuestionPageIds)
@@ -461,10 +466,10 @@ public class PgQuestionAttempts implements IQuestionAttemptManager {
             Long userId = results.getLong("user_id");
 
             Map<String, Map<String, List<LightweightQuestionValidationResponse>>> mapOfQuestionAttemptsByPage
-                    = mapToAugment.computeIfAbsent(userId, k -> Maps.newHashMap());
+                    = mapToAugment.computeIfAbsent(userId, k -> Maps.newLinkedHashMap());
 
             Map<String, List<LightweightQuestionValidationResponse>> attemptsForThisQuestionPage
-                    = mapOfQuestionAttemptsByPage.computeIfAbsent(questionPageId, k -> Maps.newHashMap());
+                    = mapOfQuestionAttemptsByPage.computeIfAbsent(questionPageId, k -> Maps.newLinkedHashMap());
 
             List<LightweightQuestionValidationResponse> listOfResponses
                     = attemptsForThisQuestionPage.computeIfAbsent(questionId, k -> Lists.newArrayList());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -393,7 +393,7 @@ public class QuestionManager {
     }
 
     /**
-     * getQuestionAttemptsByUser. This method will return all of the question attempts for a given user as a map.
+     * getLightweightQuestionAttemptsByUser. This method will return all of the question attempts for a given user as a map.
      *
      * Attempts will not be augmented with the full attempt JSON data.
      *

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/QuestionManager.java
@@ -393,6 +393,23 @@ public class QuestionManager {
     }
 
     /**
+     * getQuestionAttemptsByUser. This method will return all of the question attempts for a given user as a map.
+     *
+     * Attempts will not be augmented with the full attempt JSON data.
+     *
+     * @param user
+     *            - with the session information included.
+     * @return map of question attempts (QuestionPageId -> QuestionID -> [LightweightQuestionValidationResponse] or an empty map.
+     * @throws SegueDatabaseException
+     *             - if there is a database error.
+     */
+    public Map<String, Map<String, List<LightweightQuestionValidationResponse>>> getLightweightQuestionAttemptsByUser(final RegisteredUserDTO user)
+            throws SegueDatabaseException {
+        return this.questionAttemptPersistenceManager.getLightweightQuestionAttempts(user.getId());
+    }
+
+
+    /**
      * Return all the attempts of a user at a specified page ID prefix.
      *
      * The map returned by this method is in the same format as {@link #getQuestionAttemptsByUser(AbstractSegueUserDTO)}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/StatisticsManager.java
@@ -26,7 +26,7 @@ import uk.ac.cam.cl.dtg.isaac.api.services.ContentSummarizerService;
 import uk.ac.cam.cl.dtg.isaac.dos.AudienceContext;
 import uk.ac.cam.cl.dtg.isaac.dos.Difficulty;
 import uk.ac.cam.cl.dtg.isaac.dos.IUserStreaksManager;
-import uk.ac.cam.cl.dtg.isaac.dos.QuestionValidationResponse;
+import uk.ac.cam.cl.dtg.isaac.dos.LightweightQuestionValidationResponse;
 import uk.ac.cam.cl.dtg.isaac.dos.Stage;
 import uk.ac.cam.cl.dtg.isaac.dos.users.Role;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacQuestionPageDTO;
@@ -206,15 +206,14 @@ public class StatisticsManager implements IStatisticsManager {
         LocalDate lastDayOfPreviousAcademicYear =
                 now.isAfter(endOfAugustThisYear) ? endOfAugustThisYear : endOfAugustLastYear;
 
-        Map<String, Map<String, List<QuestionValidationResponse>>> questionAttemptsByUser = questionManager.getQuestionAttemptsByUser(userOfInterest);
+        Map<String, Map<String, List<LightweightQuestionValidationResponse>>> questionAttemptsByUser = questionManager.getLightweightQuestionAttemptsByUser(userOfInterest);
         Map<String, ContentDTO> questionMap = this.getQuestionMap(questionAttemptsByUser.keySet());
 
         // Loop through each Question attempted:
-        for (Entry<String, Map<String, List<QuestionValidationResponse>>> question : questionAttemptsByUser.entrySet()) {
+        for (Entry<String, Map<String, List<LightweightQuestionValidationResponse>>> question : questionAttemptsByUser.entrySet()) {
             ContentDTO contentDTO = questionMap.get(question.getKey());
             if (!(contentDTO instanceof IsaacQuestionPageDTO)) {
-                log.warn(String.format("Excluding unknown question (%s) from user progress statistics for user (%s)!",
-                        question.getKey(), userOfInterest.getId()));
+                log.warn("Excluding unknown question ({}) from user progress statistics for user ({})!", question.getKey(), userOfInterest.getId());
                 // This content is missing, or it is not a question page; either way, exclude it.
                 continue;
             }
@@ -236,7 +235,7 @@ public class StatisticsManager implements IStatisticsManager {
                     LocalDate mostRecentAttemptAtThisQuestionPart = null;
 
                     // Loop through each attempt at the Question Part if they have attempted it:
-                    for (QuestionValidationResponse validationResponse : question.getValue().get(questionPart.getId())) {
+                    for (LightweightQuestionValidationResponse validationResponse : question.getValue().get(questionPart.getId())) {
                         LocalDate dateAttempted = LocalDateTime.ofInstant(
                                 validationResponse.getDateAttempted().toInstant(), ZoneId.systemDefault()).toLocalDate();
                         if (mostRecentAttemptAtThisQuestionPart == null || dateAttempted.isAfter(mostRecentAttemptAtThisQuestionPart)) {


### PR DESCRIPTION
Prior to this commit, we loaded the full attempt JSON data from the database for every question attempt the user had made - but at no point do we need this data. We can avoid a great deal of deserialising if we instead load just the lightweight attempts, which we can do using existing queries (plus some plumbing).

One bug was revealed; although the database query sorts the lightweight attempts identically to the full attempts, and the structure of the nested Maps is identical - the Lightweight code path used HashMaps but the full validation response code path used LinkedHashMaps. The former do not preserve insertion order, and so were removing this sorting. The existing uses of the data clearly did not _need_ sorted attempts, but the My Progress stats page does. The cost of switching to the LinkedHashMap is small and only on creation; iterating over it as we do is much faster. This now preserves the (costly) sorting done in the DB.