### PR TITLE
April package updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.82</version>
+            <version>1.84</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -499,18 +499,18 @@
         <!-- These two don't need to be included in the war package so their scope is "provided" which means we
              promise to make them available in the deployment environment, but we aren't going to because they are
              not needed at runtime anyway. -->
-<!--        <dependency>-->
-<!--            <groupId>org.owasp</groupId>-->
-<!--            <artifactId>dependency-check-maven</artifactId>-->
-<!--            <version>${dependency-check.version}</version>-->
-<!--            <scope>provided</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.sonatype.ossindex.maven</groupId>-->
-<!--            <artifactId>ossindex-maven-plugin</artifactId>-->
-<!--            <version>${ossindex.version}</version>-->
-<!--            <scope>provided</scope>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.ossindex.maven</groupId>
+            <artifactId>ossindex-maven-plugin</artifactId>
+            <version>${ossindex.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,20 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-ai-openai</artifactId>
             <version>1.0.0-beta.16</version>
+            <!-- We exclude netty and use the Java 11+ built-in HTTP client to avoid netty's vulnerabilities
+             https://learn.microsoft.com/en-us/azure/developer/java/sdk/http-client-pipeline -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-jdk-httpclient</artifactId>
+            <version>1.1.3</version>
         </dependency>
 
         <dependency>
@@ -732,17 +746,6 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <!-- This ensures that transitive dependencies of any azure packages are up-to-date.
-            Taken from Microsoft's recommended config:
-             https://learn.microsoft.com/en-us/azure/developer/java/sdk/get-started-maven#add-azure-sdk-for-java-to-an-existing-project-->
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-sdk-bom</artifactId>
-                <version>1.3.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -735,6 +735,18 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!-- This ensures that transitive dependencies of any azure packages are up-to-date.
+            Taken from Microsoft's recommended config:
+             https://learn.microsoft.com/en-us/azure/developer/java/sdk/get-started-maven#add-azure-sdk-for-java-to-an-existing-project-->
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-sdk-bom</artifactId>
+                <version>1.3.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <!-- Maven forces this to scope 'compile' since it is used by multiple transitive deps,
                      but it really is 'provided' when we run Jetty locally or in Docker! -->

--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
         <dependency>
             <artifactId>isaac-graph-checker-library</artifactId>
             <groupId>org.isaacphysics</groupId>
-            <version>2.0.2</version>
+            <version>2.0.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.resteasy</groupId>
@@ -499,18 +499,18 @@
         <!-- These two don't need to be included in the war package so their scope is "provided" which means we
              promise to make them available in the deployment environment, but we aren't going to because they are
              not needed at runtime anyway. -->
-        <dependency>
-            <groupId>org.owasp</groupId>
-            <artifactId>dependency-check-maven</artifactId>
-            <version>${dependency-check.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.sonatype.ossindex.maven</groupId>
-            <artifactId>ossindex-maven-plugin</artifactId>
-            <version>${ossindex.version}</version>
-            <scope>provided</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.owasp</groupId>-->
+<!--            <artifactId>dependency-check-maven</artifactId>-->
+<!--            <version>${dependency-check.version}</version>-->
+<!--            <scope>provided</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.sonatype.ossindex.maven</groupId>-->
+<!--            <artifactId>ossindex-maven-plugin</artifactId>-->
+<!--            <version>${ossindex.version}</version>-->
+<!--            <scope>provided</scope>-->
+<!--        </dependency>-->
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <segue.version>v4.0.3-SNAPSHOT</segue.version>
-        <log4j.version>2.25.3</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <resteasy.version>6.2.14.Final</resteasy.version>
         <guice.version>7.0.0</guice.version>
         <oauth-client.version>1.39.0</oauth-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,20 +18,20 @@
         <jackson.version>2.21.2</jackson.version>
         <jackson-databind.version>2.21.2</jackson-databind.version>  <!-- separate in case updated separately -->
         <jackson-annotations.version>2.21</jackson-annotations.version>  <!-- now not release with patch versions -->
-        <mockito.version>5.11.0</mockito.version>
+        <mockito.version>5.23.0</mockito.version>
         <junit-5.version>5.14.1</junit-5.version>
         <swagger-ui-version>4.13.2</swagger-ui-version>
         <prometheus.version>0.16.0</prometheus.version>
         <jetty-version>12.1.8</jetty-version>
         <jetty.port.api>8080</jetty.port.api>
         <jetty.port.etl>8090</jetty.port.etl>
-        <testcontainers.version>2.0.3</testcontainers.version>
+        <testcontainers.version>2.0.4</testcontainers.version>
         <web.xml>web-api-live.xml</web.xml>
         <web.xml.etl>web-etl.xml</web.xml.etl>
         <web.xml.local>web-api-local.xml</web.xml.local>
         <dependency-check.version>12.1.8</dependency-check.version>
         <ossindex.version>3.2.0</ossindex.version>
-        <swagger-core.version>2.2.40</swagger-core.version>
+        <swagger-core.version>2.2.48</swagger-core.version>
         <jgit.version>6.10.1.202505221210-r</jgit.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <surefire.jacoco.args />
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.isaacphysics.thirdparty</groupId>
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>4.5.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>
@@ -328,7 +328,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.19.0</version>
+            <version>3.20.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -343,17 +343,17 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.14.0</version>
+            <version>1.15.0</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
-            <version>2.5.0</version>
+            <version>2.5.2</version>
         </dependency>
 
         <dependency>
@@ -390,19 +390,19 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.8</version>
+            <version>42.7.10</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.13.0</version>
+            <version>2.14.0</version>
         </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.14.0</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
         <dependency>
             <artifactId>isaac-graph-checker-library</artifactId>
             <groupId>org.isaacphysics</groupId>
-            <version>2.0.3</version>
+            <version>2.0.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
Updates API dependencies, resolving all high, and leaving only medium vulnerabilities.

- Github dependency report: 4 -> 0. Resolves 4 medium vulnerabilities, by updating `bouncycastle`, `log4j`.
- IntelliJ dependency report (excluding dev dependencies with the `provided` scope): 22 (including 3 high) -> 11 (all medium). The high vulnerabilities are in the Netty http client. I've modified our azure openai installation so we use java's built-in HTTP client instead of Netty.
- also performed trivial (non-major) version upgrades that did not fix a vulnerability (obtained by runnin `mvn versions:display-dependency-updates`)
- IntelliJ still highlights a medium dependency in `pom.xml`. This is a major version upgrade (5 -> 7) for JGit. Did not perform this, since the vulnerability is only a 4.3 and is not exploitable through the API.  

