### PR TITLE
Add Accessibility user preferences

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/Constants.java
@@ -230,7 +230,7 @@ public final class Constants {
      * User preference categories
      */
     public enum IsaacUserPreferences {
-        BETA_FEATURE, EXAM_BOARD, PROGRAMMING_LANGUAGE, BOOLEAN_NOTATION, DISPLAY_SETTING, CONSENT
+        BETA_FEATURE, EXAM_BOARD, PROGRAMMING_LANGUAGE, BOOLEAN_NOTATION, DISPLAY_SETTING, ACCESSIBILITY, CONSENT
     }
 
     /**

--- a/src/main/resources/db_scripts/migrations/2025-08-accessibility-user-preferences.sql
+++ b/src/main/resources/db_scripts/migrations/2025-08-accessibility-user-preferences.sql
@@ -1,0 +1,1 @@
+UPDATE user_preferences SET preference_type = 'ACCESSIBILITY' WHERE preference_name = 'REDUCED_MOTION' OR preference_name = 'PREFER_MATHML';


### PR DESCRIPTION
Adds a new preference field, `ACCESSIBILITY`, to better separate accessibility features from display features.

Also adds a migration to convert `REDUCED_MOTION` and `PREFER_MATHML` from `DISPLAY_SETTINGS` to `ACCESSIBILITY`.