### PR TITLE
Make wildcards optional and not used by default

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -366,7 +366,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "You must provide a gameboard object").toResponse();
             }
 
-            if ((newGameboardObject.getId() != null || newGameboardObject.getTags().size() > 0
+            if ((newGameboardObject.getId() != null || !newGameboardObject.getTags().isEmpty()
                     || newGameboardObject.getWildCard() != null) && !isUserStaff(userManager, user)) {
                 return new SegueErrorResponse(Status.FORBIDDEN, "You cannot provide a gameboard wildcard, ID or tags.").toResponse();
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -196,8 +196,6 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             return Response.ok(gameboard).cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (IllegalArgumentException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST, "Your gameboard filter request is invalid.").toResponse();
-        } catch (NoWildcardException e) {
-            return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Unable to load the wildcard.").toResponse();
         } catch (SegueDatabaseException e) {
             String message = "SegueDatabaseException whilst generating a gameboard";
             log.error(message, e);
@@ -383,9 +381,6 @@ public class GameboardsFacade extends AbstractIsaacFacade {
         try {
             persistedGameboard = gameManager.saveNewGameboard(newGameboardObject, user);
 
-        } catch (NoWildcardException e) {
-            return new SegueErrorResponse(Status.BAD_REQUEST, "No wildcard available. Unable to construct gameboard.")
-                    .toResponse();
         } catch (InvalidGameboardException e) {
             return new SegueErrorResponse(Status.BAD_REQUEST, String.format("The gameboard you provided is invalid"), e)
                     .toResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -141,8 +141,6 @@ public class GameManager {
      *            The user that should be marked as the creator of the gameBoard.
      * @return a gameboard if possible that satisifies the conditions provided by the parameters. Will return null if no
      *         questions can be provided.
-     * @throws NoWildcardException
-     *             - when we are unable to provide you with a wildcard object.
      * @throws SegueDatabaseException
      *             - if there is an error contacting the database.
      * @throws ContentManagerException
@@ -154,7 +152,7 @@ public class GameManager {
             final List<Integer> levels, final List<String> concepts, final List<String> questionCategories,
             final List<String> stages, final List<String> difficulties, final List<String> examBoards,
             final AbstractSegueUserDTO boardOwner)
-    throws NoWildcardException, SegueDatabaseException, ContentManagerException {
+    throws SegueDatabaseException, ContentManagerException {
 
         Long boardOwnerId;
         if (boardOwner instanceof RegisteredUserDTO) {
@@ -565,8 +563,6 @@ public class GameManager {
      * @param owner
      *            - user to make owner of gameboard.
      * @return gameboardDTO as persisted
-     * @throws NoWildcardException
-     *             - if we cannot add a wildcard.
      * @throws InvalidGameboardException
      *             - if the gameboard already exists with the given id.
      * @throws SegueDatabaseException
@@ -577,7 +573,7 @@ public class GameManager {
      *             - if we are unable to lookup the required content.
      */
     public GameboardDTO saveNewGameboard(final GameboardDTO gameboardDTO, final RegisteredUserDTO owner)
-            throws NoWildcardException, InvalidGameboardException, SegueDatabaseException, DuplicateGameboardException,
+            throws InvalidGameboardException, SegueDatabaseException, DuplicateGameboardException,
             ContentManagerException {
         Objects.requireNonNull(gameboardDTO);
         Objects.requireNonNull(owner);
@@ -1411,18 +1407,6 @@ public class GameManager {
                 || gameboardDTO.getTitle().length() > GAMEBOARD_MAX_TITLE_LENGTH) {
             throw new InvalidGameboardException(String.format(
                     "The gameboard title provided is invalid; the maximum length is %s", GAMEBOARD_MAX_TITLE_LENGTH));
-        }
-
-        if (gameboardDTO.getWildCard() != null) {
-            // This will throw a NoWildCardException if we cannot locate a valid
-            // wildcard for this gameboard.
-            try {
-                this.getWildCardById(gameboardDTO.getWildCard().getId());
-            } catch (ContentManagerException e) {
-                log.error("Error validating gameboard.", e);
-                throw new InvalidGameboardException(
-                        "There was a problem validating the gameboard due to ContentManagerException another exception.");
-            }
         }
 
     }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/app/GameboardsFacadeTest.java
@@ -23,12 +23,10 @@ import uk.ac.cam.cl.dtg.isaac.api.Constants;
 import uk.ac.cam.cl.dtg.isaac.api.GameboardsFacade;
 import uk.ac.cam.cl.dtg.isaac.api.managers.FastTrackManger;
 import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
-import uk.ac.cam.cl.dtg.isaac.api.managers.NoWildcardException;
 import uk.ac.cam.cl.dtg.isaac.dto.users.AbstractSegueUserDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.QuestionManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
@@ -80,14 +78,12 @@ public class GameboardsFacadeTest {
 	/**
 	 * Verify that when an empty gameboard is noticed a 204 is returned.
 	 * 
-	 * @throws NoUserLoggedInException
 	 * @throws ContentManagerException
 	 */
 	@Test
 	@PowerMockIgnore({ "jakarta.ws.*" })
 	public final void isaacEndPoint_checkEmptyGameboardCausesErrorNoUser_SegueErrorResponseShouldBeReturned()
-			throws NoWildcardException, SegueDatabaseException, NoUserLoggedInException,
-			ContentManagerException {
+			throws SegueDatabaseException, ContentManagerException {
 		GameboardsFacade gameboardFacade = new GameboardsFacade(
 				dummyPropertiesLoader, dummyLogManager, dummyGameManager, questionManager,
 				userManager, fastTrackManager);


### PR DESCRIPTION
We have not shown wildcards on ordinary boards in a long time, so this moves to not _adding_ them to ordinary boards either. No more random selection of a wildcard; the wildcard is just left empty if it is not explicitly provided by a staff user. All other users get no wildcard when they make a board now.