### PR TITLE
Add external validator timeout

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IValidator.java
@@ -16,7 +16,6 @@
 package uk.ac.cam.cl.dtg.isaac.quiz;
 
 
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,6 +31,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,6 +109,7 @@ public interface IValidator {
 
             HttpRequest httpRequest = HttpRequest.newBuilder()
                     .uri(URI.create(externalValidatorUrl))
+                    .timeout(Duration.ofMillis(1000))
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(requestString))
                     .build();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -296,7 +296,7 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                     log.error(
                             "Failed to check formula with chemistry checker. Is the server running? Not trying again."
                     );
-                    throw new ValidatorUnavailableException("We are having problems marking Chemistry Questions."
+                    throw new ValidatorUnavailableException("We are having problems marking chemistry equation questions."
                             + " Please try again later!");
                 }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicLogicValidator.java
@@ -208,7 +208,7 @@ public class IsaacSymbolicLogicValidator implements IValidator {
 
                 } catch (IOException e) {
                     log.error("Failed to check formula with symbolic checker. Is the server running? Not trying again.");
-                    throw new ValidatorUnavailableException("We are having problems marking Logic Questions."
+                    throw new ValidatorUnavailableException("We are having problems marking logic questions."
                             + " Please try again later!");
                 }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
@@ -27,6 +27,7 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.Formula;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 
 import java.io.IOException;
+import java.net.http.HttpTimeoutException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -208,8 +209,12 @@ public class IsaacSymbolicValidator implements IValidator {
                     }
 
                 } catch (IOException e) {
-                    log.error("Failed to check formula with symbolic checker. Is the server running? Not trying again.");
-                    throw new ValidatorUnavailableException("We are having problems marking Symbolic Questions."
+                    if (e instanceof HttpTimeoutException) {
+                        log.error("Timeout waiting for symbolic checker! Not trying again.");
+                    } else {
+                        log.error("Failed to check formula with symbolic checker. Is the server running? Not trying again.");
+                    }
+                    throw new ValidatorUnavailableException("We are having problems marking symbolic questions."
                             + " Please try again later!");
                 }
 


### PR DESCRIPTION
Without a timeout specified here, the .send() call would block indefinitely. I believe 1 second is a safe enough limit; most validator requests take around 50-100ms (and trivial requests much less).
However, we should keep an eye on this when deployed.

This should prevent the validator from queuing too many requests and exhausting the Jetty threadpool.

For symbolic questions, the most common, explicitly log the timeout as an error by itself, to aid review of the timeout duration.
