### PR TITLE
Stop LLMFreeTextQuestions from generating choices-based content warnings

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -992,7 +992,7 @@ public class ContentIndexer {
         }
 
         if (content instanceof ChoiceQuestion question
-                && !(content.getType().equals("isaacQuestion"))) {
+                && !(content.getType().equals("isaacQuestion") || content.getType().equals("isaacLLMFreeTextQuestion"))) {
 
             if (question.getChoices() == null || question.getChoices().isEmpty()) {
                 this.registerContentProblem(question,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -17,18 +17,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacCard;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacCardDeck;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacClozeQuestion;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacCoordinateQuestion;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacDndQuestion;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacEventPage;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacNumericQuestion;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuestionBase;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuiz;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacQuizSection;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacSymbolicChemistryQuestion;
-import uk.ac.cam.cl.dtg.isaac.dos.IsaacSymbolicQuestion;
+import uk.ac.cam.cl.dtg.isaac.dos.*;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ChemicalFormula;
 import uk.ac.cam.cl.dtg.isaac.dos.content.Choice;
 import uk.ac.cam.cl.dtg.isaac.dos.content.ChoiceQuestion;
@@ -1200,6 +1189,14 @@ public class ContentIndexer {
                         }
                     }
                 }
+            }
+        }
+
+        if (content instanceof IsaacLLMFreeTextQuestion q) {
+            if (null == q.getMarkScheme() || q.getMarkScheme().isEmpty()) {
+                this.registerContentProblem(content,
+                        String.format("LLM Free Text Question: %s has no mark scheme set. This question cannot be marked.", q.getId()),
+                    indexProblemCache);
             }
         }
     }


### PR DESCRIPTION
`isaacLLMFreeTextQuestion`s do not require a `choices` field, since they use a `markScheme` as its equivalent. 
We should therefore not be giving a warning when the `choices` field is missing.