### PR TITLE
Temporarily remove automatic nuclear question feedback

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -331,7 +331,7 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
 
             // STEP 4: Decide on what response to give to user
 
-            if (containsError) {
+            if (!isNuclear && containsError) {
 
                 // User input contains error terms.
                 if (closestResponse != null && VALID_ERROR_FEEDBACK.contains((String) closestResponse.get("error"))) {
@@ -346,6 +346,11 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                 // There is an exact match to a choice.
                 feedback = (Content) closestMatch.getExplanation();
                 responseCorrect = closestMatch.isCorrect();
+
+            } else if (isNuclear) {
+
+                // Temporarily removing nuclear question feedback while we decide on the specific wording
+                feedback = new Content("");
 
             } else if (isNuclear && !chemistryQuestion.isNuclear()) {
 


### PR DESCRIPTION
This removes all automatic feedback (e.g. `"Check that all atoms have a mass and atomic number!"`, `"Your equation is unbalanced!"`) from all symbolic nuclear questions. Specific feedback as written by content developers from an exact match are still given.

This is a temporary measure while we come to an agreement about the wording of each of these feedback messages.