### PR TITLE
Add null checking to LLM Free Text Questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
@@ -68,6 +68,10 @@ public class IsaacLLMFreeTextValidator implements IValidator {
         Objects.requireNonNull(question);
         if (!(question instanceof IsaacLLMFreeTextQuestion)) {
             throw new IllegalArgumentException(question.getId() + " is not a LLM free-text question");
+        } else {
+            if (((IsaacLLMFreeTextQuestion) question).getMaxMarks() == null) {
+                ((IsaacLLMFreeTextQuestion) question).setMaxMarks(0);
+            }
         }
 
         // Validate answer


### PR DESCRIPTION
`IsaacLLMFreeTextQuestion`s have many unique fields not used in other questions that must each be set manually in the content editor. 

Most of these are fine to be null - several are explicitly optional (e.g. **markingFormula**, **additionalMarkingInstructions**) and so are already null-checked, others are lists (e.g. **markScheme**, **markedExamples**) so any nulls are safely converted to empty lists during processing - however **maxMarks** is a required field so was leading to a `NullPointerException` when missing. 

We can avoid this by simply setting a default value of 0 during question input validation.