### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mvn dependency:go-offline
 COPY . /isaac-api
 RUN mvn package -Dmaven.test.skip=true -Dsegue.version=$BUILD_VERSION -P $BUILD_TARGET
 
-FROM jetty:11.0.24-jdk11-eclipse-temurin
+FROM jetty:11.0.25-jdk11-eclipse-temurin
 USER root
 COPY --from=builder /isaac-api/target/isaac-api.war /var/lib/jetty/webapps/isaac-api.war
 RUN chmod 755 /var/lib/jetty/webapps/*

--- a/pom.xml
+++ b/pom.xml
@@ -12,26 +12,26 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <segue.version>v3.18.6-SNAPSHOT</segue.version>
         <log4j.version>2.24.3</log4j.version>
-        <resteasy.version>6.2.11.Final</resteasy.version>
+        <resteasy.version>6.2.12.Final</resteasy.version>
         <guice.version>7.0.0</guice.version>
-        <oauth-client.version>1.38.0</oauth-client.version>
-        <jackson.version>2.18.2</jackson.version>
-        <jackson-databind.version>2.18.2</jackson-databind.version>
+        <oauth-client.version>1.39.0</oauth-client.version>
+        <jackson.version>2.18.3</jackson.version>
+        <jackson-databind.version>2.18.3</jackson-databind.version>
         <powermock.version>2.0.9</powermock.version>
         <junit-4.version>4.13.2</junit-4.version>
         <junit-5.version>5.11.4</junit-5.version>
         <swagger-ui-version>4.13.2</swagger-ui-version>
         <prometheus.version>0.16.0</prometheus.version>
-        <jetty-version>11.0.24</jetty-version>
+        <jetty-version>11.0.25</jetty-version>
         <jetty.port.api>8080</jetty.port.api>
         <jetty.port.etl>8090</jetty.port.etl>
-        <testcontainers.version>1.20.4</testcontainers.version>
+        <testcontainers.version>1.20.6</testcontainers.version>
         <web.xml>web-api-live.xml</web.xml>
         <web.xml.etl>web-etl.xml</web.xml.etl>
         <web.xml.local>web-api-local.xml</web.xml.local>
         <dependency-check.version>12.1.0</dependency-check.version>
         <ossindex.version>3.2.0</ossindex.version>
-        <swagger-core.version>2.2.28</swagger-core.version>
+        <swagger-core.version>2.2.29</swagger-core.version>
         <jgit.version>6.10.0.202406032230-r</jgit.version>
         <surefire.jacoco.args />
         <failsafe.jacoco.args />
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-ai-openai</artifactId>
-            <version>1.0.0-beta.13</version>
+            <version>1.0.0-beta.16</version>
         </dependency>
 
         <dependency>
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.0-jre</version>
+            <version>33.4.6-jre</version>
         </dependency>
 
         <dependency>
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
-            <version>1.46.1</version>
+            <version>1.46.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.apis</groupId>
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -376,13 +376,13 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.13.1</version>
+            <version>2.14.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.17.27</version>
+            <version>7.17.28</version>
         </dependency>
 
         <dependency>
@@ -399,12 +399,12 @@
         <dependency>
             <groupId>com.mailjet</groupId>
             <artifactId>mailjet-client</artifactId>
-            <version>5.2.5</version>
+            <version>5.2.6</version>
         </dependency>
         <dependency>
             <groupId>com.mailgun</groupId>
             <artifactId>mailgun-java</artifactId>
-            <version>1.1.4</version>
+            <version>1.1.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -533,7 +533,7 @@
                         See https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit.html#manually-specifying-a-provider -->
                         <groupId>org.apache.maven.surefire</groupId>
                         <artifactId>surefire-junit47</artifactId>
-                        <version>3.5.2</version>
+                        <version>3.5.3</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
@@ -230,7 +230,7 @@ public abstract class IsaacIntegrationTest {
     @BeforeAll
     public static void setUpClass() throws Exception {
         // Initialise Postgres - we will create a new, clean instance for each test class.
-        postgres = new PostgreSQLContainer<>("postgres:12")
+        postgres = new PostgreSQLContainer<>("postgres:16")
                 .withEnv("POSTGRES_HOST_AUTH_METHOD", "trust")
                 .withUsername("rutherford")
                 .withFileSystemBind(getClassLoaderResourcePath("db_scripts/postgres-rutherford-create-script.sql"), "/docker-entrypoint-initdb.d/00-isaac-create.sql")


### PR DESCRIPTION
In the integration tests, postgres:12 EOL-ed last year, so that also warranted an update.
