### PR TITLE
Fix coordinate validation when sig figs aren't being used

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -281,7 +281,8 @@ public class IsaacCoordinateValidator implements IValidator {
         }
 
         // If incorrect & no other feedback, check for too few significant figures
-        if (!responseCorrect && feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
+        boolean disregardSigFigs = null != coordinateQuestion.getDisregardSignificantFigures() && coordinateQuestion.getDisregardSignificantFigures();
+        if (!disregardSigFigs && !responseCorrect && feedbackIsNullOrEmpty(feedback) && submittedItems.stream().anyMatch(i -> i.getCoordinates().stream()
                 .anyMatch(c -> ValidationUtils.tooFewSignificantFigures(c, sigFigsMin, log)))) {
             feedback = new Content(DEFAULT_VALIDATION_RESPONSE);
             feedback.setTags(new HashSet<>(ImmutableList.of("sig_figs", "sig_figs_too_few")));

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -306,15 +306,22 @@ public class IsaacCoordinateValidator implements IValidator {
 
             if (null != coordinateQuestion.getDisregardSignificantFigures()
                     && coordinateQuestion.getDisregardSignificantFigures()) {
-                return ValidationUtils.numericValuesMatch(choiceValue, submittedValue, null, log);
+                if (!ValidationUtils.numericValuesMatch(choiceValue, submittedValue, null, log)) {
+                    return false;
+                }
+                continue;
             }
 
             if (allowTooManySigFigs) {
                 // Check if the submission has more significant figures than the allowed maximum
                 if (ValidationUtils.tooManySignificantFigures(submittedValue, sigFigsMax, log)) {
                     // Check if the submission would match the choice if we ignore the excess significant figures
-                    return ValidationUtils.numericValuesMatch(choiceValue, submittedValue, sigFigsMax, log);
+                    if (!ValidationUtils.numericValuesMatch(choiceValue, submittedValue, sigFigsMax, log)) {
+                        return false;
+                    }
+                    continue; // If the value does match without excess significant figures
                 }
+                return false; // If there weren't too many significant figures
             }
 
             int sigFigs = ValidationUtils.numberOfSignificantFiguresToValidateWith(submittedValue, sigFigsMin, sigFigsMax, log);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidator.java
@@ -322,7 +322,6 @@ public class IsaacCoordinateValidator implements IValidator {
                     }
                     continue; // If the value does match without excess significant figures
                 }
-                return false; // If there weren't too many significant figures
             }
 
             int sigFigs = ValidationUtils.numberOfSignificantFiguresToValidateWith(submittedValue, sigFigsMin, sigFigsMax, log);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacCoordinateValidatorTest.java
@@ -60,6 +60,7 @@ public class IsaacCoordinateValidatorTest {
         // Set up the question objects:
         someCoordinateQuestion = new IsaacCoordinateQuestion();
         someCoordinateQuestion.setNumberOfDimensions(2);
+        someCoordinateQuestion.setDisregardSignificantFigures(false);
         someCoordinateQuestion.setSignificantFiguresMin(2);
         someCoordinateQuestion.setSignificantFiguresMax(2);
         someCoordinateQuestion.setOrdered(true);
@@ -123,6 +124,20 @@ public class IsaacCoordinateValidatorTest {
 
         assertFalse(response.isCorrect());
         assertEquals(someIncorrectExplanation, response.getExplanation());
+    }
+
+    @Test
+    public final void isaacCoordinateValidator_TestPartiallyIncorrectAnswer() {
+        someCoordinateQuestion.setDisregardSignificantFigures(true);
+
+        // Correct first coordinate, incorrect second coordinate
+        CoordinateChoice c = new CoordinateChoice();
+        c.setItems(List.of(item1, item3));
+
+        QuestionValidationResponse response = validator.validateQuestionResponse(someCoordinateQuestion, c);
+
+        assertFalse(response.isCorrect());
+        assertNull(response.getExplanation());
     }
 
     @Test


### PR DESCRIPTION
This was only verifying the first dimension in each coordinate.