### PR TITLE
Search by tags according to the QF tag field

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -471,7 +471,7 @@ public class GitContentManager {
                     searchInstructionBuilder.searchFor(new SearchInField(TAGS_FIELDNAME, entry.getValue())
                             .strategy(Strategy.SIMPLE)
                             .required(true));
-                } else if (Arrays.asList(SUBJECTS_FIELDNAME, FIELDS_FIELDNAME, TOPICS_FIELDNAME, CATEGORIES_FIELDNAME)
+                } else if (Arrays.asList(SUBJECTS_FIELDNAME, FIELDS_FIELDNAME, TOPICS_FIELDNAME, CATEGORIES_FIELDNAME, TAGS_FIELDNAME)
                         .contains(entry.getKey())) {
                     searchInstructionBuilder.searchFor(new SearchInField(TAGS_FIELDNAME, entry.getValue())
                             .strategy(Strategy.SIMPLE)


### PR DESCRIPTION
To allow for the redesigned QF searching across topic/subject/field boundaries, we should allow tags to be passed from the front-end to be searched.

We have already done most of the work here, but aren’t actually applying the tags to the search. This shouldn’t affect anything on the live site as no tags are passed in from the front-end yet.