### PR TITLE
Cache content not found

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/GlossaryFacade.java
@@ -28,13 +28,11 @@ import uk.ac.cam.cl.dtg.isaac.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.isaac.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
@@ -150,40 +148,5 @@ public class GlossaryFacade extends AbstractSegueFacade {
             log.warn("Error loading glossary terms!", e);  // Sadly need full stack trace here, since errors are nested!
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error loading glossary terms!").toResponse();
         }
-    }
-
-    /**
-     * Gets the current version of the segue application.
-     *
-     * @param term_id - The ID of the term to retrieve.
-     *
-     * @return segue version as a string wrapped in a response.
-     */
-    @GET
-    @Path("terms/{term_id}")
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Get the term with the given id.")
-    public final Response getTermById(@PathParam("term_id") final String term_id) {
-
-        if (null == term_id) {
-            return new SegueErrorResponse(Status.BAD_REQUEST, "Please specify a term_id.").toResponse();
-        }
-
-        ResultsWrapper<ContentDTO> c;
-        try {
-            c = this.contentManager.getUnsafeCachedDTOsByIdPrefix(term_id, 0, 10000);
-            if (null == c) {
-                SegueErrorResponse error = new SegueErrorResponse(Status.NOT_FOUND, "No glossary term found with id: " + term_id);
-                log.debug(error.getErrorMessage());
-                return error.toResponse();
-            }
-        } catch (ContentManagerException e) {
-            return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
-                    "Content acquisition error.", e).toResponse();
-        }
-        // Calculate the ETag on last modified date of tags list
-        // NOTE: Assumes that the latest version of the content is being used.
-        EntityTag etag = new EntityTag(this.contentManager.getCurrentContentSHA().hashCode() + "");
-        return Response.ok(c).tag(etag).build();
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -268,37 +268,6 @@ public class GitContentManager {
     }
 
     /**
-     *  Retrieve all DTO content matching an ID prefix.
-     *
-     *  This may return cached objects, and will temporarily cache the objects
-     *  to avoid re-querying the data store and the deserialization costs.
-     *  Do not modify the returned DTO objects.
-     *
-     * @param idPrefix the content object ID prefix.
-     * @param startIndex the integer start index for pagination.
-     * @param limit the limit for pagination.
-     * @return a ResultsWrapper of the matching content.
-     * @throws ContentManagerException on failure to return the objects.
-     */
-    public ResultsWrapper<ContentDTO> getUnsafeCachedDTOsByIdPrefix(final String idPrefix, final int startIndex,
-                                                                    final int limit) throws ContentManagerException {
-
-        String k = "getByIdPrefix~" + getCurrentContentSHA() + "~" + idPrefix + "~" + startIndex + "~" + limit;
-        if (!cache.asMap().containsKey(k)) {
-
-            ResultsWrapper<String> searchHits = this.searchProvider.findByPrefix(contentIndex, CONTENT_TYPE,
-                    Constants.ID_FIELDNAME + "." + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX,
-                    idPrefix, startIndex, limit, this.getBaseFilters());
-
-            List<Content> searchResults = mapper.mapFromStringListToContentList(searchHits.getResults());
-
-            cache.put(k, new ResultsWrapper<>(mapper.getDTOByDOList(searchResults), searchHits.getTotalResults()));
-        }
-
-        return (ResultsWrapper<ContentDTO>) cache.getIfPresent(k);
-    }
-
-    /**
      *  Get a list of DTO objects by their IDs.
      *
      *  This may return cached objects, and will temporarily cache the objects


### PR DESCRIPTION
Currently we have a problem with optional page fragments, such as the seasonal warning message on the contact us form, or the help fragments which don't have to exist.

In the old world, for one that does not exist: when it is queried for by a user, we go to ElasticSearch and discover is doesn't exist, but the cache contains only valid content and so we cannot add anything to the cache. When the next user loads the page, we ought already to know that this will fail, but since we couldn't cache it, we make the same unnecessary query to ES.

This PR moves the `GitContentManager` caches to always cache `ResultsWrappers`; these can always exist even when there are no results, and thus a failed lookup result can be cached. (I did initially experiment with using Optionals back in 2023 - rebasing the commit to more recently - but I decided that `ResultsWrappers` were cleaner). For the sake of avoiding unsafe casts, move to using two caches separated by type; I don't _think_ this will increase the memory usage since it is the same stuff being cached but I suppose cleanup may be triggered differently due to different access patterns for the two caches.

This also moves to using an atomic `get()` call; this means that the stats recorded for Prometheus will actually be useful, since now there can actually be cache misses (previously we carefully checked whether a value was present first, non-atomically).

There were three GCM methods to refactor, but one of them was only used by an unnecessary and unused glossary terms endpoint; so to avoid refactoring it I just deleted the endpoint and then the method.