### PR TITLE
Use prefixed cookies for further cookie security

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -570,6 +570,7 @@ public final class Constants {
     public static final String REDIRECT_URL = "redirectUrl";
 
     public static final String SEGUE_AUTH_COOKIE = "SEGUE_AUTH_COOKIE";
+    public static final String SECURE_SEGUE_AUTH_COOKIE = "__Host-SEGUE_AUTH_COOKIE";
     public static final String JSESSION_COOOKIE = "JSESSIONID";
 
     public static final String DEFAULT_DATE_FORMAT = "EEE MMM dd HH:mm:ss Z yyyy";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -96,6 +96,8 @@ public class UserAuthenticationManager {
     private static final Logger log = LoggerFactory.getLogger(UserAuthenticationManager.class);
     private static final String HMAC_SHA_ALGORITHM = "HmacSHA256";
 
+    private static final String DUPLICATE_COOKIES = "Duplicate auth cookies found in request from ({}). Ignoring old cookie!";
+
     private final AbstractConfigLoader properties;
     private final IUserDataManager database;
     private final IDeletionTokenPersistenceManager deletionTokenPersistenceManager;
@@ -556,16 +558,10 @@ public class UserAuthenticationManager {
         Objects.requireNonNull(request);
         try {
             request.getSession().invalidate();
-            Cookie logoutCookie = new Cookie(SEGUE_AUTH_COOKIE, "");
-            logoutCookie.setPath("/");
-            logoutCookie.setMaxAge(0);  // This will lead to it being removed by the browser immediately.
-            logoutCookie.setHttpOnly(true);
-            logoutCookie.setSecure(true);
-            logoutCookie.setAttribute("SameSite", "Strict");
-
+            Cookie logoutCookie = generateSegueAuthCookie("", 0);
             response.addCookie(logoutCookie);
-        } catch (IllegalStateException e) {
-            log.info("The session has already been invalidated. " + "Unable to logout again...", e);
+        } catch (final IllegalStateException e) {
+            log.info("The session has already been invalidated. Unable to logout again...", e);
         }
     }
     
@@ -1022,20 +1018,14 @@ public class UserAuthenticationManager {
             sessionInformationBuilder.put(HMAC, sessionHMAC);
 
             Map<String, String> sessionInformation = sessionInformationBuilder.build();
+            String cookieValue = Base64.encodeBase64String(serializationMapper.writeValueAsString(sessionInformation).getBytes());
 
-            Cookie authCookie = new Cookie(SEGUE_AUTH_COOKIE,
-                    Base64.encodeBase64String(serializationMapper.writeValueAsString(sessionInformation).getBytes()));
-            authCookie.setMaxAge(sessionExpiryTimeInSeconds);
-            authCookie.setPath("/");
-            authCookie.setHttpOnly(true);
-            authCookie.setSecure(true);
-            authCookie.setAttribute("SameSite", "Strict");
-
-            log.debug(String.format("Creating AuthCookie for user (%s) with value %s", userId, authCookie.getValue()));
-
+            Cookie authCookie = generateSegueAuthCookie(cookieValue, sessionExpiryTimeInSeconds);
             response.addCookie(authCookie);
 
-        } catch (JsonProcessingException e1) {
+            log.debug("Creating SEGUE_AUTH_COOKIE for user ({}) with value ({})", userId, authCookie.getValue());
+
+        } catch (final JsonProcessingException e1) {
             log.error("Unable to save cookie.", e1);
         }
     }
@@ -1132,6 +1122,24 @@ public class UserAuthenticationManager {
     }
 
     /**
+     * Create a new SEGUE_AUTH_COOKIE with standard security settings.
+     *
+     * @param cookieValue - string content of the cookie.
+     * @param maxAge - cookie lifetime.
+     * @return the new Cookie object.
+     */
+    private Cookie generateSegueAuthCookie(final String cookieValue, final int maxAge) {
+        Cookie authCookie = new Cookie(SECURE_SEGUE_AUTH_COOKIE, cookieValue);
+        authCookie.setMaxAge(maxAge);
+        authCookie.setPath("/");
+        authCookie.setHttpOnly(true);
+        authCookie.setSecure(true);
+        authCookie.setAttribute("SameSite", "Strict");
+
+        return authCookie;
+    }
+
+    /**
      * This method is used to check whether a Segue Session's reported HMAC matches our recalculation. Assuming we've
      * kept our HMAC_SALT secret and non-guessable, that will mean the session information has not been tampered with.
      *
@@ -1204,13 +1212,23 @@ public class UserAuthenticationManager {
         }
 
         for (Cookie c : request.getCookies()) {
+            // FIXME: remove support for SEGUE_AUTH_COOKIE after old cookies expired.
             if (c.getName().equals(SEGUE_AUTH_COOKIE)) {
+                if (null != segueAuthCookie) {
+                    log.warn(DUPLICATE_COOKIES, RequestIPExtractor.getClientIpAddr(request));
+                } else {
+                    segueAuthCookie = c;
+                }
+            } else if (c.getName().equals(SECURE_SEGUE_AUTH_COOKIE)) {
+                if (null != segueAuthCookie) {
+                    log.warn(DUPLICATE_COOKIES, RequestIPExtractor.getClientIpAddr(request));
+                }
                 segueAuthCookie = c;
             }
         }
 
         if (null == segueAuthCookie) {
-            throw new InvalidSessionException("There are no cookies set.");
+            throw new InvalidSessionException("There are no session cookies set.");
         }
 
         @SuppressWarnings("unchecked")
@@ -1234,13 +1252,23 @@ public class UserAuthenticationManager {
         }
 
         for (HttpCookie c : request.getCookies()) {
+            // FIXME: remove support for SEGUE_AUTH_COOKIE after old cookies expired.
             if (c.getName().equals(SEGUE_AUTH_COOKIE)) {
+                if (null != segueAuthCookie) {
+                    log.warn(DUPLICATE_COOKIES, "websocket");
+                } else {
+                    segueAuthCookie = c;
+                }
+            } else if (c.getName().equals(SECURE_SEGUE_AUTH_COOKIE)) {
+                if (null != segueAuthCookie) {
+                    log.warn(DUPLICATE_COOKIES, "websocket");
+                }
                 segueAuthCookie = c;
             }
         }
 
         if (null == segueAuthCookie) {
-            throw new InvalidSessionException("There are no cookies set.");
+            throw new InvalidSessionException("There are no session cookies set.");
         }
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAuthenticationManager.java
@@ -560,6 +560,11 @@ public class UserAuthenticationManager {
             request.getSession().invalidate();
             Cookie logoutCookie = generateSegueAuthCookie("", 0);
             response.addCookie(logoutCookie);
+            // FIXME old-cookies: remove once old cookies deprecated:
+            Cookie oldLogoutCookie = new Cookie(SEGUE_AUTH_COOKIE, "");
+            oldLogoutCookie.setMaxAge(0);
+            oldLogoutCookie.setPath("/");
+            response.addCookie(oldLogoutCookie);
         } catch (final IllegalStateException e) {
             log.info("The session has already been invalidated. Unable to logout again...", e);
         }
@@ -1212,7 +1217,7 @@ public class UserAuthenticationManager {
         }
 
         for (Cookie c : request.getCookies()) {
-            // FIXME: remove support for SEGUE_AUTH_COOKIE after old cookies expired.
+            // FIXME old-cookies: remove support for SEGUE_AUTH_COOKIE after old cookies expired.
             if (c.getName().equals(SEGUE_AUTH_COOKIE)) {
                 if (null != segueAuthCookie) {
                     log.warn(DUPLICATE_COOKIES, RequestIPExtractor.getClientIpAddr(request));
@@ -1252,7 +1257,7 @@ public class UserAuthenticationManager {
         }
 
         for (HttpCookie c : request.getCookies()) {
-            // FIXME: remove support for SEGUE_AUTH_COOKIE after old cookies expired.
+            // FIXME old-cookies: remove support for SEGUE_AUTH_COOKIE after old cookies expired.
             if (c.getName().equals(SEGUE_AUTH_COOKIE)) {
                 if (null != segueAuthCookie) {
                     log.warn(DUPLICATE_COOKIES, "websocket");

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AuthenticationFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AuthenticationFacadeIT.java
@@ -22,10 +22,8 @@ import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.CHARLIE_STUDENT_EMAIL;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.CHARLIE_STUDENT_PASSWORD;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.ERIKA_PROVIDER_USER_ID;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.ERIKA_STUDENT_ID;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 @SuppressWarnings("checkstyle:MissingJavadocType")
 public class AuthenticationFacadeIT extends IsaacIntegrationTestWithREST {
@@ -39,7 +37,7 @@ public class AuthenticationFacadeIT extends IsaacIntegrationTestWithREST {
                 "password", CHARLIE_STUDENT_PASSWORD,
                 "rememberMe", false
         ));
-        NewCookie authCookie = response.response.getCookies().get("SEGUE_AUTH_COOKIE");
+        NewCookie authCookie = response.response.getCookies().get(SECURE_SEGUE_AUTH_COOKIE);
         assertEquals(NewCookie.SameSite.STRICT, authCookie.getSameSite());
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTestWithREST.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTestWithREST.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 /**
  * Abstract superclass for integration test. Use when testing in the context of a REST application. This lets you
@@ -186,11 +187,11 @@ public class IsaacIntegrationTestWithREST extends AbstractIsaacIntegrationTest {
         }
 
         void assertNoUserLoggedIn() {
-            assertThat(this.response.getCookies()).doesNotContainKey("SEGUE_AUTH_COOKIE");
+            assertThat(this.response.getCookies()).doesNotContainKey(SECURE_SEGUE_AUTH_COOKIE);
         }
 
         void assertUserLoggedIn(final Number userId) {
-            String base64Cookie = this.response.getCookies().get("SEGUE_AUTH_COOKIE").getValue();
+            String base64Cookie = this.response.getCookies().get(SECURE_SEGUE_AUTH_COOKIE).getValue();
             byte[] cookieBytes = java.util.Base64.getDecoder().decode(base64Cookie);
             JSONObject cookie = new JSONObject(new String(cookieBytes));
             assertEquals(userId, cookie.getLong("id"));

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/UsersFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/UsersFacadeIT.java
@@ -1,15 +1,10 @@
 package uk.ac.cam.cl.dtg.isaac.api;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.ws.rs.core.Request;
-import jakarta.ws.rs.core.Response;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
@@ -30,6 +25,11 @@ import uk.ac.cam.cl.dtg.segue.dao.users.IDeletionTokenPersistenceManager;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 import uk.ac.cam.cl.dtg.util.YamlLoader;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.Response;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -37,11 +37,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.ALICE_STUDENT_ID;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_TEACHER_EMAIL;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_TEACHER_PASSWORD;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.newCapture;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.*;
+import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
 
 public class UsersFacadeIT extends IsaacIntegrationTest {
@@ -155,7 +163,7 @@ public class UsersFacadeIT extends IsaacIntegrationTest {
         assertEquals(true, ((Map<String, Boolean>) createResponse.getEntity()).get("EMAIL_VERIFICATION_REQUIRED"));
 
         // check we have an auth cookie with INCOMPLETE_MANDATORY_EMAIL_VERIFICATION caveat only
-        assertEquals("SEGUE_AUTH_COOKIE", cookieToCapture.getValue().getName());
+        assertEquals(SECURE_SEGUE_AUTH_COOKIE, cookieToCapture.getValue().getName());
         assertEquals(List.of(Constants.AuthenticationCaveat.INCOMPLETE_MANDATORY_EMAIL_VERIFICATION.name()),
                 getCaveatsFromCookie(cookieToCapture.getValue()));
 
@@ -238,7 +246,7 @@ public class UsersFacadeIT extends IsaacIntegrationTest {
         assertEquals(Response.Status.OK.getStatusCode(), createResponse.getStatus());
 
         // check we were given a session cookie
-        assertEquals("SEGUE_AUTH_COOKIE", setCookie.getValue().getName());
+        assertEquals(SECURE_SEGUE_AUTH_COOKIE, setCookie.getValue().getName());
     }
 
     /**

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/UserManagerTest.java
@@ -810,7 +810,7 @@ public class UserManagerTest {
 
     private Cookie[] getCookieArray(Map<String, String> sessionInformation) throws JsonProcessingException {
         ObjectMapper om = new ObjectMapper();
-        Cookie[] cookieWithSessionInfo = { new Cookie(Constants.SEGUE_AUTH_COOKIE,
+        Cookie[] cookieWithSessionInfo = { new Cookie(Constants.SECURE_SEGUE_AUTH_COOKIE,
                 Base64.encodeBase64String(om.writeValueAsString(sessionInformation).getBytes())) };
         return cookieWithSessionInfo;
     }


### PR DESCRIPTION
The `__Host-` prefix requires cookies to be set securely, limited to just the domain that set them, and is more widely supported than the even more restrictive `__Host-Http-` prefix.

In order not to break existing sessions we support loading both old and new cookies, though warn if a request uses both. We should remove this functionality ~30 days after we are happy we are sticking with the new prefixed cookies.