### PR TITLE
Enforce 2FA for EVENT_MANAGER accounts

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -354,8 +354,8 @@ public class UserAccountManager implements IUserAccountManager {
             // we can't just log them in we have to set a caveat cookie
             this.logUserInWithCaveats(request, response, user, rememberMe, Set.of(AuthenticationCaveat.INCOMPLETE_MFA_CHALLENGE));
             throw new AdditionalAuthenticationRequiredException();
-        } else if (Role.ADMIN.equals(user.getRole())) {
-            // Admins MUST have 2FA enabled to use password login, so if we reached this point login cannot proceed.
+        } else if (Role.ADMIN.equals(user.getRole()) || Role.EVENT_MANAGER.equals(user.getRole())) {
+            // Administrator accounts MUST have 2FA to use password login, so if we are here login cannot proceed.
             String message = "Your account type requires 2FA, but none has been configured! "
                     + "Please ask an admin to demote your account to regain access.";
             throw new MFARequiredButNotConfiguredException(message);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AbstractIsaacIntegrationTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/AbstractIsaacIntegrationTest.java
@@ -72,7 +72,6 @@ import uk.ac.cam.cl.dtg.segue.comm.EmailCommunicator;
 import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
 import uk.ac.cam.cl.dtg.segue.comm.MailGunEmailManager;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.associations.PgAssociationDataManager;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentSubclassMapper;
 import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
@@ -81,6 +80,7 @@ import uk.ac.cam.cl.dtg.segue.dao.users.IDeletionTokenPersistenceManager;
 import uk.ac.cam.cl.dtg.segue.dao.users.PgAnonymousUsers;
 import uk.ac.cam.cl.dtg.segue.dao.users.PgDeletionTokenPersistenceManager;
 import uk.ac.cam.cl.dtg.segue.dao.users.PgPasswordDataManager;
+import uk.ac.cam.cl.dtg.segue.dao.users.PgTOTPDataManager;
 import uk.ac.cam.cl.dtg.segue.dao.users.PgUserGroupPersistenceManager;
 import uk.ac.cam.cl.dtg.segue.dao.users.PgUsers;
 import uk.ac.cam.cl.dtg.segue.database.GitDb;
@@ -99,8 +99,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -282,14 +280,7 @@ public class AbstractIsaacIntegrationTest {
         emailManager = new EmailManager(communicator, userPreferenceManager, properties, contentManager, logManager, globalTokens);
 
         userAuthenticationManager = new UserAuthenticationManager(pgUsers, deletionTokenPersistenceManager, properties, providersToRegister, emailManager);
-        secondFactorManager = createMock(SegueTOTPAuthenticator.class);
-        // We don't care for MFA here so we can safely disable it
-        try {
-            expect(secondFactorManager.has2FAConfigured(anyObject())).andReturn(false).atLeastOnce();
-        } catch (SegueDatabaseException e) {
-            throw new RuntimeException(e);
-        }
-        replay(secondFactorManager);
+        secondFactorManager = new SegueTOTPAuthenticator(new PgTOTPDataManager(postgresSqlDb));
 
         userAccountManager = new UserAccountManager(pgUsers, questionManager, properties, providersToRegister, mainMapper, emailManager, pgAnonymousUsers, logManager, userAuthenticationManager, secondFactorManager, userPreferenceManager);
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacadeIT.java
@@ -18,14 +18,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.replay;
-import static org.junit.jupiter.api.Assertions.*;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_EVENT_LEADERS_OPEN_GROUP_ID;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_EVENT_LEADERS_WAITING_LIST_GROUP_ID;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_STUDENT_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.*;
 
 
 public class EventsFacadeIT extends IsaacIntegrationTest {
@@ -74,7 +76,7 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
         // --- Login as a student
         LoginResult studentLogin = loginAs(httpSession, ITConstants.TEST_STUDENT_EMAIL, ITConstants.TEST_STUDENT_PASSWORD);
         // --- Login as an event manager
-        LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.TEST_EVENTMANAGER_EMAIL, ITConstants.TEST_EVENTMANAGER_PASSWORD);
+        LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.TEST_EVENTMANAGER_EMAIL, ITConstants.TEST_EVENTMANAGER_PASSWORD, ITConstants.TEST_EVENTMANAGER_MFA_SECRET);
 
         // --- Create a booking as a logged in student
         HttpServletRequest createBookingRequest = createRequestWithCookies(new Cookie[] { studentLogin.cookie });
@@ -149,7 +151,7 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
         assertNotEquals(Response.Status.OK.getStatusCode(), getEventBookingsAsEditor_Response.getStatus());
 
         // Get event bookings by event id as an event manager (should succeed)
-        LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.TEST_EVENTMANAGER_EMAIL, ITConstants.TEST_EVENTMANAGER_PASSWORD);
+        LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.TEST_EVENTMANAGER_EMAIL, ITConstants.TEST_EVENTMANAGER_PASSWORD, ITConstants.TEST_EVENTMANAGER_MFA_SECRET);
         HttpServletRequest getEventBookingsAsEventManager_Request = createRequestWithCookies(new Cookie[] { eventManagerLogin.cookie });
         replay(getEventBookingsAsEventManager_Request);
         Response getEventBookingsAsEventManager_Response = eventsFacade.adminGetEventBookingByEventId(getEventBookingsAsEventManager_Request, "_regular_test_event");
