### PR TITLE
Add support for teacher notes on SeguePages and PageFragments

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacEventPage.java
@@ -87,6 +87,7 @@ public class IsaacEventPage extends SeguePage {
                           @JsonProperty("tags") Set<String> tags,
                           @JsonProperty("permissions") String permissions,
                           @JsonProperty("notes") String notes,
+                          @JsonProperty("teacherNotes") String teacherNotes,
                           @JsonProperty("date") Date date, @JsonProperty("end_date") Date end_date,
                           @JsonProperty("bookingDeadline") Date bookingDeadline,
                           @JsonProperty("prepWorkDeadline") Date prepWorkDeadline,
@@ -99,7 +100,8 @@ public class IsaacEventPage extends SeguePage {
                           @JsonProperty("groupReservationLimit") Integer groupReservationLimit,
                           @JsonProperty("allowGroupReservations") Boolean allowGroupReservations) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null,
-                null, relatedContent, published, deprecated, supersededBy, tags, permissions, notes, null);
+                null, relatedContent, published, deprecated, supersededBy, tags, permissions, notes,
+                teacherNotes, null);
 
         this.date = date;
         this.end_date = end_date;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPageFragment.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacPageFragment.java
@@ -24,6 +24,7 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 @JsonContentType("isaacPageFragment")
 public class IsaacPageFragment extends Content {
     private String summary;
+    private String teacherNotes;
 
     /**
      * Gets the summary.
@@ -42,5 +43,24 @@ public class IsaacPageFragment extends Content {
      */
     public final void setSummary(final String summary) {
         this.summary = summary;
+    }
+
+    /**
+     * Gets the teacherNotes.
+     *
+     * @return the teacherNotes
+     */
+    public String getTeacherNotes() {
+        return teacherNotes;
+    }
+
+    /**
+     * Sets the teacherNotes.
+     *
+     * @param teacherNotes
+     *            the teacherNotes to set
+     */
+    public void setTeacherNotes(final String teacherNotes) {
+        this.teacherNotes = teacherNotes;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
@@ -46,10 +46,12 @@ public class IsaacQuestionPage extends SeguePage {
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") boolean published,
             @JsonProperty("deprecated") Boolean deprecated, @JsonProperty("tags") Set<String> tags,
             @JsonProperty("permissions") String permissions, @JsonProperty("notes") String notes,
+            @JsonProperty("teacherNotes") String teacherNotes,
             @JsonProperty("level") Integer level, @JsonProperty("difficulty") Integer difficulty,
             @JsonProperty("passMark") Float passMark, @JsonProperty("supersededBy") String supersededBy) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, supersededBy, tags, permissions, notes, level);
+                attribution, relatedContent, published, deprecated, supersededBy, tags, permissions, notes,
+                teacherNotes, level);
 
         this.passMark = passMark;
         this.difficulty = difficulty;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuiz.java
@@ -56,12 +56,14 @@ public class IsaacQuiz extends SeguePage {
             @JsonProperty("tags") Set<String> tags,
             @JsonProperty("permissions") String permissions,
             @JsonProperty("notes") String notes,
+            @JsonProperty("teacherNotes") String teacherNotes,
             @JsonProperty("level") Integer level,
             @JsonProperty("hiddenFromRoles") List<String> hiddenFromRoles,
             @JsonProperty("rubric") Content rubric) {
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, deprecated, supersededBy, tags, permissions, notes, level);
+                relatedContent, published, deprecated, supersededBy, tags, permissions, notes,
+                teacherNotes, level);
 
         this.hiddenFromRoles = hiddenFromRoles;
         this.rubric = rubric;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
