### PR TITLE
Add maxMarks to LLMFreeTextQuestionDTO

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacLLMFreeTextQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacLLMFreeTextQuestionDTO.java
@@ -10,6 +10,15 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.LLM_FREE_TEXT_QUESTION_TYPE;
 @JsonContentType(LLM_FREE_TEXT_QUESTION_TYPE)
 @ValidatesWith(IsaacLLMFreeTextValidator.class)
 public class IsaacLLMFreeTextQuestionDTO extends QuestionDTO {
+    private Integer maxMarks;
+
     public IsaacLLMFreeTextQuestionDTO() {
+    }
+
+    public Integer getMaxMarks() {
+        return maxMarks;
+    }
+    public void setMaxMarks(Integer maxMarks) {
+        this.maxMarks = maxMarks;
     }
 }


### PR DESCRIPTION
The change is very straightforward, but the timing slightly less. This will need to merge first, then a week later the react-app, and the content only once the second release has happened.

The only side effect from this is that people using the old version of the app after the second release will see no maximum marks displayed until they've answered the question, but this isn't a major issue and will be resolved by a refresh so 🤷‍♀️ I think it's fine. 