@@ -265,7 +267,7 @@ public class EventsFacadeIT extends IsaacIntegrationTest {
         // The student does not own the group so this should not succeed
         assertNotEquals(Response.Status.OK.getStatusCode(), alice_Response.getStatus());
 
-        LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.TEST_EVENTMANAGER_EMAIL, ITConstants.TEST_EVENTMANAGER_PASSWORD);
+        LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.TEST_EVENTMANAGER_EMAIL, ITConstants.TEST_EVENTMANAGER_PASSWORD, ITConstants.TEST_EVENTMANAGER_MFA_SECRET);
         HttpServletRequest eventManager_Request = createRequestWithCookies(new Cookie[] { eventManagerLogin.cookie });
         replay(eventManager_Request);
         Response eventManager_Response = eventsFacade.getEventBookingForGivenGroup(eventManager_Request, "_regular_test_event", "2");

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ITConstants.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ITConstants.java
@@ -24,6 +24,7 @@ public final class ITConstants {
     // Users
     public static final String TEST_ADMIN_EMAIL = "test-admin@test.com";
     public static final String TEST_ADMIN_PASSWORD = "test1234";
+    public static final String TEST_ADMIN_MFA_SECRET = "OQXZE3PEGIGKAAP6";
     public static final long TEST_ADMIN_ID = 2L;
 
     public static final String TEST_EDITOR_EMAIL = "test-editor@test.com";
@@ -36,10 +37,12 @@ public final class ITConstants {
 
     public static final String TEST_EVENTMANAGER_EMAIL = "test-event@test.com";
     public static final String TEST_EVENTMANAGER_PASSWORD = "test1234";
+    public static final String  TEST_EVENTMANAGER_MFA_SECRET = TEST_ADMIN_MFA_SECRET;
     public static final long TEST_EVENTMANAGER_ID = 3L;
 
     public static final String GARY_EVENTMANAGER_EMAIL = "gary-event@test.com";
     public static final String GARY_EVENTMANAGER_PASSWORD = "test1234";
+    public static final String GARY_EVENTMANAGER_MFA_SECRET = TEST_ADMIN_MFA_SECRET;
     public static final long GARY_EVENTMANAGER_ID = 14L;
 
     public static final String TEST_EVENTLEADER_EMAIL = "test-event-leader@test.com";

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/IsaacIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.ac.cam.cl.dtg.isaac.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.warrenstrange.googleauth.GoogleAuthenticator;
 import org.apache.commons.codec.binary.Base64;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -47,6 +48,10 @@ public abstract class IsaacIntegrationTest extends AbstractIsaacIntegrationTest 
     private final ObjectMapper serializationMapper = new ObjectMapper();
 
     protected LoginResult loginAs(final HttpSession httpSession, final String username, final String password) throws Exception {
+        return loginAs(httpSession, username, password, null);
+    }
+
+    protected LoginResult loginAs(final HttpSession httpSession, final String username, final String password, final String mfaSecret) throws Exception {
         Capture<Cookie> capturedUserCookie = Capture.newInstance(); // new Capture<Cookie>(); seems deprecated
 
         HttpServletRequest userLoginRequest = createNiceMock(HttpServletRequest.class);
@@ -61,7 +66,21 @@ public abstract class IsaacIntegrationTest extends AbstractIsaacIntegrationTest 
         RegisteredUserDTO user;
         try {
             user = userAccountManager.authenticateWithCredentials(userLoginRequest, userLoginResponse, AuthenticationProvider.SEGUE.toString(), username, password, false);
-        } catch (AdditionalAuthenticationRequiredException | EmailMustBeVerifiedException e) {
+        } catch (AdditionalAuthenticationRequiredException e) {
+            GoogleAuthenticator gAuth = new GoogleAuthenticator();
+            Integer totpCode = gAuth.getTotpPassword(mfaSecret);
+
+            HttpServletRequest userMfaRequest = createNiceMock(HttpServletRequest.class);
+            expect(userMfaRequest.getCookies()).andReturn(new Cookie[]{capturedUserCookie.getValue()}).atLeastOnce();
+            replay(userMfaRequest);
+
+            capturedUserCookie = Capture.newInstance();
+            HttpServletResponse userMfaResponse = createNiceMock(HttpServletResponse.class);
+            userMfaResponse.addCookie(and(capture(capturedUserCookie), isA(Cookie.class)));
+            replay(userMfaResponse);
+
+            user = userAccountManager.authenticateMFA(userMfaRequest, userMfaResponse, totpCode, false);
+        } catch (EmailMustBeVerifiedException e) {
             // In this case, we won't get a user object but the cookies have still been set.
             user = null;
         }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/QuizFacadeIT.java
@@ -199,8 +199,8 @@ public class QuizFacadeIT extends IsaacIntegrationTest {
     })
     public void getAvailableQuizzesEndpoint_getQuizzesAsStaff_includesNofilterTaggedQuizzes(String email) throws Exception {
         // Arrange
-        // log in, create request
-        LoginResult login = loginAs(httpSession, email, "test1234");
+        // log in, create request (and assume password and MFA secret same for all)
+        LoginResult login = loginAs(httpSession, email, "test1234", ITConstants.TEST_ADMIN_MFA_SECRET);
         HttpServletRequest availableQuizzesRequest = createRequestWithCookies(new Cookie[]{login.cookie});
         replay(availableQuizzesRequest);
 
@@ -271,8 +271,8 @@ public class QuizFacadeIT extends IsaacIntegrationTest {
     })
     public void previewQuizEndpoint_previewNofilterQuizAsTutorOrAbove_succeeds(String email) throws Exception {
         // Arrange
-        // log in as user, create request
-        LoginResult login = loginAs(httpSession, email, "test1234");
+        // log in as user, create request (and assume password and MFA secret same for all)
+        LoginResult login = loginAs(httpSession, email, "test1234", ITConstants.TEST_ADMIN_MFA_SECRET);
         HttpServletRequest previewQuizRequest = createRequestWithCookies(new Cookie[]{login.cookie});
         replay(previewQuizRequest);
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/UsersFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/UsersFacadeIT.java
@@ -1,15 +1,10 @@
 package uk.ac.cam.cl.dtg.isaac.api;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.ws.rs.core.Request;
-import jakarta.ws.rs.core.Response;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
@@ -30,6 +25,11 @@ import uk.ac.cam.cl.dtg.segue.dao.users.IDeletionTokenPersistenceManager;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 import uk.ac.cam.cl.dtg.util.YamlLoader;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.Response;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -37,11 +37,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.ALICE_STUDENT_ID;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_TEACHER_EMAIL;
-import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_TEACHER_PASSWORD;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.newCapture;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.*;
 
 
 public class UsersFacadeIT extends IsaacIntegrationTest {
@@ -662,7 +669,7 @@ public class UsersFacadeIT extends IsaacIntegrationTest {
     public void createOrUpdateEndpoint_updateAnotherUserWhileLoggedInAsEventManager_succeeds(RegisteredUser targetUser) throws Exception {
         // Arrange
         // log in as Event Manager
-        LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.GARY_EVENTMANAGER_EMAIL, ITConstants.GARY_EVENTMANAGER_PASSWORD);
+        LoginResult eventManagerLogin = loginAs(httpSession, ITConstants.GARY_EVENTMANAGER_EMAIL, ITConstants.GARY_EVENTMANAGER_PASSWORD, ITConstants.GARY_EVENTMANAGER_MFA_SECRET);
         HttpServletRequest request = createRequestWithCookies(new Cookie[]{eventManagerLogin.cookie});
         replay(request);
 
@@ -807,8 +814,8 @@ public class UsersFacadeIT extends IsaacIntegrationTest {
         UsersFacade usersFacadeForTest = new UsersFacade(propertiesForTest, userAccountManager, logManager, userAssociationManager,
                 misuseMonitor, userPreferenceManager, schoolListReader);
 
-        // log in as user
-        LoginResult login = loginAs(httpSession, user.getEmail(), "test1234");
+        // log in as user (and assume password and MFA secret same for all)
+        LoginResult login = loginAs(httpSession, user.getEmail(), "test1234", ITConstants.TEST_ADMIN_MFA_SECRET);
         HttpServletRequest request = createRequestWithCookies(new Cookie[]{login.cookie});
         replay(request);
 

--- a/src/test/resources/test-postgres-rutherford-data-dump.sql
+++ b/src/test/resources/test-postgres-rutherford-data-dump.sql
@@ -361,6 +361,8 @@ COPY public.user_streak_targets (user_id, target_count, start_date, end_date, co
 
 COPY public.user_totp (user_id, shared_secret, created, last_updated) FROM stdin;
 2	OQXZE3PEGIGKAAP6	2022-07-06 10:48:02.111+00	2022-07-06 10:48:05.498+00
+3	OQXZE3PEGIGKAAP6	2022-07-06 10:48:02.111+00	2022-07-06 10:48:05.498+00
+14	OQXZE3PEGIGKAAP6	2022-07-06 10:48:02.111+00	2022-07-06 10:48:05.498+00
 \.
 
 


### PR DESCRIPTION
We will now require 2FA for all `EVENT_MANAGER` users as well as all `ADMIN`s.