### PR TITLE
Correct email validation message

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -425,9 +425,8 @@ public class UserAccountManager implements IUserAccountManager {
             return new SegueErrorResponse(Response.Status.INTERNAL_SERVER_ERROR,
                     "Unable to set a password.").toResponse();
         } catch (MissingRequiredFieldException e) {
-            log.warn(String.format("Missing field during update operation: %s ", e.getMessage()));
-            return new SegueErrorResponse(Response.Status.BAD_REQUEST, "You are missing a required field. "
-                    + "Please make sure you have specified all mandatory fields in your response.").toResponse();
+            log.warn(String.format("Missing or invalid field during update operation: %s ", e.getMessage()));
+            return new SegueErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()).toResponse();
         } catch (DuplicateAccountException e) {
             log.warn(String.format("Duplicate account registration attempt for (%s)", userObjectFromClient.getEmail()));
             return new SegueErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()).toResponse();


### PR DESCRIPTION
Uses the exception message when the user-provided email address fails validation, instead of the misleading generic message.