### PR TITLE
Prevent caching of board if `isBoardLinkedToUser` has changed

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -235,6 +235,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
 
         try {
             GameboardDTO gameboard;
+            boolean isLinked = false;
 
             AbstractSegueUserDTO randomUser = this.userManager.getCurrentUser(httpServletRequest);
 
@@ -251,11 +252,15 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             } else {
                 List<String> gameboardPageIds = unAugmentedGameboard.getContents().stream().map(GameboardItem::getId).collect(Collectors.toList());
                 userQuestionAttempts = this.questionManager.getMatchingLightweightQuestionAttempts((RegisteredUserDTO) randomUser, gameboardPageIds);
+                isLinked = gameManager.isBoardLinkedToUser((RegisteredUserDTO) randomUser, unAugmentedGameboard.getId());
             }
 
             // Calculate the ETag
             EntityTag etag = new EntityTag(unAugmentedGameboard.toString().hashCode()
-                    + userQuestionAttempts.toString().hashCode() + "");
+                    + userQuestionAttempts.toString().hashCode()
+                    + Boolean.hashCode(isLinked)
+                    + ""
+            );
 
             Response cachedResponse = generateCachedResponse(request, etag, NEVER_CACHE_WITHOUT_ETAG_CHECK);
             if (cachedResponse != null) {
@@ -263,6 +268,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             }
 
             // attempt to augment the gameboard with user information.
+            // FIXME isBoardLinkedToUser gets called a second time here
             gameboard = gameManager.getGameboard(gameboardId, randomUser, userQuestionAttempts);
 
             // We decided not to log this on the backend as the front end uses this lots.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -958,7 +958,7 @@ public class GameManager {
      * @throws SegueDatabaseException
      *             if there is a database error
      */
-    private boolean isBoardLinkedToUser(final RegisteredUserDTO user, final String gameboardId)
+    public boolean isBoardLinkedToUser(final RegisteredUserDTO user, final String gameboardId)
             throws SegueDatabaseException {
         Set<String> linkedIds = this.gameboardPersistenceManager
                 .getGameboardIdsLinkedToUser(user.getId(), Collections.singleton(gameboardId));


### PR DESCRIPTION
Prevents the server returning the same board without the mutation applied if `isBoardLinkedToUser` has changed.