### PR TITLE
Question Finder improvements

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -334,6 +334,12 @@ public class PagesFacade extends AbstractIsaacFacade {
                     String.format("Search string exceeded %s character limit.", SEARCH_TEXT_CHAR_LIMIT));
         }
 
+        // TODO: the limit ought to be lower when filtering by attempt status
+        if (null != paramLimit && paramLimit > MAX_SEARCH_RESULT_LIMIT) {
+            log.warn("Question search requested {} results!", paramLimit);
+            return SegueErrorResponse.getBadRequestResponse("Maximum search result limit exceeded!");
+        }
+
         try {
             user = userManager.getCurrentUser(httpServletRequest);
         } catch (SegueDatabaseException e) {
@@ -375,6 +381,7 @@ public class PagesFacade extends AbstractIsaacFacade {
         logEntry.put(TAGS_FIELDNAME, csvParamToLogValue(tags));
         logEntry.put(QUESTION_STATUSES_FIELDNAME, csvParamToLogValue(statuses));
         logEntry.put(START_INDEX_FIELDNAME, String.valueOf(startIndex));
+        logEntry.put(LIMIT_FIELDNAME, String.valueOf(limit));
 
         this.getLogManager().logEvent(user, httpServletRequest, IsaacServerLogType.QUESTION_FINDER_SEARCH, logEntry);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -289,9 +289,7 @@ public class PagesFacade extends AbstractIsaacFacade {
 
     /**
      * REST end point to provide a list of questions.
-     * 
-     * @param request
-     *            - used to determine if we can return a cache response.
+     *
      * @param ids
      *            - the ids of the concepts to request.
      * @param searchString
@@ -314,19 +312,19 @@ public class PagesFacade extends AbstractIsaacFacade {
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
     @Operation(summary = "List all question page objects matching the provided criteria.")
-    public final Response getQuestionList(@Context final Request request,
-            @Context final HttpServletRequest httpServletRequest,
+    public final Response getQuestionList(@Context final HttpServletRequest httpServletRequest,
             @QueryParam("ids") final String ids, @QueryParam("searchString") final String searchString,
             @QueryParam("tags") final String tags, @QueryParam("levels") final String level,
-            @QueryParam("subjects") final String subjects,
-            @QueryParam("fields") final String fields, @QueryParam("topics") final String topics,
+            @QueryParam("subjects") final String subjects, @QueryParam("fields") final String fields,
+            @QueryParam("topics") final String topics,
             @QueryParam("stages") final String stages, @QueryParam("difficulties") final String difficulties,
-            @QueryParam("examBoards") final String examBoards, @QueryParam("books") final String books,
-            @QueryParam("questionCategories") final String questionCategories,
+            @QueryParam("examBoards") final String examBoards,
+            @QueryParam("books") final String books, @QueryParam("questionCategories") final String questionCategories,
             @QueryParam("statuses") final String statuses,
             @DefaultValue("false") @QueryParam("fasttrack") final Boolean fasttrack,
             @DefaultValue(DEFAULT_START_INDEX_AS_STRING) @QueryParam("startIndex") final Integer paramStartIndex,
-            @DefaultValue(DEFAULT_RESULTS_LIMIT_AS_STRING) @QueryParam("limit") final Integer paramLimit) {
+            @DefaultValue(DEFAULT_RESULTS_LIMIT_AS_STRING) @QueryParam("limit") final Integer paramLimit,
+            @QueryParam("randomSeed") final Long randomSeed) {
         Map<String, Set<String>> fieldsToMatch = Maps.newHashMap();
         Set<CompletionState> filterByStatuses;
         AbstractSegueUserDTO user;
@@ -444,10 +442,11 @@ public class PagesFacade extends AbstractIsaacFacade {
                 ResultsWrapper<ContentDTO> c;
                 c = contentManager.questionSearch(
                         validatedSearchString,
+                        randomSeed,
                         fieldsToMatch,
-                        fasttrack,
                         nextSearchStartIndex,
                         limit,
+                        fasttrack,
                         showNoFilterContent,
                         showSupersededContent
                 );

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -442,6 +442,7 @@ public final class Constants {
     public static final String DEFAULT_RESULTS_LIMIT_AS_STRING = "10";
 
     public static final String DEFAULT_SEARCH_RESULT_LIMIT_AS_STRING = "25";
+    public static final Integer MAX_SEARCH_RESULT_LIMIT = 350;
 
     public static final Integer SEARCH_TEXT_CHAR_LIMIT = 1000;
 
@@ -481,6 +482,7 @@ public final class Constants {
     public static final String SEARCH_STRING_FIELDNAME = "searchString";
     public static final String QUESTION_STATUSES_FIELDNAME = "questionStatuses";
     public static final String START_INDEX_FIELDNAME = "startIndex";
+    public static final String LIMIT_FIELDNAME = "limit";
     public static final Set<String> NESTED_QUERY_FIELDS =
             ImmutableSet.of(STAGE_FIELDNAME, DIFFICULTY_FIELDNAME, EXAM_BOARD_FIELDNAME);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -391,6 +391,7 @@ public class GitContentManager {
                 startIndex,
                 limit,
                 searchInstructionBuilder.build(),
+                null,
                 sortOrder
         );
 
@@ -413,9 +414,10 @@ public class GitContentManager {
      */
     public final ResultsWrapper<ContentDTO> questionSearch(
             @Nullable final String searchString,
+            @Nullable final Long randomSeed,
             final Map<String, Set<String>> filterFieldNamesToValues,
-            final boolean fasttrack, final Integer startIndex,
-            final Integer limit, final boolean showNoFilterContent, final boolean showSupersededContent
+            final Integer startIndex, final Integer limit,
+            final boolean fasttrack, final boolean showNoFilterContent, final boolean showSupersededContent
     ) throws ContentManagerException {
 
         // Set question type (content type) based on fasttrack status
@@ -484,9 +486,9 @@ public class GitContentManager {
             }
         }
 
-        // If no search terms were provided, sort by ascending alphabetical order of title.
+        // If no search terms or random seed, sort by ascending alphabetical order of title.
         Map<String, Constants.SortOrder> sortOrder = null;
-        if (searchTerms.isEmpty()) {
+        if (searchTerms.isEmpty() && null == randomSeed) {
             sortOrder = new HashMap<>();
             sortOrder.put(
                     Constants.TITLE_FIELDNAME + "." + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX,
@@ -500,6 +502,7 @@ public class GitContentManager {
                 startIndex,
                 limit,
                 searchInstructionBuilder.build(),
+                randomSeed,
                 sortOrder
         );
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ISearchProvider.java
@@ -17,9 +17,9 @@ package uk.ac.cam.cl.dtg.segue.search;
 
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
-import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
@@ -108,9 +108,10 @@ public interface ISearchProvider {
             final String... fields
     ) throws SegueSearchException;
 
-    public ResultsWrapper<String> nestedMatchSearch(
+    ResultsWrapper<String> nestedMatchSearch(
             final String indexBase, final String indexType, final Integer startIndex, final Integer limit,
-            @NotNull final BooleanInstruction matchInstruction, @Nullable final Map<String, Constants.SortOrder> sortOrder
+            @NotNull final BooleanInstruction matchInstruction, @Nullable Long randomSeed,
+            @Nullable final Map<String, Constants.SortOrder> sortOrder
     ) throws SegueSearchException;
 
     /**

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacadeIT.java
@@ -16,10 +16,6 @@
 
 package uk.ac.cam.cl.dtg.isaac.api;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.core.Request;
-import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.ac.cam.cl.dtg.isaac.api.managers.URIManager;
@@ -27,13 +23,15 @@ import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.segue.api.services.ContentService;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.replay;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class PagesFacadeIT extends IsaacIntegrationTest{
@@ -57,8 +55,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
-                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", "", "", false, 0, -1);
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
+                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", "", "", false, 0, -1, null);
 
         // Assert
         // check status code is OK
@@ -83,8 +81,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
-                ITConstants.SEARCH_TEST_CONCEPT_ID, "", "", "", "", "", "", "", "", "", "", "", "", false, 0, -1);
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
+                ITConstants.SEARCH_TEST_CONCEPT_ID, "", "", "", "", "", "", "", "", "", "", "", "", false, 0, -1, null);
 
         // Assert
         // check status code is OK
@@ -109,8 +107,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
-                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", "", "", true, 0, -1);
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
+                ITConstants.REGRESSION_TEST_PAGE_ID, "", "", "", "", "", "", "", "", "", "", "", "", true, 0, -1, null);
 
         // Assert
         // check status code is OK
@@ -135,9 +133,9 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
                 String.format("%s,%s", ITConstants.REGRESSION_TEST_PAGE_ID, ITConstants.ASSIGNMENT_TEST_PAGE_ID), "",
-                "", "", "", "", "", "", "", "", "", "", "", false, 0, -1);
+                "", "", "", "", "", "", "", "", "", "", "", false, 0, -1, null);
 
         // Assert
         // check status code is OK
@@ -162,8 +160,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
-                "", "Regression Test Page", "", "", "", "", "", "", "", "", "", "", "", false, 0, -1);
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
+                "", "Regression Test Page", "", "", "", "", "", "", "", "", "", "", "", false, 0, -1, null);
 
         // Assert
         // check status code is OK
@@ -197,8 +195,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
-                "", "Regression Test Page", "", "", "", "", "", "", "", "", "", "", "", false, 0, 1);
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
+                "", "Regression Test Page", "", "", "", "", "", "", "", "", "", "", "", false, 0, 1, null);
 
         // Assert
         // check status code is OK
@@ -228,8 +226,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
-                "", "Canary", "", "", "", "", "", "", "", "", "", "", "", false, 0, 1);
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
+                "", "Canary", "", "", "", "", "", "", "", "", "", "", "", false, 0, 1, null);
 
         // Assert
         // check status code is OK
@@ -258,8 +256,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
-                "", "Convival", "", "", "", "", "", "", "", "", "", "", "", false, 0, 1);
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
+                "", "Convival", "", "", "", "", "", "", "", "", "", "", "", false, 0, 1, null);
 
         // Assert
         // check status code is OK
@@ -284,8 +282,8 @@ public class PagesFacadeIT extends IsaacIntegrationTest{
 
         // Act
         // make request
-        Response searchResponse = pagesFacade.getQuestionList(createNiceMock(Request.class), searchRequest,
-                "", "Convival", "", "", "", "", "", "", "", "", "", "", "", false, 0, 1);
+        Response searchResponse = pagesFacade.getQuestionList(searchRequest,
+                "", "Convival", "", "", "", "", "", "", "", "", "", "", "", false, 0, 1, null);
 
         // Assert
         // check status code is OK


### PR DESCRIPTION
This does not use the existing but deprecated GitContentManager method, but updates the questionSearch method to allow passing a random seed which will be used if no sort order is provided. The random sorting is done in ElasticSearch in exactly the same way the old gameboard builder randomisation was.

I reordered the arguments of the function to better logically group them, and removed some unused arguments from all the methods involved.

Add a hard limit to the question search endpoint, and also improve logging of the usage of the limit parameter.

This is entirely backwards compatible.