### PR TITLE
Add "Exact answers only" option to coordinate questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCoordinateQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacCoordinateQuestion.java
@@ -29,6 +29,7 @@ public class IsaacCoordinateQuestion extends IsaacQuestionBase {
     private String[] suffixes;
     private String buttonText;
 
+    private Boolean disregardSignificantFigures;
     private Integer significantFiguresMin;
     private Integer significantFiguresMax;
 
@@ -54,6 +55,25 @@ public class IsaacCoordinateQuestion extends IsaacQuestionBase {
 
     public void setOrdered(final Boolean ordered) {
         this.ordered = ordered;
+    }
+
+    /**
+     * Gets whether to disregard significant figures, i.e. allow exact answers only.
+     *
+     * @return true if significant figures should be disregarded, false or null otherwise.
+     */
+    public Boolean getDisregardSignificantFigures() {
+        return disregardSignificantFigures;
+    }
+
+    /**
+     * Sets whether to disregard significant figures, i.e. allow exact answers only.
+     *
+     * @param disregardSignificantFigures
+     *          - whether to disregard significant figures
+     */
+    public void setDisregardSignificantFigures(final Boolean disregardSignificantFigures) {
+        this.disregardSignificantFigures = disregardSignificantFigures;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -93,10 +93,6 @@ public class IsaacCoordinateValidator implements IValidator {
             feedback = new Content("You did not provide the correct number of coordinates.");
         }
 
-        // Get significant figures to validate with
-        int sigFigsMin = requireNonNullElse(coordinateQuestion.getSignificantFiguresMin(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
-        int sigFigsMax = requireNonNullElse(coordinateQuestion.getSignificantFiguresMax(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
-
         // STEP 2: If they did, does their answer match a known answer?
 
         if (null == feedback) {
@@ -152,10 +148,10 @@ public class IsaacCoordinateValidator implements IValidator {
                             CoordinateItem choiceItem = choiceItems.get(coordIndex);
                             CoordinateItem submittedItem = submittedItems.get(coordIndex);
                             // Check that the submitted item matches the choice item
-                            if (!coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false, coordinateQuestion)) {
+                            if (!coordinateItemsMatch(submittedItem, choiceItem, coordinateQuestion, false)) {
                                 allItemsMatch = false;
                                 // On mismatch, check if the items would match without excess significant figures
-                                if (!coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true, coordinateQuestion)) {
+                                if (!coordinateItemsMatch(submittedItem, choiceItem, coordinateQuestion, true)) {
                                     allItemsMatchWithoutSigFigs = false;
                                     // Exit early on mismatch:
                                     break;
@@ -186,10 +182,10 @@ public class IsaacCoordinateValidator implements IValidator {
                                 boolean submittedItemInChoiceItem = false;
                                 boolean itemInChoiceWithoutSigFigs = false;
                                 for (CoordinateItem choiceItem : choiceItems) {
-                                    if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false, coordinateQuestion)) {
+                                    if (coordinateItemsMatch(submittedItem, choiceItem, coordinateQuestion, false)) {
                                         submittedItemInChoiceItem = true;
                                         break;
-                                    } else if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true, coordinateQuestion)) {
+                                    } else if (coordinateItemsMatch(submittedItem, choiceItem, coordinateQuestion, true)) {
                                         // On mismatch, check if the items would match without excess significant figures
                                         itemInChoiceWithoutSigFigs = true;
                                     }
@@ -228,10 +224,10 @@ public class IsaacCoordinateValidator implements IValidator {
                                 boolean choiceItemInSubmittedItems = false;
                                 boolean itemInSubmittedWithoutSigFigs = false;
                                 for (CoordinateItem submittedItem : submittedItems) {
-                                    if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false, coordinateQuestion)) {
+                                    if (coordinateItemsMatch(submittedItem, choiceItem, coordinateQuestion, false)) {
                                         choiceItemInSubmittedItems = true;
                                         break;
-                                    } else if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true, coordinateQuestion)) {
+                                    } else if (coordinateItemsMatch(submittedItem, choiceItem, coordinateQuestion, true)) {
                                         // On mismatch, check if the items would match without excess significant figures
                                         itemInSubmittedWithoutSigFigs = true;
                                     }
@@ -273,6 +269,7 @@ public class IsaacCoordinateValidator implements IValidator {
         }
 
         // If incorrect & no other feedback, check for too few significant figures
+        int sigFigsMin = requireNonNullElse(coordinateQuestion.getSignificantFiguresMin(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
         if (!responseCorrect && feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
                 .anyMatch(c -> ValidationUtils.tooFewSignificantFigures(c, sigFigsMin, log)))) {
             feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
@@ -283,8 +280,10 @@ public class IsaacCoordinateValidator implements IValidator {
     }
 
     private boolean coordinateItemsMatch(final CoordinateItem submittedItem, final CoordinateItem choiceItem,
-                                         final int sigFigsMin, final int sigFigsMax, final boolean allowTooManySigFigs,
-                                         final IsaacCoordinateQuestion coordinateQuestion) {
+                                         final IsaacCoordinateQuestion coordinateQuestion, final boolean allowTooManySigFigs) {
+
+        int sigFigsMin = requireNonNullElse(coordinateQuestion.getSignificantFiguresMin(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
+        int sigFigsMax = requireNonNullElse(coordinateQuestion.getSignificantFiguresMax(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
 
         if (submittedItem.getCoordinates().size() != choiceItem.getCoordinates().size()) {
             return false;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -46,6 +46,10 @@ public class IsaacCoordinateValidator implements IValidator {
         IsaacCoordinateQuestion coordinateQuestion = (IsaacCoordinateQuestion) question;
         CoordinateChoice submittedChoice = (CoordinateChoice) answer;
 
+        // Get significant figures to validate with
+        int sigFigsMin = requireNonNullElse(coordinateQuestion.getSignificantFiguresMin(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
+        int sigFigsMax = requireNonNullElse(coordinateQuestion.getSignificantFiguresMax(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
+
         // STEP 0: Is it even possible to answer this question?
 
         if (null == coordinateQuestion.getChoices() || coordinateQuestion.getChoices().isEmpty()) {
@@ -56,6 +60,14 @@ public class IsaacCoordinateValidator implements IValidator {
         if (null == coordinateQuestion.getNumberOfDimensions() || coordinateQuestion.getNumberOfDimensions() < 1) {
             log.error("Question ({}) does not have dimensions set. src: {}", question.getId(), question.getCanonicalSourceFile());
             feedback = new Content("This question cannot be answered correctly.");
+        }
+
+        // Only worry about broken significant figure rules if we are going to use them (i.e. if "exact match" is false)
+        if (null == coordinateQuestion.getDisregardSignificantFigures() || !coordinateQuestion.getDisregardSignificantFigures()) {
+            if (sigFigsMin < 1 || sigFigsMax < 1 || sigFigsMax < sigFigsMin) {
+                log.error("Question has broken significant figure rules! " + question.getId() + " src: " + question.getCanonicalSourceFile());
+                feedback = new Content("This question cannot be answered correctly.");
+            }
         }
 
         // STEP 1: Did they provide a valid answer?
@@ -269,7 +281,6 @@ public class IsaacCoordinateValidator implements IValidator {
         }
 
         // If incorrect & no other feedback, check for too few significant figures
-        int sigFigsMin = requireNonNullElse(coordinateQuestion.getSignificantFiguresMin(), NUMERIC_QUESTION_DEFAULT_SIGNIFICANT_FIGURES);
         if (!responseCorrect && feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
                 .anyMatch(c -> ValidationUtils.tooFewSignificantFigures(c, sigFigsMin, log)))) {
             feedback = new Content(DEFAULT_VALIDATION_RESPONSE);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -152,10 +152,10 @@ public class IsaacCoordinateValidator implements IValidator {
                             CoordinateItem choiceItem = choiceItems.get(coordIndex);
                             CoordinateItem submittedItem = submittedItems.get(coordIndex);
                             // Check that the submitted item matches the choice item
-                            if (!coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false)) {
+                            if (!coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false, coordinateQuestion)) {
                                 allItemsMatch = false;
                                 // On mismatch, check if the items would match without excess significant figures
-                                if (!coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true)) {
+                                if (!coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true, coordinateQuestion)) {
                                     allItemsMatchWithoutSigFigs = false;
                                     // Exit early on mismatch:
                                     break;
@@ -186,10 +186,10 @@ public class IsaacCoordinateValidator implements IValidator {
                                 boolean submittedItemInChoiceItem = false;
                                 boolean itemInChoiceWithoutSigFigs = false;
                                 for (CoordinateItem choiceItem : choiceItems) {
-                                    if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false)) {
+                                    if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false, coordinateQuestion)) {
                                         submittedItemInChoiceItem = true;
                                         break;
-                                    } else if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true)) {
+                                    } else if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true, coordinateQuestion)) {
                                         // On mismatch, check if the items would match without excess significant figures
                                         itemInChoiceWithoutSigFigs = true;
                                     }
@@ -228,10 +228,10 @@ public class IsaacCoordinateValidator implements IValidator {
                                 boolean choiceItemInSubmittedItems = false;
                                 boolean itemInSubmittedWithoutSigFigs = false;
                                 for (CoordinateItem submittedItem : submittedItems) {
-                                    if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false)) {
+                                    if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, false, coordinateQuestion)) {
                                         choiceItemInSubmittedItems = true;
                                         break;
-                                    } else if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true)) {
+                                    } else if (coordinateItemsMatch(submittedItem, choiceItem, sigFigsMin, sigFigsMax, true, coordinateQuestion)) {
                                         // On mismatch, check if the items would match without excess significant figures
                                         itemInSubmittedWithoutSigFigs = true;
                                     }
@@ -272,8 +272,8 @@ public class IsaacCoordinateValidator implements IValidator {
             feedback = coordinateQuestion.getDefaultFeedback();
         }
 
-        // If there was no default feedback, check for too few significant figures
-        if (feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
+        // If incorrect & no other feedback, check for too few significant figures
+        if (!responseCorrect && feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
                 .anyMatch(c -> ValidationUtils.tooFewSignificantFigures(c, sigFigsMin, log)))) {
             feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
             feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_few")));
@@ -283,7 +283,8 @@ public class IsaacCoordinateValidator implements IValidator {
     }
 
     private boolean coordinateItemsMatch(final CoordinateItem submittedItem, final CoordinateItem choiceItem,
-                                         final int sigFigsMin, final int sigFigsMax, final boolean allowTooManySigFigs) {
+                                         final int sigFigsMin, final int sigFigsMax, final boolean allowTooManySigFigs,
+                                         final IsaacCoordinateQuestion coordinateQuestion) {
 
         if (submittedItem.getCoordinates().size() != choiceItem.getCoordinates().size()) {
             return false;
@@ -292,6 +293,11 @@ public class IsaacCoordinateValidator implements IValidator {
         for (int dimension = 0; dimension < submittedItem.getCoordinates().size(); dimension++) {
             String submittedValue = submittedItem.getCoordinates().get(dimension);
             String choiceValue = choiceItem.getCoordinates().get(dimension);
+
+            if (null != coordinateQuestion.getDisregardSignificantFigures()
+                    && coordinateQuestion.getDisregardSignificantFigures()) {
+                return ValidationUtils.numericValuesMatch(choiceValue, submittedValue, null, log);
+            }
 
             if (allowTooManySigFigs) {
                 // Check if the submission has more significant figures than the allowed maximum

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidationUtils.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ValidationUtils.java
@@ -219,8 +219,10 @@ public final class ValidationUtils {
 
         // Parse exactly into a BigDecimal:
         BigDecimal bd = new BigDecimal(untrustedParsedValue);
-
-        if (untrustedParsedValue.contains(".")) {
+        if (bd.equals(BigDecimal.ZERO)) {
+            // Zero is a special case; let it be ambiguous with any number of sig figs
+            return new ValidationUtils.SigFigResult(true, 0, Integer.MAX_VALUE);
+        } else if (untrustedParsedValue.contains(".")) {
             // If it contains a decimal point then there is no ambiguity in how many sig figs it has.
             return new ValidationUtils.SigFigResult(false, bd.precision(), bd.precision());
         } else {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
@@ -235,6 +235,26 @@ public class IsaacCoordinateValidatorTest {
     }
 
     @Test
+    public final void isaacCoordinateValidator_TestDisregardSignificantFigures() {
+        someCoordinateQuestion.setDisregardSignificantFigures(true);
+
+        // Exact match should be correct
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1, item2Again));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertTrue(response.isCorrect());
+
+        // Extra trailing 0 should still be correct
+        c.setItems(List.of(item1ExtraSigFig, item2Again));
+
+        response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertTrue(response.isCorrect());
+    }
+
+    @Test
     public final void isaacCoordinateValidator_TestSubsetOfCorrectChoice() {
         someCoordinateQuestion.setOrdered(false);
         CoordinateChoice c = new CoordinateChoice();

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidatorTest.java
@@ -702,7 +702,7 @@ public class IsaacNumericValidatorTest {
 
         verifyCorrectNumberOfSigFigsNoRange(Arrays.asList("50300", "-50300"), Arrays.asList(3, 4, 5), Arrays.asList(1, 2, 6));
 
-        verifyCorrectNumberOfSigFigsNoRange(Arrays.asList("0", "-0"), Collections.singletonList(1), Collections.singletonList(2));
+        verifyCorrectNumberOfSigFigsNoRange(Arrays.asList("0", "-0"), Collections.singletonList(1), Collections.emptyList());
 
         verifyCorrectNumberOfSigFigsNoRange(Arrays.asList("0000100", "-0000100"), Arrays.asList(1, 2, 3), Arrays.asList(4, 5, 6, 7));
 


### PR DESCRIPTION
Adds an option for "Exact answers only" (`disregardSignificantFigures`) for coordinate questions. This works the same way as it does for numeric questions, i.e. validates that two values are numerically equal without considering significant figures, even if significant figures have been set on the question.

This enables coordinate questions to be used for cases where different values in the choice need to be given to different significant figures (e.g. (1, 2.34)).