### PR TITLE
Silence azure HTTP client warnings

### DIFF
--- a/src/main/resources/log4j2.yaml
+++ b/src/main/resources/log4j2.yaml
@@ -65,3 +65,6 @@ Configuration:
           additivity: false
           AppenderRef:
             - ref: Audit_Appender
+
+        - name: com.azure.core.http.jdk.httpclient.JdkHttpClient
+          level: error


### PR DESCRIPTION
This is to silence messages about the content-length header. The openjdk http client treats this as restricted, as it wants to calculate it itself, ensuring it's always correct. The azure  wrapper realises this and even unsets the header
(https://github.com/Azure/azure-sdk-for-java/blob/e73510225bf5afd70c4f6b30fc6a2c3add0a9bc9/sdk/clientcore/core/src/main/java12/io/clientcore/core/implementation/http/client/HeaderFilteringMap.java#L53) so an exception is not thrown trying to set it. For some nebulous reason, it also prints a warning. As you can see in HeaderFilteringMap, there's no option to silence just this log. I also think we should avoid setting the system property, as it would make any instance of httpClient less safe.

I've locally tested that errors are still logged (I've made a request fail by setting the restrictedHeaders property to allow content-length in pom.xml. This seems to only affect the property received by the Azure wrapper, but not the underlying http client, and causes the client to throw an exception when it encounters a request with content-length.). I've also verified on `dev` that these warnings are no longer being logged. LLM questions also still work on dev.