### PR TITLE
Let anonymous users list student-visible quizzes

### DIFF
--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/IsaacTest.java
@@ -38,6 +38,7 @@ import uk.ac.cam.cl.dtg.isaac.dto.QuizAttemptDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.UserGroupDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.content.QuizSummaryDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryWithEmailAddressDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.GroupManager;
@@ -86,6 +87,7 @@ public class IsaacTest {
     protected RegisteredUserDTO secondTeacher;
     protected RegisteredUserDTO otherTeacher;
     protected RegisteredUserDTO noone;
+    protected AnonymousUserDTO anonUser;
     protected RegisteredUserDTO secondStudent;
     protected RegisteredUserDTO otherStudent;
     protected RegisteredUserDTO adminUser;
@@ -190,6 +192,7 @@ public class IsaacTest {
         otherTeacher.setId(++id);
 
         noone = null;
+        anonUser = new AnonymousUserDTO("fake-session-id");
 
         secondStudent = new RegisteredUserDTO("Second", "Student", "second-student@test.com", EmailVerificationStatus.VERIFIED, somePastDate, Gender.FEMALE, somePastDate, "", null, false);
         secondStudent.setRole(Role.STUDENT);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AbstractFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AbstractFacadeTest.java
@@ -17,21 +17,22 @@ package uk.ac.cam.cl.dtg.isaac.api;
 
 import com.google.api.client.util.Maps;
 import com.google.common.base.Joiner;
-import jakarta.ws.rs.core.Request;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import uk.ac.cam.cl.dtg.isaac.IsaacTest;
-import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.getCurrentArguments;
@@ -100,7 +102,12 @@ abstract public class AbstractFacadeTest extends IsaacTest {
 
     @Before
     public void abstractFacadeTestSetup() {
+        HttpSession session = createMock(HttpSession.class);
+        expect(session.getAttribute(anyString())).andReturn(null).anyTimes();
+        expect(session.getId()).andReturn("fake-session-id").anyTimes();
+        replay(session);
         httpServletRequest = createMock(HttpServletRequest.class);
+        expect(httpServletRequest.getSession()).andReturn(session).anyTimes();
         replay(httpServletRequest);
         request = createNiceMock(Request.class);  // We don't particularly care about what gets called on this.
         replay(request);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeTest.java
@@ -183,8 +183,7 @@ public class QuizFacadeTest extends AbstractFacadeTest {
     @Test
     public void availableQuizzes() {
         forEndpoint(() -> quizFacade.getAvailableQuizzes(request, httpServletRequest),
-            requiresLogin(),
-            as(anyOf(student, secondStudent),
+            as(anyOf(noone, student, secondStudent),
                 check((response) ->
                     assertEquals(Collections.singletonList(studentQuizSummary), extractResults(response)))
             ),


### PR DESCRIPTION
This does not affect viewing the quiz itself, so it just pushes the problem along a step. We may want to allow the "/view" endpoint to have similar behaviour too, for consistency, but I think that's a separate discussion.