### PR TITLE
Improved gameboard loading

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -553,7 +553,7 @@ public class GameManager {
         List<GameboardDTO> sublistOfGameboards = resultToReturn.subList(startIndex, toIndex);
 
         // fully augment only those we are returning.
-        this.gameboardPersistenceManager.augmentGameboardItems(sublistOfGameboards);
+        this.gameboardPersistenceManager.augmentGameboardItemsWithContentData(sublistOfGameboards);
 
         return new GameboardListDTO(sublistOfGameboards, (long) resultToReturn.size(),
                 totalNotStarted, totalInProgress, totalAllAttempted);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -28,7 +28,6 @@ import com.google.inject.Inject;
 import ma.glasnost.orika.MapperFacade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.isaac.api.managers.URIManager;
 import uk.ac.cam.cl.dtg.isaac.dos.GameboardContentDescriptor;
 import uk.ac.cam.cl.dtg.isaac.dos.GameboardCreationMethod;
 import uk.ac.cam.cl.dtg.isaac.dos.GameboardDO;
@@ -87,8 +86,6 @@ public class GameboardPersistenceManager {
 
     private final GitContentManager contentManager;
 
-    private final URIManager uriManager;
-
     /**
      * Creates a new user data manager object.
      * 
@@ -100,18 +97,14 @@ public class GameboardPersistenceManager {
      *            - An instance of an automapper that can be used for mapping to and from GameboardDOs and DTOs.
      * @param objectMapper
      *            - An instance of an automapper that can be used for converting objects to and from json.
-     * 
-     * @param uriManager
-     *            - so we can generate appropriate content URIs.
      */
     @Inject
     public GameboardPersistenceManager(final PostgresSqlDb database, final GitContentManager contentManager,
-                                       final MapperFacade mapper, final ContentMapper objectMapper, final URIManager uriManager) {
+                                       final MapperFacade mapper, final ContentMapper objectMapper) {
         this.database = database;
         this.mapper = mapper;
         this.contentManager = contentManager;
         this.objectMapper = objectMapper.getSharedContentObjectMapper();;
-        this.uriManager = uriManager;
         this.gameboardNonPersistentStorage = CacheBuilder.newBuilder()
                 .expireAfterAccess(GAMEBOARD_TTL_MINUTES, TimeUnit.MINUTES).<String, GameboardDO> build();
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -783,10 +783,6 @@ public class GameboardPersistenceManager {
                     listOfResults.add(this.convertFromSQLToGameboardDO(results));
                 }
 
-                if (listOfResults.size() == 0) {
-                    return null;
-                }
-
                 List<GameboardDTO> databaseGameboards = listOfResults.stream().map(r -> this.convertToGameboardDTO(r, fullyPopulate)).collect(Collectors.toList());
 
                 return Stream.of(cachedGameboards, databaseGameboards).flatMap(Collection::stream).collect(Collectors.toList());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.api.managers.AssignmentManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.isaac.api.managers.QuizAssignmentManager;
-import uk.ac.cam.cl.dtg.isaac.api.managers.URIManager;
 import uk.ac.cam.cl.dtg.isaac.api.services.ContentSummarizerService;
 import uk.ac.cam.cl.dtg.isaac.api.services.EmailService;
 import uk.ac.cam.cl.dtg.isaac.api.services.GroupChangedService;
@@ -1232,12 +1231,10 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Inject
     @Provides
     @Singleton
-    private static GameboardPersistenceManager getGameboardPersistenceManager(final PostgresSqlDb database,
-                                                                              final GitContentManager contentManager, final MapperFacade mapper, final ContentMapper objectMapper,
-                                                                              final URIManager uriManager) {
+    private static GameboardPersistenceManager getGameboardPersistenceManager(final PostgresSqlDb database, final GitContentManager contentManager,
+                                                                              final MapperFacade mapper, final ContentMapper objectMapper) {
         if (null == gameboardPersistenceManager) {
-            gameboardPersistenceManager = new GameboardPersistenceManager(database, contentManager, mapper,
-                    objectMapper, uriManager);
+            gameboardPersistenceManager = new GameboardPersistenceManager(database, contentManager, mapper, objectMapper);
             log.info("Creating Singleton of GameboardPersistenceManager");
         }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
@@ -325,7 +325,7 @@ public abstract class IsaacIntegrationTest {
         PgUserGroupPersistenceManager pgUserGroupPersistenceManager = new PgUserGroupPersistenceManager(postgresSqlDb);
         IAssignmentPersistenceManager assignmentPersistenceManager = new PgAssignmentPersistenceManager(postgresSqlDb, mapperFacade);
 
-        GameboardPersistenceManager gameboardPersistenceManager = new GameboardPersistenceManager(postgresSqlDb, contentManager, mapperFacade, contentMapper, new URIManager(properties));
+        GameboardPersistenceManager gameboardPersistenceManager = new GameboardPersistenceManager(postgresSqlDb, contentManager, mapperFacade, contentMapper);
         gameManager = new GameManager(contentManager, gameboardPersistenceManager, mapperFacade, questionManager);
         groupManager = new GroupManager(pgUserGroupPersistenceManager, userAccountManager, gameManager, mapperFacade);
         userAssociationManager = new UserAssociationManager(pgAssociationDataManager, userAccountManager, groupManager);


### PR DESCRIPTION
At present when gameboards are loaded in bulk and augmented by `getGameboardsByIds` in the `GameboardPersistenceManager`, we make separate requests to ElasticSearch for each gameboard. This is because the DO to DTO mapping is run once per board, rather than all together, and each call makes a query to ES.
But `getGameboardItemMap`, which that method implicitly used, had been written to allow bulk loading of data in much larger groups than a single gameboard. So instead of making the bulk `convertToGameboardDTOs` method use the single `convertToGameboardDTO` method, the reverse is now true; single boards are augmented via a singleton list and the bulk loading is the only code path.
That enables DO to DTO mapping to vastly reduce the number of ES queries that are made, and also reduced the spaghetti code down to a single code path. From there, all the augmentation methods can be combined and the duplicate or redundant code removed.

Doing this also allows us to fix a bug where existing bulk augmentation of gameboards would lose the creationContext for a question if it was included on multiple boards. This was because there was one map of question ID -> gameboard item (`gameboardReadyQuestions`), which could only keep just one context per question.
This rewrites the code to use a map of question ID to ContentDTO (which is always the same), and does the mapping inline in the renamed `augmentGameboardItemsWithContentData` method using the correct context for each question/gameboard combination.
