### PR TITLE
Reject contact form messages over 5000 characters

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -444,6 +444,7 @@ public final class Constants {
     public static final Integer MAX_SEARCH_RESULT_LIMIT = 350;
 
     public static final Integer SEARCH_TEXT_CHAR_LIMIT = 1000;
+    public static final Integer CONTACT_FORM_CHAR_LIMIT = 5000;
 
     public static final Integer NO_SEARCH_LIMIT = -1;
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/ContactFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/ContactFacade.java
@@ -104,6 +104,11 @@ public class ContactFacade extends AbstractSegueFacade {
             return error.toResponse();
         }
 
+        if (form.get("message").length() > CONTACT_FORM_CHAR_LIMIT) {
+            SegueErrorResponse error = new SegueErrorResponse(Status.BAD_REQUEST, "Your message is too long!");
+            return error.toResponse();
+        }
+
         try {
             String currentUserId;
             String currentUserRole;


### PR DESCRIPTION
This should be prevented by the frontend (see https://github.com/isaacphysics/isaac-react-app/pull/2120) when the contact form is used normally, but we should reject the request if this endpoint is accessed another way with a message that is too long.