### PR TITLE
Bring coord sig fig feedback in line with numeric questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -203,18 +203,19 @@ public class IsaacCoordinateValidator implements IValidator {
                             if (allSubmittedItemsInChoiceItems) {
                                 feedback = new Content((submittedItems.size() == 1 ? "This is" : "These are")
                                         + " correct, but can you find more?");
+                                feedback.setTags(new HashSet<>()); // Clear tags in case we previously set sig figs tags
                                 break;
                             } else if (allItemsInChoiceWithoutSigFigs) {
                                 feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
                                 feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_many")));
-                                break;
+                                // Don't break; we could find a better match
                             }
                         }
 
                         // If subset matching is allowed for this choice, check if the choice is a proper subset of the
                         // submitted items
                         boolean allowSubsetMatch = (null != coordinateChoice.isAllowSubsetMatch() && coordinateChoice.isAllowSubsetMatch());
-                        if (allowSubsetMatch && (submittedItems.size() > choiceItems.size())) {
+                        if (null == feedback && allowSubsetMatch && (submittedItems.size() > choiceItems.size())) {
                             boolean allChoiceItemsInSubmittedItems = true;
                             for (CoordinateItem choiceItem : choiceItems) {
                                 boolean choiceItemInSubmittedItems = false;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -258,18 +258,15 @@ public class IsaacCoordinateValidator implements IValidator {
             }
         }
 
-        // STEP 3: If incorrect and we still have no feedback to give, use the question's default feedback if any to use:
-        if (!responseCorrect && feedbackIsNullOrEmpty(feedback)) {
-            if (null != coordinateQuestion.getDefaultFeedback()) {
-                feedback = coordinateQuestion.getDefaultFeedback();
-            } else {
-                // If there was no default feedback, check for too few significant figures
-                if (submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
+        // STEP 3: If we still have no feedback to give, use the question's default feedback if any to use:
+        if (feedbackIsNullOrEmpty(feedback) && null != coordinateQuestion.getDefaultFeedback()) {
+            feedback = coordinateQuestion.getDefaultFeedback();
+        }
+        // If there was no default feedback, check for too few significant figures
+        if (feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
                         .anyMatch(c -> ValidationUtils.tooFewSignificantFigures(c, sigFigsMin, log)))) {
-                    feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
-                    feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_few")));
-                }
-            }
+            feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
+            feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_few")));
         }
 
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -205,12 +205,11 @@ public class IsaacCoordinateValidator implements IValidator {
                             if (allSubmittedItemsInChoiceItems) {
                                 feedback = new Content((submittedItems.size() == 1 ? "This is" : "These are")
                                         + " correct, but can you find more?");
-                                feedback.setTags(new HashSet<>()); // Clear tags in case we previously set sig figs tags
                                 break;
                             } else if (allItemsInChoiceWithoutSigFigs) {
                                 feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
                                 feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_many")));
-                                // Don't break; we could find a better match
+                                break;
                             }
                         }
 
@@ -243,12 +242,11 @@ public class IsaacCoordinateValidator implements IValidator {
                             if (allChoiceItemsInSubmittedItems) {
                                 responseCorrect = coordinateChoice.isCorrect();
                                 feedback = (Content) coordinateChoice.getExplanation();
-                                feedback.setTags(new HashSet<>()); // Clear tags in case we previously set sig figs tags
                                 break;
                             } else if (allItemsInSubmittedWithoutSigFigs) {
                                 feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
                                 feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_many")));
-                                // Don't break; we could find a better match
+                                break;
                             }
                         }
                     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -251,7 +251,11 @@ public class IsaacCoordinateValidator implements IValidator {
             String submittedValue = submittedItem.getCoordinates().get(dimension);
             String choiceValue = choiceItem.getCoordinates().get(dimension);
 
-            int sigFigs = ValidationUtils.numberOfSignificantFiguresToValidateWith(submittedValue, sigFigsMin, sigFigsMax, log);
+            Integer sigFigs = null;
+            if (null != sigFigsMin || null != sigFigsMax) {
+                sigFigs = ValidationUtils.numberOfSignificantFiguresToValidateWith(submittedValue, sigFigsMin, sigFigsMax, log);
+            }
+
             if (!ValidationUtils.numericValuesMatch(choiceValue, submittedValue, sigFigs, log)
                     || null != sigFigsMin && ValidationUtils.tooFewSignificantFigures(submittedValue, sigFigsMin, log)
                         || null != sigFigsMax && ValidationUtils.tooManySignificantFigures(submittedValue, sigFigsMax, log)) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -216,7 +216,7 @@ public class IsaacCoordinateValidator implements IValidator {
                         // If subset matching is allowed for this choice, check if the choice is a proper subset of the
                         // submitted items
                         boolean allowSubsetMatch = (null != coordinateChoice.isAllowSubsetMatch() && coordinateChoice.isAllowSubsetMatch());
-                        if (null == feedback && allowSubsetMatch && (submittedItems.size() > choiceItems.size())) {
+                        if (allowSubsetMatch && (submittedItems.size() > choiceItems.size())) {
                             boolean allChoiceItemsInSubmittedItems = true;
                             boolean allItemsInSubmittedWithoutSigFigs = true;
                             for (CoordinateItem choiceItem : choiceItems) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -263,7 +263,8 @@ public class IsaacCoordinateValidator implements IValidator {
             feedback = coordinateQuestion.getDefaultFeedback();
         }
         // If there was no default feedback, check for too few significant figures
-        if (feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
+        if (feedbackIsNullOrEmpty(feedback) && null != sigFigsMin
+                && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
                         .anyMatch(c -> ValidationUtils.tooFewSignificantFigures(c, sigFigsMin, log)))) {
             feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
             feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_few")));

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNullElse;
 import static uk.ac.cam.cl.dtg.isaac.api.Constants.*;
 import static uk.ac.cam.cl.dtg.isaac.quiz.IsaacNumericValidator.DEFAULT_VALIDATION_RESPONSE;
 
@@ -45,8 +46,8 @@ public class IsaacCoordinateValidator implements IValidator {
         IsaacCoordinateQuestion coordinateQuestion = (IsaacCoordinateQuestion) question;
         CoordinateChoice submittedChoice = (CoordinateChoice) answer;
 
-        Integer sigFigsMin = coordinateQuestion.getSignificantFiguresMin();
-        Integer sigFigsMax = coordinateQuestion.getSignificantFiguresMax();
+        int sigFigsMin = requireNonNullElse(coordinateQuestion.getSignificantFiguresMin(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
+        int sigFigsMax = requireNonNullElse(coordinateQuestion.getSignificantFiguresMax(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
 
         // STEP 0: Is it even possible to answer this question?
 
@@ -263,8 +264,7 @@ public class IsaacCoordinateValidator implements IValidator {
             feedback = coordinateQuestion.getDefaultFeedback();
         }
         // If there was no default feedback, check for too few significant figures
-        if (feedbackIsNullOrEmpty(feedback) && null != sigFigsMin
-                && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
+        if (feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
                         .anyMatch(c -> ValidationUtils.tooFewSignificantFigures(c, sigFigsMin, log)))) {
             feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
             feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_few")));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
@@ -44,7 +44,9 @@ public class IsaacCoordinateValidatorTest {
     private final CoordinateItem item3 = new CoordinateItem(List.of("1.0", "3.0"));
     private final CoordinateItem item4 = new CoordinateItem(List.of("3.0", "1.0"));
     private final CoordinateItem item2Again = new CoordinateItem(List.of("2.0", "1.0"));  // Ensure no == comparisons.
+
     private final CoordinateItem item1ExtraSigFig = new CoordinateItem(List.of("1.00", "2.00"));
+    private final CoordinateItem item1TooFewSigFigs = new CoordinateItem(List.of("1", "2"));
 
     private final Content someIncorrectExplanation = new Content("Some incorrect explanation.");
 
@@ -180,9 +182,8 @@ public class IsaacCoordinateValidatorTest {
 
     @Test
     public final void isaacCoordinateValidator_TestTooFewSignificantFigures() {
-        CoordinateItem ci = new CoordinateItem(List.of("1", "2"));
         CoordinateChoice c = new CoordinateChoice();
-        c.setItems(List.of(ci, item2));
+        c.setItems(List.of(item1TooFewSigFigs, item2));
 
         QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
 
@@ -244,9 +245,8 @@ public class IsaacCoordinateValidatorTest {
     @Test
     public final void isaacCoordinateValidator_TestDefaultFeedback() {
         // If default feedback is set, prefer it over "too few sig figs"
-        CoordinateItem ci = new CoordinateItem(List.of("1", "2"));
         CoordinateChoice c = new CoordinateChoice();
-        c.setItems(List.of(ci, item2));
+        c.setItems(List.of(item1TooFewSigFigs, item2));
 
         Content defaultExplanation = new Content("Default feedback.");
         someCoordinateQuestion.setDefaultFeedback(defaultExplanation);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
@@ -193,6 +193,52 @@ public class IsaacCoordinateValidatorTest {
     }
 
     @Test
+    public final void isaacCoordinateValidator_TestDefaultSigFigsMax() {
+        // If max sig figs is not set, it should default to 2
+        someCoordinateQuestion.setSignificantFiguresMax(null);
+
+        // 3 sig figs should be too many
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1ExtraSigFig, item2));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getTags().contains("sig_figs"));
+        assertTrue(response.getExplanation().getTags().contains("sig_figs_too_many"));
+
+        // 2 sig figs should be correct
+        c.setItems(List.of(item1, item2));
+
+        response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertTrue(response.isCorrect());
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestDefaultSigFigsMin() {
+        // If min sig figs is not set, it should default to 2
+        someCoordinateQuestion.setSignificantFiguresMin(null);
+
+        // 1 sig fig should be too few
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1TooFewSigFigs, item2));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getTags().contains("sig_figs"));
+        assertTrue(response.getExplanation().getTags().contains("sig_figs_too_few"));
+
+        // 2 sig figs should be correct
+        c.setItems(List.of(item1, item2));
+
+        response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertTrue(response.isCorrect());
+    }
+
+    @Test
     public final void isaacCoordinateValidator_TestSubsetOfCorrectChoice() {
         someCoordinateQuestion.setOrdered(false);
         CoordinateChoice c = new CoordinateChoice();

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
@@ -38,13 +38,13 @@ public class IsaacCoordinateValidatorTest {
 
     private IsaacCoordinateValidator validator;
     private IsaacCoordinateQuestion someCoordinateQuestion;
-    private IsaacCoordinateQuestion someUnorderedCoordinateQuestion;
 
-    private final CoordinateItem item1 = new CoordinateItem(List.of("1", "2"));
-    private final CoordinateItem item2 = new CoordinateItem(List.of("2", "1"));
-    private final CoordinateItem item3 = new CoordinateItem(List.of("1", "3"));
-    private final CoordinateItem item4 = new CoordinateItem(List.of("3", "1"));
-    private final CoordinateItem item2Again = new CoordinateItem(List.of("2", "1"));  // Ensure no == comparisons.
+    private final CoordinateItem item1 = new CoordinateItem(List.of("1.0", "2.0"));
+    private final CoordinateItem item2 = new CoordinateItem(List.of("2.0", "1.0"));
+    private final CoordinateItem item3 = new CoordinateItem(List.of("1.0", "3.0"));
+    private final CoordinateItem item4 = new CoordinateItem(List.of("3.0", "1.0"));
+    private final CoordinateItem item2Again = new CoordinateItem(List.of("2.0", "1.0"));  // Ensure no == comparisons.
+    private final CoordinateItem item1ExtraSigFig = new CoordinateItem(List.of("1.00", "2.00"));
 
     private final Content someIncorrectExplanation = new Content("Some incorrect explanation.");
 
@@ -58,12 +58,9 @@ public class IsaacCoordinateValidatorTest {
         // Set up the question objects:
         someCoordinateQuestion = new IsaacCoordinateQuestion();
         someCoordinateQuestion.setNumberOfDimensions(2);
-        someCoordinateQuestion.setSignificantFiguresMin(1);
-        someCoordinateQuestion.setSignificantFiguresMax(1);
+        someCoordinateQuestion.setSignificantFiguresMin(2);
+        someCoordinateQuestion.setSignificantFiguresMax(2);
         someCoordinateQuestion.setOrdered(true);
-
-        someUnorderedCoordinateQuestion = new IsaacCoordinateQuestion();
-        someUnorderedCoordinateQuestion.setNumberOfDimensions(2);
 
         List<Choice> answerList = Lists.newArrayList();
         ItemChoice someIncorrectChoice = new CoordinateChoice();
@@ -81,7 +78,6 @@ public class IsaacCoordinateValidatorTest {
         answerList.add(someIncorrectChoice);
         answerList.add(someCorrectChoice);
         someCoordinateQuestion.setChoices(answerList);
-        someUnorderedCoordinateQuestion.setChoices(answerList);
     }
 
     @Test
@@ -171,28 +167,20 @@ public class IsaacCoordinateValidatorTest {
     }
 
     @Test
-    public final void isaacCoordinateValidator_TestSubsetOfCorrectChoice() {
+    public final void isaacCoordinateValidator_TestTooManySignificantFigures() {
         CoordinateChoice c = new CoordinateChoice();
-        c.setItems(List.of(item1));
+        c.setItems(List.of(item1ExtraSigFig, item2));
 
-        QuestionValidationResponse response = validator.validateQuestionResponse(someUnorderedCoordinateQuestion, c);
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
 
         assertFalse(response.isCorrect());
-        assertTrue(response.getExplanation().getValue().contains("but can you find more?"));
+        assertTrue(response.getExplanation().getTags().contains("sig_figs"));
+        assertTrue(response.getExplanation().getTags().contains("sig_figs_too_many"));
     }
 
     @Test
-    public final void isaacCoordinateValidator_TestSupersetOfSubsetMatchChoice() {
-        CoordinateChoice c = new CoordinateChoice();
-        c.setItems(List.of(item1, item3, item4));
-        QuestionValidationResponse response = validator.validateQuestionResponse(someUnorderedCoordinateQuestion, c);
-        assertFalse(response.isCorrect());
-        assertEquals(someIncorrectExplanation, response.getExplanation());
-    }
-
-    @Test
-    public final void isaacCoordinateValidator_TestIncorrectSignificantFigures() {
-        CoordinateItem ci = new CoordinateItem(List.of("1.00", "2.00"));
+    public final void isaacCoordinateValidator_TestTooFewSignificantFigures() {
+        CoordinateItem ci = new CoordinateItem(List.of("1", "2"));
         CoordinateChoice c = new CoordinateChoice();
         c.setItems(List.of(ci, item2));
 
@@ -200,6 +188,75 @@ public class IsaacCoordinateValidatorTest {
 
         assertFalse(response.isCorrect());
         assertTrue(response.getExplanation().getTags().contains("sig_figs"));
+        assertTrue(response.getExplanation().getTags().contains("sig_figs_too_few"));
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestSubsetOfCorrectChoice() {
+        someCoordinateQuestion.setOrdered(false);
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getValue().contains("but can you find more?"));
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestSupersetOfSubsetMatchChoice() {
+        someCoordinateQuestion.setOrdered(false);
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1, item3, item4));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertEquals(someIncorrectExplanation, response.getExplanation());
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestSubsetOfCorrectChoiceTooManySigFigs() {
+        someCoordinateQuestion.setOrdered(false);
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1ExtraSigFig));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getTags().contains("sig_figs"));
+        assertTrue(response.getExplanation().getTags().contains("sig_figs_too_many"));
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestSupersetOfSubsetMatchChoiceTooManySigFigs() {
+        someCoordinateQuestion.setOrdered(false);
+        CoordinateChoice c = new CoordinateChoice();
+        CoordinateItem item3ExtraSigFig = new CoordinateItem(List.of("1.00", "3.00"));
+        CoordinateItem item4ExtraSigFig = new CoordinateItem(List.of("3.00", "1.00"));
+        c.setItems(List.of(item1ExtraSigFig, item3ExtraSigFig, item4ExtraSigFig));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertTrue(response.getExplanation().getTags().contains("sig_figs"));
+        assertTrue(response.getExplanation().getTags().contains("sig_figs_too_many"));
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestDefaultFeedback() {
+        // If default feedback is set, prefer it over "too few sig figs"
+        CoordinateItem ci = new CoordinateItem(List.of("1", "2"));
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(ci, item2));
+
+        Content defaultExplanation = new Content("Default feedback.");
+        someCoordinateQuestion.setDefaultFeedback(defaultExplanation);
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertEquals(defaultExplanation, response.getExplanation());
     }
 
     // Test the internals of the item-ordering:

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
@@ -232,9 +232,7 @@ public class IsaacCoordinateValidatorTest {
     public final void isaacCoordinateValidator_TestSupersetOfSubsetMatchChoiceTooManySigFigs() {
         someCoordinateQuestion.setOrdered(false);
         CoordinateChoice c = new CoordinateChoice();
-        CoordinateItem item3ExtraSigFig = new CoordinateItem(List.of("1.00", "3.00"));
-        CoordinateItem item4ExtraSigFig = new CoordinateItem(List.of("3.00", "1.00"));
-        c.setItems(List.of(item1ExtraSigFig, item3ExtraSigFig, item4ExtraSigFig));
+        c.setItems(List.of(item1ExtraSigFig, item3, item4));
 
         QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
 


### PR DESCRIPTION
- If min./max. significant figures aren't set on a coordinate question, use 2 as the default, as is the case for numeric questions.

- Coordinate questions already showed sig figs feedback in the "correct but too many sig figs" case. Add feedback for the "too few sig figs, irrespective of correctness" case if and only if we have exhausted all other relevant feedback options, as is the case for numeric questions.

- Enable significant figures feedback for both subset cases (submission ⊂ correct choice, subset match choice ⊂ submission).