### PR TITLE
Simpler IP location

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ILocationHistory.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/ILocationHistory.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  *
  */
-public interface LocationHistory {
+public interface ILocationHistory {
     /**
      * Get the latest location by an ip address.
      * 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationHistory.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/PgLocationHistory.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  * @author sac92
  *
  */
-public class PgLocationHistory implements LocationHistory {
+public class PgLocationHistory implements ILocationHistory {
     private final PostgresSqlDb database;
     private final ObjectMapper locationSerializer;
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -54,9 +54,9 @@ import uk.ac.cam.cl.dtg.isaac.dao.PgQuizAssignmentPersistenceManager;
 import uk.ac.cam.cl.dtg.isaac.dao.PgQuizAttemptPersistenceManager;
 import uk.ac.cam.cl.dtg.isaac.dao.PgQuizQuestionAttemptPersistenceManager;
 import uk.ac.cam.cl.dtg.isaac.dos.AbstractUserPreferenceManager;
+import uk.ac.cam.cl.dtg.isaac.dos.ILocationHistory;
 import uk.ac.cam.cl.dtg.isaac.dos.IUserAlerts;
 import uk.ac.cam.cl.dtg.isaac.dos.IUserStreaksManager;
-import uk.ac.cam.cl.dtg.isaac.dos.LocationHistory;
 import uk.ac.cam.cl.dtg.isaac.dos.PgLocationHistory;
 import uk.ac.cam.cl.dtg.isaac.dos.PgUserAlerts;
 import uk.ac.cam.cl.dtg.isaac.dos.PgUserPreferenceManager;
@@ -420,7 +420,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
      * Deals with application data managers.
      */
     private void configureApplicationManagers() {
-        bind(LocationHistory.class).to(PgLocationHistory.class);
+        bind(ILocationHistory.class).to(PgLocationHistory.class);
 
         bind(PostCodeLocationResolver.class).to(PostCodeIOLocationResolver.class);
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
@@ -79,14 +79,15 @@ public class LocationManager {
      *             - if there is an IO error
      */
     public void refreshLocation(final String ipAddress) throws SegueDatabaseException, IOException {
-        // do not attempt to record localhost IP addresses:
-        if (ipAddress == null || ipAddress.equals("0:0:0:0:0:0:0:1") || ipAddress.equals("127.0.0.1")) {
-            log.debug("Not geocoding ip address as it looks like localhost: {}", ipAddress);
+        // if the IP is missing or present in our cache, no need to look up again
+        if (ipAddress == null || ipAddress.isEmpty() || locationUpdatedRecentlyCache.getIfPresent(ipAddress) != null) {
             return;
         }
 
-        // if it is present in our cache, no need to look up again
-        if (locationUpdatedRecentlyCache.getIfPresent(ipAddress) != null) {
+        // do not attempt to record localhost IP addresses:
+        if (ipAddress.equals("0:0:0:0:0:0:0:1") || ipAddress.equals("127.0.0.1")) {
+            log.debug("Not geocoding ip address as it looks like localhost: {}", ipAddress);
+            this.locationUpdatedRecentlyCache.put(ipAddress, false);
             return;
         }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
@@ -51,8 +51,7 @@ public class LocationManager implements IPLocationResolver {
     private final LocationHistory dao;
     private final IPLocationResolver ipLocationResolver;
     private final PostCodeLocationResolver postCodeLocationResolver;
-    private final Cache<String, Location> locationCache;
-    private final Cache<String, Location> failedLocationCache;
+    private final Cache<String, Boolean> locationUpdatedRecentlyCache;
 
     /**
      * @param dao
@@ -69,11 +68,8 @@ public class LocationManager implements IPLocationResolver {
         this.ipLocationResolver = ipLocationResolver;
         this.postCodeLocationResolver = postCodeLocationResolver;
 
-        // This cache is here to prevent lots of needless look ups to the database.
-        locationCache = CacheBuilder.newBuilder().expireAfterWrite(NON_PERSISTENT_CACHE_TIME_IN_HOURS, TimeUnit.HOURS)
-                .<String, Location> build();
-        failedLocationCache = CacheBuilder.newBuilder().expireAfterWrite(NON_PERSISTENT_CACHE_TIME_IN_HOURS, TimeUnit.HOURS)
-                .<String, Location> build();
+        // This cache is here to prevent lots of needless look-ups to the database.
+        locationUpdatedRecentlyCache = CacheBuilder.newBuilder().expireAfterWrite(NON_PERSISTENT_CACHE_TIME_IN_HOURS, TimeUnit.HOURS).build();
     }
 
     /**
@@ -87,58 +83,59 @@ public class LocationManager implements IPLocationResolver {
      *             - if there is an IO error
      */
     public void refreshLocation(final String ipAddress) throws SegueDatabaseException, IOException {
-        // special case
-        if (ipAddress == null || ipAddress.startsWith("localhost") || ipAddress.contains("0:0:0:0:0:0:0:1")
-                || ipAddress.contains("127.0.0.1")) {
-            // do not record
+        // do not attempt to record localhost IP addresses:
+        if (ipAddress == null || ipAddress.equals("0:0:0:0:0:0:0:1") || ipAddress.equals("127.0.0.1")) {
             log.debug("Not geocoding ip address as it looks like localhost: {}", ipAddress);
             return;
         }
 
-        // if it is present in a local cache we have no need to hit the database
-        if (locationCache.getIfPresent(ipAddress) != null || failedLocationCache.getIfPresent(ipAddress) != null) {
+        // if it is present in our cache, no need to look up again
+        if (locationUpdatedRecentlyCache.getIfPresent(ipAddress) != null) {
             return;
         }
 
-        // do we have an existing location for this ip address.
+        // if it is a private subnet, lookup will fail, so skip lookup and cache this failure
+        if (ipAddress.startsWith("10.") || ipAddress.startsWith("192.168.")
+                || (ipAddress.startsWith("172.") && ipAddress.matches("^172\\.(?:1[6-9]|2[0-9]|3[01])\\..*"))) {
+            log.debug("Not geocoding ip address as it looks like a private subnet: {}", ipAddress);
+            this.locationUpdatedRecentlyCache.put(ipAddress, false);
+            return;
+        }
+
+        // do we have an existing location for this ip address?
         LocationHistoryEvent latestByIPAddress = dao.getLatestByIPAddress(ipAddress);
-        Location locationToCache;
         try {
             if (latestByIPAddress != null) {
-                locationToCache = latestByIPAddress.getLocationInformation();
                 Calendar locationExpiry = Calendar.getInstance();
                 locationExpiry.setTime(latestByIPAddress.getLastUpdated());
                 locationExpiry.add(Calendar.DATE, LOCATION_UPDATE_FREQUENCY_IN_DAYS);
 
                 if (new Date().after(locationExpiry.getTime())) {
-                    // lookup to see if ip location data is different. If so update it.
-                    log.debug("Performing IP Location lookup.");
-                    Location locationInformation = ipLocationResolver
-                            .resolveAllLocationInformation(ipAddress);
+                    // check if ip location data has changed, and if so update it, else mark it still valid
+                    Location locationInformation = ipLocationResolver.resolveAllLocationInformation(ipAddress);
 
                     if (locationInformation.equals(latestByIPAddress.getLocationInformation())) {
                         dao.updateLocationEventDate(latestByIPAddress.getId(), true);
-                        log.debug("Ip address location is the same. Refreshing.");
+                        log.debug("Location for IP '{}' unchanged. Marking as current.", ipAddress);
 
                     } else {
                         dao.updateLocationEventDate(latestByIPAddress.getId(), false);
-                        locationToCache = dao.storeLocationEvent(ipAddress, locationInformation)
-                                .getLocationInformation();
-                        log.debug("Location Info Different. Updating to new value.");
+                        dao.storeLocationEvent(ipAddress, locationInformation);
+                        log.debug("Location for IP '{}' changed. Updating to new value.", ipAddress);
                     }
                 }
             } else {
                 Location locationInformation = ipLocationResolver.resolveAllLocationInformation(ipAddress);
-                locationToCache = dao.storeLocationEvent(ipAddress, locationInformation).getLocationInformation();
+                dao.storeLocationEvent(ipAddress, locationInformation);
+                log.debug("Recording location for IP '{}'.", ipAddress);
             }
 
-            this.locationCache.put(ipAddress, locationToCache);
-            log.debug("Location Cache currently has {} ip addresses", locationCache.size());
+            this.locationUpdatedRecentlyCache.put(ipAddress, true);
 
-        } catch (LocationServerException e) {
-            log.error("Unable to resolve location for ip address: {}. Skipping...", ipAddress, e);
-            // add it to the ephemeral failed cache for a while so we don't keep asking for an address with no info immediately.
-            this.failedLocationCache.put(ipAddress, new Location(null, 0.0, 0.0));
+        } catch (final LocationServerException e) {
+            log.error("Unable to resolve location for IP address: '{}'. {} ", ipAddress, e.getMessage());
+            // add to failed cache so we don't repeat failed lookups immediately
+            this.locationUpdatedRecentlyCache.put(ipAddress, false);
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
@@ -20,7 +20,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.isaac.dos.LocationHistory;
+import uk.ac.cam.cl.dtg.isaac.dos.ILocationHistory;
 import uk.ac.cam.cl.dtg.isaac.dos.LocationHistoryEvent;
 import uk.ac.cam.cl.dtg.util.locations.IPLocationResolver;
 import uk.ac.cam.cl.dtg.util.locations.Location;
@@ -48,7 +48,7 @@ public class LocationManager implements IPLocationResolver {
     private static final int LOCATION_UPDATE_FREQUENCY_IN_DAYS = 30;
     private static final int NON_PERSISTENT_CACHE_TIME_IN_HOURS = 1;
 
-    private final LocationHistory dao;
+    private final ILocationHistory dao;
     private final IPLocationResolver ipLocationResolver;
     private final PostCodeLocationResolver postCodeLocationResolver;
     private final Cache<String, Boolean> locationUpdatedRecentlyCache;
@@ -62,8 +62,8 @@ public class LocationManager implements IPLocationResolver {
      *            - the external postCode location resolver.
      */
     @Inject
-    public LocationManager(final LocationHistory dao, final IPLocationResolver ipLocationResolver,
-            final PostCodeLocationResolver postCodeLocationResolver) {
+    public LocationManager(final ILocationHistory dao, final IPLocationResolver ipLocationResolver,
+                           final PostCodeLocationResolver postCodeLocationResolver) {
         this.dao = dao;
         this.ipLocationResolver = ipLocationResolver;
         this.postCodeLocationResolver = postCodeLocationResolver;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
@@ -36,14 +36,10 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * LocationHistoryManager. This class is intended to be used to maintain a database of geocoded ip addresses such that
- * we can look up historically where a particular ip address was. This is based on the assumption that ip address
- * allocation change over time.
- * 
- * @author sac92, ags46
+ * This manager governs access to IP and other location lookup services.
  *
  */
-public class LocationManager implements IPLocationResolver {
+public class LocationManager {
     private static final Logger log = LoggerFactory.getLogger(LocationManager.class);
     private static final int LOCATION_UPDATE_FREQUENCY_IN_DAYS = 30;
     private static final int NON_PERSISTENT_CACHE_TIME_IN_HOURS = 1;
@@ -137,12 +133,6 @@ public class LocationManager implements IPLocationResolver {
             // add to failed cache so we don't repeat failed lookups immediately
             this.locationUpdatedRecentlyCache.put(ipAddress, false);
         }
-    }
-
-    @Override
-    public Location resolveAllLocationInformation(final String ipAddress) throws IOException, LocationServerException {
-        return ipLocationResolver.resolveAllLocationInformation(ipAddress);
-
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/LocationManager.java
@@ -145,11 +145,6 @@ public class LocationManager implements IPLocationResolver {
 
     }
 
-    @Override
-    public Location resolveCountryOnly(final String ipAddress) throws IOException, LocationServerException {
-        return ipLocationResolver.resolveCountryOnly(ipAddress);
-    }
-
     /**
      * @param postCodeAndUserIds
      *            - A map of postcodes to userids

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/PgLogManager.java
@@ -268,12 +268,10 @@ public class PgLogManager implements ILogManager {
         }
 
         if (ipAddress != null) {
-            logEvent.setIpAddress(ipAddress.split(",")[0]);
+            logEvent.setIpAddress(ipAddress);
 
             try {
-                // split based on the fact that we usually get ip addresses of the form
-                // [user_ip], [balancer/gateway_ip]
-                locationManager.refreshLocation(ipAddress.split(",")[0]);
+                locationManager.refreshLocation(ipAddress);
             } catch (SegueDatabaseException | IOException e1) {
                 log.error("Unable to record location information for ip Address: {}", ipAddress, e1);
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/IPLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/IPLocationResolver.java
@@ -34,17 +34,4 @@ public interface IPLocationResolver {
      *             - if the server responds with an error.
      */
     Location resolveAllLocationInformation(final String ipAddress) throws IOException, LocationServerException;
-
-    /**
-     * Get a location with only minimal information.
-     * 
-     * @param ipAddress
-     *            that we are trying to convert into a location.
-     * @return a location populated with as much information as possible.
-     * @throws IOException
-     *             -
-     * @throws LocationServerException
-     *             - if the server responds with an error.
-     */
-    Location resolveCountryOnly(final String ipAddress) throws IOException, LocationServerException;
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/MaxMindIPLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/MaxMindIPLocationResolver.java
@@ -47,13 +47,6 @@ public class MaxMindIPLocationResolver implements IPLocationResolver {
         }
     }
 
-    @Override
-    public Location resolveCountryOnly(final String ipAddress) throws IOException, LocationServerException {
-        // It is no additional work to do just load everything.
-        // FIXME; can we just remove this method from the interface?
-        return resolveAllLocationInformation(ipAddress);
-    }
-
     private Location responseToLocation(final CityResponse response) {
 
         Country country = response.getCountry();

--- a/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/locations/PostCodeIOLocationResolver.java
@@ -23,7 +23,7 @@ import com.google.api.client.util.Maps;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.isaac.dos.LocationHistory;
+import uk.ac.cam.cl.dtg.isaac.dos.ILocationHistory;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 
 import jakarta.ws.rs.core.Response;
@@ -52,7 +52,7 @@ public class PostCodeIOLocationResolver implements PostCodeLocationResolver {
     private final String outCodeUrl = "https://api.postcodes.io/outcodes"; // For partial postcodes (e.g. CB3)
     private final int POSTCODEIO_MAX_REQUESTS = 100;
     
-    private final LocationHistory locationHistory;
+    private final ILocationHistory locationHistory;
     private final HttpClient httpClient;
 
     /**
@@ -62,7 +62,7 @@ public class PostCodeIOLocationResolver implements PostCodeLocationResolver {
      *            - the location history so we can access the database of existing post codes
      */
     @Inject
-    public PostCodeIOLocationResolver(final LocationHistory locationHistory) {
+    public PostCodeIOLocationResolver(final ILocationHistory locationHistory) {
         this.locationHistory = locationHistory;
         this.httpClient = HttpClient.newHttpClient();
     }

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/util/PostCodeLocationResolverTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/util/PostCodeLocationResolverTest.java
@@ -15,6 +15,18 @@
  */
 package uk.ac.cam.cl.dtg.segue.util;
 
+import com.google.api.client.util.Maps;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.cam.cl.dtg.isaac.dos.ILocationHistory;
+import uk.ac.cam.cl.dtg.isaac.dos.PgLocationHistory;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
+import uk.ac.cam.cl.dtg.util.locations.LocationServerException;
+import uk.ac.cam.cl.dtg.util.locations.PostCodeIOLocationResolver;
+import uk.ac.cam.cl.dtg.util.locations.PostCodeRadius;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -22,21 +34,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.easymock.EasyMock;
-
-import com.google.api.client.util.Maps;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
-import uk.ac.cam.cl.dtg.isaac.dos.LocationHistory;
-import uk.ac.cam.cl.dtg.isaac.dos.PgLocationHistory;
-import uk.ac.cam.cl.dtg.util.locations.LocationServerException;
-import uk.ac.cam.cl.dtg.util.locations.PostCodeIOLocationResolver;
-import uk.ac.cam.cl.dtg.util.locations.PostCodeRadius;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class PostCodeLocationResolverTest {
 
-    private LocationHistory locationHistory;
+    private ILocationHistory locationHistory;
     private PostCodeIOLocationResolver resolver;
     private PostgresSqlDb mockDatabase;
 


### PR DESCRIPTION
The primary driver for this PR is to reduce the number of exceptions and logged stack traces caused by users on RFC 1918 private subnets when looking up IP address location. However, the code was a mess, so I have neatened it up.