@@ -34,6 +34,7 @@ public class SeguePage extends Content {
     private String supersededBy;
     private String permissions;
     private String notes;
+    private String teacherNotes;
 
     @JsonCreator
     public SeguePage(@JsonProperty("id") String id,
@@ -45,7 +46,8 @@ public class SeguePage extends Content {
             @JsonProperty("relatedContent") List<String> relatedContent, @JsonProperty("published") Boolean published,
             @JsonProperty("deprecated") Boolean deprecated, @JsonProperty("supersededBy") String supersededBy,
             @JsonProperty("tags") Set<String> tags, @JsonProperty("permissions") String permissions,
-            @JsonProperty("notes") String notes, @JsonProperty("level") Integer level) {
+            @JsonProperty("notes") String notes, @JsonProperty("teacherNotes") String teacherNotes,
+            @JsonProperty("level") Integer level) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
                 attribution, relatedContent, published, tags, level);
@@ -54,6 +56,7 @@ public class SeguePage extends Content {
         this.supersededBy = supersededBy;
         this.permissions = permissions;
         this.notes = notes;
+        this.teacherNotes = teacherNotes;
 
     }
 
@@ -93,5 +96,13 @@ public class SeguePage extends Content {
 
     public void setSupersededBy(String supersededBy) {
         this.supersededBy = supersededBy;
+    }
+
+    public String getTeacherNotes() {
+        return teacherNotes;
+    }
+
+    public void setTeacherNotes(final String teacherNotes) {
+        this.teacherNotes = teacherNotes;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -110,6 +110,7 @@ public class IsaacEventPageDTO extends SeguePageDTO {
                              @JsonProperty("version") boolean published,
                              @JsonProperty("deprecated") Boolean deprecated,
                              @JsonProperty("supersededBy") String supersededBy,
+                             @JsonProperty("teacherNotes") String teacherNotes,
                              @JsonProperty("tags") Set<String> tags,
                              @JsonProperty("date") Date date,
                              @JsonProperty("end_date") Date end_date,
@@ -124,7 +125,7 @@ public class IsaacEventPageDTO extends SeguePageDTO {
                              @JsonProperty("groupReservationLimit") Integer groupReservationLimit,
                              @JsonProperty("allowGroupReservations") Boolean allowGroupReservations) {
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, null, null,
-                relatedContent, published, deprecated, supersededBy, tags, null);
+                relatedContent, published, deprecated, supersededBy, tags, teacherNotes, null);
 
         this.date = date;
         this.end_date = end_date;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPageFragmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacPageFragmentDTO.java
@@ -22,6 +22,7 @@ import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 @JsonContentType("isaacPageFragment")
 public class IsaacPageFragmentDTO extends ContentDTO {
     private String summary;
+    private String teacherNotes;
 
     @Override
     @JsonIgnore(false) // Override the parent class decorator!
@@ -46,5 +47,24 @@ public class IsaacPageFragmentDTO extends ContentDTO {
      */
     public final void setSummary(final String summary) {
         this.summary = summary;
+    }
+
+    /**
+     * Gets the teacherNotes.
+     *
+     * @return the teacherNotes
+     */
+    public String getTeacherNotes() {
+        return teacherNotes;
+    }
+
+    /**
+     * Sets the teacherNotes.
+     *
+     * @param teacherNotes
+     *            the teacherNotes to set
+     */
+    public void setTeacherNotes(final String teacherNotes) {
+        this.teacherNotes = teacherNotes;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuestionPageDTO.java
@@ -45,10 +45,11 @@ public class IsaacQuestionPageDTO extends SeguePageDTO {
             @JsonProperty("published") Boolean published, @JsonProperty("tags") Set<String> tags,
             @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("level") Integer level, @JsonProperty("difficulty") Integer difficulty,
-            @JsonProperty("passMark") Float passMark, @JsonProperty("supersededBy") String supersededBy) {
+            @JsonProperty("passMark") Float passMark, @JsonProperty("supersededBy") String supersededBy,
+            @JsonProperty("teacherNotes") String teacherNotes) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
-                attribution, relatedContent, published, deprecated, supersededBy, tags, level);
+                attribution, relatedContent, published, deprecated, supersededBy, tags, teacherNotes, level);
 
         this.passMark = passMark;
         this.difficulty = difficulty;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacQuizDTO.java
@@ -64,13 +64,15 @@ public class IsaacQuizDTO extends SeguePageDTO implements EmailService.HasTitleO
             @JsonProperty("deprecated") Boolean deprecated,
             @JsonProperty("supersededBy") String supersededBy,
             @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("teacherNotes") String teacherNotes,
             @JsonProperty("level") Integer level,
             @JsonProperty("hiddenFromRoles") List<String> hiddenFromRoles,
             @JsonProperty("defaultFeedbackMode") QuizFeedbackMode defaultFeedbackMode,
             @JsonProperty("rubric") ContentDTO rubric) {
         super(id, title, subtitle, type, author, encoding,
                 canonicalSourceFile, layout, children, value, attribution,
-                relatedContent, published, deprecated, supersededBy, tags, level);
+                relatedContent, published, deprecated, supersededBy, tags, teacherNotes,
+                level);
 
         this.hiddenFromRoles = hiddenFromRoles;
         this.defaultFeedbackMode = defaultFeedbackMode;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/SeguePageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/content/SeguePageDTO.java
@@ -30,6 +30,7 @@ public class SeguePageDTO extends ContentDTO {
     private String summary;
     private Boolean deprecated;
     private String supersededBy;
+    private String teacherNotes;
 
     @JsonCreator
     public SeguePageDTO(@JsonProperty("id") String id,
@@ -40,14 +41,15 @@ public class SeguePageDTO extends ContentDTO {
             @JsonProperty("value") String value, @JsonProperty("attribution") String attribution,
             @JsonProperty("relatedContent") List<ContentSummaryDTO> relatedContent,
             @JsonProperty("published") Boolean published, @JsonProperty("deprecated") Boolean deprecated,
-            @JsonProperty("supersededBy") String supersededBy,
-            @JsonProperty("tags") Set<String> tags, @JsonProperty("level") Integer level) {
+            @JsonProperty("supersededBy") String supersededBy, @JsonProperty("tags") Set<String> tags,
+            @JsonProperty("teacherNotes") String teacherNotes, @JsonProperty("level") Integer level) {
 
         super(id, title, subtitle, type, author, encoding, canonicalSourceFile, layout, children, value,
                 attribution, relatedContent, published, tags, level);
 
         this.deprecated = deprecated;
         this.supersededBy = supersededBy;
+        this.teacherNotes = teacherNotes;
 
     }
 
@@ -77,6 +79,14 @@ public class SeguePageDTO extends ContentDTO {
     @JsonIgnore(false) // Override the parent class decorator!
     public String getCanonicalSourceFile() {
         return this.canonicalSourceFile;
+    }
+
+    public String getTeacherNotes() {
+        return teacherNotes;
+    }
+
+    public void setTeacherNotes(final String teacherNotes) {
+        this.teacherNotes = teacherNotes;
     }
 
     public Boolean getDeprecated() {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -164,14 +164,14 @@ public class IsaacTest {
         quizSection2.setId("studentQuiz|section2");
         quizSection2.setChildren(ImmutableList.of(question2, question3));
 
-        studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, null, QuizFeedbackMode.OVERALL_MARK, null);
-        studentQuizPreQuizAnswerChange = new IsaacQuizDTO("studentQuizPreQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, null, QuizFeedbackMode.OVERALL_MARK, null);
-        studentQuizPostQuizAnswerChange = new IsaacQuizDTO("studentQuizPostQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, null, QuizFeedbackMode.OVERALL_MARK, null);
-        teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, ImmutableList.of("STUDENT"), null, null);
-        otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, null, null, null, null, null, QuizFeedbackMode.DETAILED_FEEDBACK, null);
+        studentQuiz = new IsaacQuizDTO("studentQuiz", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, null, null, QuizFeedbackMode.OVERALL_MARK, null);
+        studentQuizPreQuizAnswerChange = new IsaacQuizDTO("studentQuizPreQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, null, null, QuizFeedbackMode.OVERALL_MARK, null);
+        studentQuizPostQuizAnswerChange = new IsaacQuizDTO("studentQuizPostQuizAnswerChange", null, null, null, null, null, null, null, ImmutableList.of(quizSection1, quizSection2), null, null, null, false, null, null, null, null, null, null, QuizFeedbackMode.OVERALL_MARK, null);
+        teacherQuiz = new IsaacQuizDTO("teacherQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, null, ImmutableList.of("STUDENT"), null, null);
+        otherQuiz = new IsaacQuizDTO("otherQuiz", null, null, null, null, null, null, null, Collections.singletonList(quizSection1), null, null, null, false, null, null, null, null, null, null, QuizFeedbackMode.DETAILED_FEEDBACK, null);
 
         // A bit scrappy, but hopefully sufficient.
-        studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, null, null, null, null);
+        studentQuizDO = new IsaacQuiz("studentQuiz", null, null, null, null, null, null, null, null, null, null, null, false, null, null, null, null, null, null, null, null, null);
 
         student = new RegisteredUserDTO("Some", "Student", "test-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.MALE, somePastDate, "", null, false);
         student.setRole(Role.STUDENT);


### PR DESCRIPTION
Adds a `teacherNotes` field on `SeguePage` and its DTO, as well as all dependents. Does the same for `PageFragment`.