### PR TITLE
LLM Error & Failure Reporting

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
@@ -71,7 +71,7 @@ public class IsaacLLMFreeTextValidator implements IValidator {
         }
         if (((IsaacLLMFreeTextQuestion) question).getMaxMarks() == null) {
             log.error("Question has missing maximum marks field: " + question.getId());
-            throw new IllegalArgumentException(question.getId() + " cannot be answered correctly");
+            throw new IllegalArgumentException("This question cannot be answered correctly");
         }
 
         // Validate answer

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.Optional;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
@@ -90,10 +91,7 @@ public class IsaacLLMFreeTextValidator implements IValidator {
     }
 
     private String generatePromptSystemMessage(final IsaacLLMFreeTextQuestion question) {
-        String llmMarkerSubject = configLoader.getProperty(LLM_MARKER_SUBJECT);
-        if (llmMarkerSubject == null) {
-            llmMarkerSubject = "";
-        }
+        String llmMarkerSubject = Optional.ofNullable(configLoader.getProperty(LLM_MARKER_SUBJECT)).orElse("");
 
         String contextAndInstructions = "You are a principal examiner marking A Level and GCSE "
             + String.format("%s questions.\n", llmMarkerSubject)

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
@@ -86,8 +86,13 @@ public class IsaacLLMFreeTextValidator implements IValidator {
     }
 
     private String generatePromptSystemMessage(final IsaacLLMFreeTextQuestion question) {
+        String llmMarkerSubject = configLoader.getProperty(LLM_MARKER_SUBJECT);
+        if (llmMarkerSubject == null) {
+            llmMarkerSubject = "";
+        }
+
         String contextAndInstructions = "You are a principal examiner marking A Level and GCSE "
-            + String.format("%s questions.\n", this.configLoader.getProperty(LLM_MARKER_SUBJECT))
+            + String.format("%s questions.\n", llmMarkerSubject)
             + "You do not like vagueness in student answers.\n"
             + "You follow a standard procedure when marking a question attempt and write your responses as JSON:\n"
             + "```\n"

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
@@ -69,6 +69,10 @@ public class IsaacLLMFreeTextValidator implements IValidator {
         if (!(question instanceof IsaacLLMFreeTextQuestion)) {
             throw new IllegalArgumentException(question.getId() + " is not a LLM free-text question");
         }
+        if (((IsaacLLMFreeTextQuestion) question).getMaxMarks() == null) {
+            log.error("Question has missing maximum marks field: " + question.getId());
+            throw new IllegalArgumentException(question.getId() + " cannot be answered correctly");
+        }
 
         // Validate answer
         Objects.requireNonNull(answer);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidator.java
@@ -28,7 +28,7 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.LLMMarkingVariable;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Question;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
-import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -80,7 +80,7 @@ public class IsaacLLMFreeTextValidator implements IValidator {
         try { maxAnswerLength = Integer.parseInt(configLoader.getProperty(LLM_MARKER_MAX_ANSWER_LENGTH)); }
         catch (NumberFormatException ignored) { /* Use default value */ }
         if (answer.getValue().length() > maxAnswerLength) {
-            log.error("Answer exceeds maximum length for LLM free-text question marking: " + answer.getValue().length());
+            log.error(String.format("Answer was %d characters long and exceeded maximum %d length for LLM free-text question marking.", answer.getValue().length(), maxAnswerLength));
             throw new IllegalArgumentException("Answer is too long for LLM free-text question marking");
         }
     }
@@ -171,14 +171,14 @@ public class IsaacLLMFreeTextValidator implements IValidator {
      * @param questionPrompt the prompt to send to the OpenAI API.
      * @return the completions from the OpenAI API or null if there was an error.
      */
-    private @Nullable ChatCompletions retrieveCompletionsFromOpenAI(final List<ChatRequestMessage> questionPrompt) {
+    private ChatCompletions retrieveCompletionsFromOpenAI(final List<ChatRequestMessage> questionPrompt) throws IOException {
         try {
             return openAIClient.getChatCompletions(
                     configLoader.getProperty(LLM_MARKER_DEFAULT_MODEL_NAME),
                     new ChatCompletionsOptions(questionPrompt).setTemperature(0.0));
         } catch (Exception e) {
             log.error("Failed to retrieve completions from OpenAI API", e);
-            return null;
+            throw new IOException(e.getMessage());
         }
     }
 
@@ -193,11 +193,7 @@ public class IsaacLLMFreeTextValidator implements IValidator {
      * @return a map of the marks awarded for each field in the mark scheme.
      */
     private Map<String, Integer> extractValidatedMarks(
-            final IsaacLLMFreeTextQuestion question, @Nullable final ChatCompletions chatCompletions) {
-        if (chatCompletions == null) {
-            // Error logged previously when we have more context.
-            return zeroMarkResult;
-        }
+            final IsaacLLMFreeTextQuestion question, final ChatCompletions chatCompletions) {
         if (chatCompletions.getChoices().size() != 1) {
             log.error("Expected exactly one choice from LLM completion provider, received: "
                     + chatCompletions.getChoices().stream().map(c -> c.getMessage().getContent())
@@ -310,15 +306,20 @@ public class IsaacLLMFreeTextValidator implements IValidator {
      * @return a response to the user's attempt at the question.
      */
     @Override
-    public final QuestionValidationResponse validateQuestionResponse(final Question question, final Choice answer) {
-        validateInputs(question, answer);
-
-        IsaacLLMFreeTextQuestion freeTextLLMQuestion = (IsaacLLMFreeTextQuestion) question;
-        List<ChatRequestMessage> questionPrompt = generateQuestionPrompt(freeTextLLMQuestion);
-        questionPrompt.add(extractUserAttemptAtQuestion(answer));
-        ChatCompletions chatCompletions = retrieveCompletionsFromOpenAI(questionPrompt);
-        Map<String, Integer> awardedMarks = extractValidatedMarks(freeTextLLMQuestion, chatCompletions);
-        int markTotal = evaluateMarkTotal(freeTextLLMQuestion, awardedMarks);
-        return generateQuestionValidationResponse(freeTextLLMQuestion, answer, awardedMarks, markTotal);
+    public final QuestionValidationResponse validateQuestionResponse(final Question question, final Choice answer) throws ValidatorUnavailableException {
+        try {
+            validateInputs(question, answer);
+            IsaacLLMFreeTextQuestion freeTextLLMQuestion = (IsaacLLMFreeTextQuestion) question;
+            List<ChatRequestMessage> questionPrompt = generateQuestionPrompt(freeTextLLMQuestion);
+            questionPrompt.add(extractUserAttemptAtQuestion(answer));
+            ChatCompletions chatCompletions = retrieveCompletionsFromOpenAI(questionPrompt);
+            Map<String, Integer> awardedMarks = extractValidatedMarks(freeTextLLMQuestion, chatCompletions);
+            int markTotal = evaluateMarkTotal(freeTextLLMQuestion, awardedMarks);
+            return generateQuestionValidationResponse(freeTextLLMQuestion, answer, awardedMarks, markTotal);
+        } catch (IOException e) {
+            log.error("Failed to check answer with OpenAI Client. Not trying again.");
+            throw new ValidatorUnavailableException("We are having problems marking LLM marked questions."
+                    + " Please try again later!");
+        }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
@@ -90,7 +90,7 @@ import static uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager.extractPageIdF
 public class QuestionFacade extends AbstractSegueFacade {
     private static final Logger log = LoggerFactory.getLogger(QuestionFacade.class);
 
-    private static final class NoUserConsentGrantedException extends Exception {
+    public static final class NoUserConsentGrantedException extends Exception {
         NoUserConsentGrantedException(final String message) {
             super(message);
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
@@ -117,7 +117,7 @@ public class QuestionFacade extends AbstractSegueFacade {
      * @throws SegueResourceMisuseException - if the user has exceeded the number of attempts they can make over a period of time.
      * @throws SegueDatabaseException - if there is an unexpected problem with the database.
      */
-    private RegisteredUserDTO assertUserCanAnswerLLMQuestions(final AbstractSegueUserDTO user) throws
+    public RegisteredUserDTO assertUserCanAnswerLLMQuestions(final AbstractSegueUserDTO user) throws
             SegueDatabaseException, NoUserLoggedInException, NoUserConsentGrantedException,
             ValidatorUnavailableException, SegueResourceMisuseException
     {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidatorTest.java
@@ -51,8 +51,10 @@ import java.util.Objects;
 
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.powermock.api.easymock.PowerMock.createMock;
 import static org.powermock.api.easymock.PowerMock.replayAll;
@@ -101,7 +103,7 @@ public class IsaacLLMFreeTextValidatorTest {
 
         validator = new IsaacLLMFreeTextValidator(propertiesForTest, client);
 
-        // Set up generic mark scheme with three available marks
+        // Set up generic mark scheme with three available marks:
         JSONArray jsonMarkScheme = new JSONArray()
             .put(new JSONObject().put("jsonField", "reasonFoo").put("shortDescription", "Foo reason").put("marks", 1))
             .put(new JSONObject().put("jsonField", "reasonBar").put("shortDescription", "Bar reason").put("marks", 1))
@@ -168,15 +170,15 @@ public class IsaacLLMFreeTextValidatorTest {
      */
     @SuppressWarnings("checkstyle:MethodName")
     @Test
-    public final void isaacLLMFreeTextValidator_OneMarkQuestionOneMarkAnswer_MarkSchemeShouldIncludeMark() {
+    public final void isaacLLMFreeTextValidator_OneMarkQuestionOneMarkAnswer_MarkSchemeShouldIncludeMark() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Foo");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"reasonFoo\": 1, \"reasonBar\": 0, \"reasonFizz\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionOneMark, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -196,15 +198,15 @@ public class IsaacLLMFreeTextValidatorTest {
         Test that a three-mark answer for a default marking formula one-mark question gets recognised as correct
      */
     @Test
-    public final void isaacLLMFreeTextValidator_OneMarkQuestionThreeMarkAnswer_MarkSchemeShouldIncludeMarks() {
+    public final void isaacLLMFreeTextValidator_OneMarkQuestionThreeMarkAnswer_MarkSchemeShouldIncludeMarks() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Foo");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"reasonFoo\": 1, \"reasonBar\": 1, \"reasonFizz\": 1}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionOneMark, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -224,15 +226,15 @@ public class IsaacLLMFreeTextValidatorTest {
         Test that a zero-mark answer for a one-mark question gets recognised as incorrect
     */
     @Test
-    public final void isaacLLMFreeTextValidator_OneMarkQuestionZeroMarkAnswer_MarkSchemeShouldIncludeNoMarks() {
+    public final void isaacLLMFreeTextValidator_OneMarkQuestionZeroMarkAnswer_MarkSchemeShouldIncludeNoMarks() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Buzz");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"reasonFoo\": 0, \"reasonBar\": 0, \"reasonFizz\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionOneMark, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -252,15 +254,15 @@ public class IsaacLLMFreeTextValidatorTest {
         Test that a two-mark answer for a default marking formula two-mark question gets recognised as correct
     */
     @Test
-    public final void isaacLLMFreeTextValidator_TwoMarkQuestionTwoMarkAnswer_MarkSchemeShouldIncludeMarks() {
+    public final void isaacLLMFreeTextValidator_TwoMarkQuestionTwoMarkAnswer_MarkSchemeShouldIncludeMarks() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Foo Bar");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"reasonFoo\": 1, \"reasonBar\": 1, \"reasonFizz\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionTwoMarks, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -280,15 +282,15 @@ public class IsaacLLMFreeTextValidatorTest {
         Test that a one-mark answer for a default marking formula two-mark question receives exactly one mark
     */
     @Test
-    public final void isaacLLMFreeTextValidator_TwoMarkQuestionOneMarkAnswer_MarkSchemeShouldIncludeMarks() {
+    public final void isaacLLMFreeTextValidator_TwoMarkQuestionOneMarkAnswer_MarkSchemeShouldIncludeMarks() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Foo");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"reasonFoo\": 1, \"reasonBar\": 0, \"reasonFizz\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionTwoMarks, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -308,15 +310,15 @@ public class IsaacLLMFreeTextValidatorTest {
         Tests that an answer containing an advantage and a disadvantage mark for a two-mark advantage/disadvantage question receives two marks
     */
     @Test
-    public final void isaacLLMFreeTextValidator_AdvantageDisadvantageQuestionADMarks_MarkTotalShouldBeTwo() {
+    public final void isaacLLMFreeTextValidator_AdvantageDisadvantageQuestionADMarks_MarkTotalShouldBeTwo() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Advantage Disadvantage");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"advantageOne\": 1, \"advantageTwo\": 0, \"disadvantageOne\": 1, \"disadvantageTwo\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionAdvantageDisadvantage, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -337,15 +339,15 @@ public class IsaacLLMFreeTextValidatorTest {
         Tests that an answer containing only a disadvantage mark for a two-mark advantage/disadvantage question receives one mark
     */
     @Test
-    public final void isaacLLMFreeTextValidator_AdvantageDisadvantageQuestionDMarks_MarkTotalShouldBeOne() {
+    public final void isaacLLMFreeTextValidator_AdvantageDisadvantageQuestionDMarks_MarkTotalShouldBeOne() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Disadvantage");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"advantageOne\": 0, \"advantageTwo\": 0, \"disadvantageOne\": 1, \"disadvantageTwo\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionAdvantageDisadvantage, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -366,15 +368,15 @@ public class IsaacLLMFreeTextValidatorTest {
        Tests that an answer containing two advantage marks for a two-mark advantage/disadvantage question receives one mark
     */
     @Test
-    public final void isaacLLMFreeTextValidator_AdvantageDisadvantageQuestionAAMarks_MarkTotalShouldBeOne() {
+    public final void isaacLLMFreeTextValidator_AdvantageDisadvantageQuestionAAMarks_MarkTotalShouldBeOne() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Advantage Advantage");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"advantageOne\": 1, \"advantageTwo\": 1, \"disadvantageOne\": 0, \"disadvantageTwo\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionAdvantageDisadvantage, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -395,15 +397,15 @@ public class IsaacLLMFreeTextValidatorTest {
        Tests that an answer containing a point and matching explanation for a two-mark point/explanation question receives two marks
     */
     @Test
-    public final void isaacLLMFreeTextValidator_PointExplanationQuestionPEMarks_MarkTotalShouldBeTwo() {
+    public final void isaacLLMFreeTextValidator_PointExplanationQuestionPEMarks_MarkTotalShouldBeTwo() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Point1 Explanation1");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"pointOne\": 1, \"pointTwo\": 0, \"explanationOne\": 1, \"explanationTwo\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionPointExplanation, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -424,15 +426,15 @@ public class IsaacLLMFreeTextValidatorTest {
         Tests that an answer containing an explanation without a matching point for a two-mark point/explanation question receives zero marks
     */
     @Test
-    public final void isaacLLMFreeTextValidator_PointExplanationQuestionEMark_MarkTotalShouldBeZero() {
+    public final void isaacLLMFreeTextValidator_PointExplanationQuestionEMark_MarkTotalShouldBeZero() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Explanation1");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"pointOne\": 0, \"pointTwo\": 0, \"explanationOne\": 1, \"explanationTwo\": 0}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionPointExplanation, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -454,15 +456,15 @@ public class IsaacLLMFreeTextValidatorTest {
         two-mark point/explanation question receives one mark
     */
     @Test
-    public final void isaacLLMFreeTextValidator_PointExplanationQuestionPEMismatchMarks_MarkTotalShouldBeOne() {
+    public final void isaacLLMFreeTextValidator_PointExplanationQuestionPEMismatchMarks_MarkTotalShouldBeOne() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Point1 Explanation2");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("{\"pointOne\": 1, \"pointTwo\": 0, \"explanationOne\": 0, \"explanationTwo\": 1}");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionPointExplanation, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -480,38 +482,18 @@ public class IsaacLLMFreeTextValidatorTest {
     }
 
     /*
-        Test that an answer exceeding the maximum answer length is rejected
-    */
-    @Test
-    public final void isaacLLMFreeTextValidator_AnswerOverLengthLimit_ExceptionShouldBeThrown() {
-        // Set up user answer:
-        LLMFreeTextChoice c = new LLMFreeTextChoice();
-        int maxAnswerLength = 4096;
-        try {
-            maxAnswerLength = Integer.parseInt(propertiesForTest.getProperty(LLM_MARKER_MAX_ANSWER_LENGTH));
-        } catch (final NumberFormatException ignored) { /* Use default value */ }
-        c.setValue(String.join("", Collections.nCopies((maxAnswerLength / 10 + 1), "Repeat Me ")));
-
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Answer is too long for LLM free-text question marking");
-
-        // This should throw an exception:
-        validator.validateQuestionResponse(llmFreeTextQuestionOneMark, c);
-    }
-
-    /*
         Test that a response from the client not in the expected json format returns zero marks
     */
     @Test
-    public final void isaacLLMFreeTextValidator_ResponseInvalidFormat_MarkSchemeShouldIncludeNoMarks() {
+    public final void isaacLLMFreeTextValidator_ResponseInvalidFormat_MarkSchemeShouldIncludeNoMarks() throws Exception {
         // Set up user answer:
         LLMFreeTextChoice c = new LLMFreeTextChoice();
         c.setValue("Foo Bar Fizz");
 
-        // Set up mocked OpenAI response to the user answer
+        // Set up mocked OpenAI response to the user answer:
         setUpMockResponse("Not a valid JSON response");
 
-        // Test response
+        // Test response:
         LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionOneMark, c);
 
         List<LLMFreeTextMarkSchemeEntry> expectedMarks = generateMarkScheme(new JSONArray()
@@ -527,7 +509,47 @@ public class IsaacLLMFreeTextValidatorTest {
         assertEquals(0, (long) response.getMarksAwarded());
     }
 
-    // TODO Add tests for OpenAI failure reporting (e.g. timeout, feature flag off, etc.) once they are fully implemented
+    /*
+        Test that an answer exceeding the maximum answer length is handled with an exception and no other response is output
+    */
+    @Test
+    public final void isaacLLMFreeTextValidator_AnswerOverLengthLimit_ExceptionShouldBeThrown() throws Exception {
+        // Set up user answer:
+        LLMFreeTextChoice c = new LLMFreeTextChoice();
+        int maxAnswerLength = 4096;
+        try {
+            maxAnswerLength = Integer.parseInt(propertiesForTest.getProperty(LLM_MARKER_MAX_ANSWER_LENGTH));
+        } catch (final NumberFormatException ignored) { /* Use default value */ }
+        c.setValue(String.join("", Collections.nCopies((maxAnswerLength / 10 + 1), "Repeat Me ")));
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Answer is too long for LLM free-text question marking");
+
+        // Test response
+        LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionOneMark, c);
+        assertNull(response);
+    }
+
+    /*
+        Test that an error from the client (e.g. timeout, rate limit, out of credits) is handled with an exception
+        and no other response is output
+    */
+    @Test
+    public final void isaacLLMFreeTextValidator_ResponseError_ExceptionShouldBeThrown() throws Exception {
+        // Set up user answer:
+        LLMFreeTextChoice c = new LLMFreeTextChoice();
+        c.setValue("Foo Bar Fizz");
+
+        // Set up mocked OpenAI exception response to the user answer
+        EasyMock.expect(client.getChatCompletions(anyString(), isA(ChatCompletionsOptions.class))).andThrow(new RuntimeException("Test Exception"));
+        replay(client);
+
+        expectedException.expect(ValidatorUnavailableException.class);
+
+        // Test response
+        LLMFreeTextQuestionValidationResponse response = (LLMFreeTextQuestionValidationResponse) validator.validateQuestionResponse(llmFreeTextQuestionOneMark, c);
+        assertNull(response);
+    }
 
     // --- Helper Functions ---
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacLLMFreeTextValidatorTest.java
@@ -541,7 +541,7 @@ public class IsaacLLMFreeTextValidatorTest {
         c.setValue("Foo Bar Fizz");
 
         // Set up mocked OpenAI exception response to the user answer
-        EasyMock.expect(client.getChatCompletions(anyString(), isA(ChatCompletionsOptions.class))).andThrow(new RuntimeException("Test Exception"));
+        EasyMock.expect(client.getChatCompletions(anyString(), isA(ChatCompletionsOptions.class))).andThrow(new RuntimeException("Test OpenAI Exception"));
         replay(client);
 
         expectedException.expect(ValidatorUnavailableException.class);


### PR DESCRIPTION
This PR covers a few different related changes:

- If there has been an error within the OpenAI client (e.g. out-of-date key, timeout, running out of credits), currently we are returning a zero mark answer to the user and not displaying that there has been an error. This is potentially very confusing, as the error is (almost certainly) nothing to do with the user's answer itself, but they are lead to believe it has specifically been marked wrong. To be consistent with the symbolic validator when such an error occurs, we now throw a `ValidatorUnavailableException` and consequently show a _"Your answer could not be checked. Please try again."_ popup in the frontend.
- Null checking for `maxMarks`, with appropriate feedback (adapted from https://github.com/isaacphysics/isaac-api/pull/691)
- Some wording changes for comments and error clarity, such as stating the current maximum answer length when exceeded
- More tests for various erroneous behaviours

To note - I have left default zero mark results in for cases where the OpenAI client *has* successfully responded but not in a format we're expecting (either not json, or using more than one message). These cases are not independent from the user's answer since they may have been caused by prompt injection or other unusual input, and we want these types of answers to still receive no marks. In this case I believe it is more helpful than an error, although I'm open to suggestions.