### PR TITLE
Remove deprecated coordinate question properties

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCoordinateQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCoordinateQuestion.java
@@ -21,10 +21,6 @@ public class IsaacCoordinateQuestion extends IsaacQuestionBase {
     private Integer numberOfDimensions;
 
     private Boolean ordered;  // If true, the order of the coordinates in a choice matters.
-    @Deprecated
-    private String placeholderXValue;
-    @Deprecated
-    private String placeholderYValue;
     private List<String> placeholderValues;
     private Integer significantFiguresMin;
     private Integer significantFiguresMax;
@@ -89,26 +85,6 @@ public class IsaacCoordinateQuestion extends IsaacQuestionBase {
      */
     public void setSignificantFiguresMax(final Integer significantFigures) {
         this.significantFiguresMax = significantFigures;
-    }
-
-    @Deprecated
-    public String getPlaceholderXValue() {
-        return placeholderXValue;
-    }
-
-    @Deprecated
-    public void setPlaceholderXValue(String placeholderXValue) {
-        this.placeholderXValue = placeholderXValue;
-    }
-
-    @Deprecated
-    public String getPlaceholderYValue() {
-        return placeholderYValue;
-    }
-
-    @Deprecated
-    public void setPlaceholderYValue(String placeholderYValue) {
-        this.placeholderYValue = placeholderYValue;
     }
 
     public List<String> getPlaceholderValues() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CoordinateItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/CoordinateItem.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 @JsonContentType("coordinateItem")
 public class CoordinateItem extends Item {
     private List<String> coordinates;
+    // These two are needed to load old attempts out of the database:
     @Deprecated
     private String x;
     @Deprecated

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCoordinateQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacCoordinateQuestionDTO.java
@@ -13,11 +13,6 @@ public class IsaacCoordinateQuestionDTO extends IsaacQuestionBaseDTO {
 
     private List<String> placeholderValues;
 
-    @Deprecated
-    private String placeholderXValue;
-    @Deprecated
-    private String placeholderYValue;
-
     public Integer getNumberOfCoordinates() {
         return numberOfCoordinates;
     }
@@ -40,26 +35,6 @@ public class IsaacCoordinateQuestionDTO extends IsaacQuestionBaseDTO {
 
     public void setOrdered(final Boolean ordered) {
         this.ordered = ordered;
-    }
-
-    @Deprecated
-    public String getPlaceholderXValue() {
-        return placeholderXValue;
-    }
-
-    @Deprecated
-    public void setPlaceholderXValue(String placeholderXValue) {
-        this.placeholderXValue = placeholderXValue;
-    }
-
-    @Deprecated
-    public String getPlaceholderYValue() {
-        return placeholderYValue;
-    }
-
-    @Deprecated
-    public void setPlaceholderYValue(String placeholderYValue) {
-        this.placeholderYValue = placeholderYValue;
     }
 
     public List<String> getPlaceholderValues() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CoordinateItemDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/CoordinateItemDTO.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public class CoordinateItemDTO extends ItemDTO {
     private List<String> coordinates;
+    // These two are needed to load old attempts out of the database:
     @Deprecated
     private String x;
     @Deprecated


### PR DESCRIPTION
We cannot remove the Item properties since those are stored in the database and we need to be able to load old answers.

The content changes to remove the deprecated properties from the JSON files needs to have been pushed before this is safe to release.