### PR TITLE
Allow permissions & notes on fasttrack question pages

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/content/SeguePage.java
@@ -99,6 +99,22 @@ public class SeguePage extends Content {
         this.supersededBy = supersededBy;
     }
 
+    public String getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(final String permissions) {
+        this.permissions = permissions;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(final String notes) {
+        this.notes = notes;
+    }
+
     public String getTeacherNotes() {
         return teacherNotes;
     }


### PR DESCRIPTION
`IsaacFastTrackQuestionPage` extends `IsaacQuestionPage` without defining a new constructor, so Jackson uses the default constructor which takes no arguments and doesn't know about `permissions` or `notes`.  Therefore these fields need getters/setters in `SeguePage`.