### PR TITLE
Add an endpoint to load a detailed quiz summary

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -174,6 +174,7 @@ public final class Constants {
         VIEW_PAGE,
         VIEW_PAGE_FRAGMENT,
         VIEW_QUESTION,
+        VIEW_QUIZ_RUBRIC,
         VIEW_QUIZ_SECTION,
         VIEW_TOPIC_SUMMARY_PAGE,
         VIEW_USER_PROGRESS,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -363,7 +363,7 @@ public class QuizFacade extends AbstractIsaacFacade {
      * @param quizId             - the ID of the quiz the user wishes to attempt.
      * @return a DetailedQuizSummaryDTO
      */
-    @POST
+    @GET
     @Path("/{quizId}/rubric")
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
@@ -31,6 +31,7 @@ import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentSummaryDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.content.DetailedQuizSummaryDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.QuizSummaryDTO;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.api.services.ContentService;
@@ -124,6 +125,17 @@ public class QuizManager {
         } else {
             throw new ContentManagerException("Expected an IsaacQuiz (id=" + quizId + "), got a " + cachedContent.getType());
         }
+    }
+
+    /**
+     *  Get a detailed quiz summary object by quiz ID.
+     *
+     * @param quizId - the quiz to summarise.
+     * @return a quiz summary containing the rubric of the quiz.
+     * @throws ContentManagerException if the quiz is not found.
+     */
+    public DetailedQuizSummaryDTO getQuizSummary(final String quizId) throws ContentManagerException {
+        return (DetailedQuizSummaryDTO) contentSummarizerService.extractContentSummary(this.findQuiz(quizId), DetailedQuizSummaryDTO.class);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/DetailedQuizSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/DetailedQuizSummaryDTO.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.isaac.dto.content;
+
+import uk.ac.cam.cl.dtg.isaac.dos.content.Content;
+
+/**
+ *  Class to encapsulate a quiz summary containing additional metadata.
+ */
+public class DetailedQuizSummaryDTO extends QuizSummaryDTO {
+    private Content rubric;
+
+    public DetailedQuizSummaryDTO() {
+
+    }
+
+    public Content getRubric() {
+        return rubric;
+    }
+
+    public void setRubric(final Content rubric) {
+        this.rubric = rubric;
+    }
+}


### PR DESCRIPTION
Currently there is no way to see the rubric of a quiz (to work out if it is relevant to you, say) before freely attempting it. However, if you freely attempt it, you must complete it to remove it from your account.

This endpoint allows previewing the rubric for non-teacher users for all freely-attemptable quizzes.