### PR TITLE
Fix inefficient group quiz CSV request

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacade.java
@@ -1407,7 +1407,6 @@ public class QuizFacade extends AbstractIsaacFacade {
             }
 
             for (RegisteredUserDTO groupMember : groupMembers) {
-                UserSummaryDTO groupMemberSummary = this.userManager.convertToUserSummaryObject(groupMember);
                 List<String> row = new ArrayList<>(Arrays.asList(groupMember.getGivenName(), groupMember.getFamilyName()));
                 List<String> quizTotals = new ArrayList<>();
                 List<String> questionResults = new ArrayList<>();


### PR DESCRIPTION
This does not need to be recomputed once per student in the group, because if it is we end up with `n*n*m` database queries for n students and m quiz assignments. This way ends up doing `2*n*m` queries, which whilst terrible is still a vast improvement for large groups.

There are some minor code clarity fixes too, though I think this still needs further work.