### PR TITLE
Restore access to deprecated content

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/PagesFacade.java
@@ -210,7 +210,8 @@ public class PagesFacade extends AbstractIsaacFacade {
         }
 
         try {
-            BooleanInstruction searchInstruction = this.contentManager.getBaseSearchInstructionBuilder().build();
+            BooleanInstruction searchInstruction = this.contentManager.getBaseSearchInstructionBuilder()
+                    .excludeDeprecatedContent(true).build();
             searchInstruction.must(new MatchInstruction(TYPE_FIELDNAME, CONCEPT_TYPE));
 
             if (idsList != null && !idsList.isEmpty()) {
@@ -1192,7 +1193,8 @@ public class PagesFacade extends AbstractIsaacFacade {
         }
 
         try {
-            BooleanInstruction searchInstruction = this.contentManager.getBaseSearchInstructionBuilder().build();
+            BooleanInstruction searchInstruction = this.contentManager.getBaseSearchInstructionBuilder()
+                    .excludeDeprecatedContent(true).build();
 
             searchInstruction.must(new MatchInstruction(TYPE_FIELDNAME, POD_FRAGMENT_TYPE));
             searchInstruction.must(new MatchInstruction(TAGS_FIELDNAME, subject));

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventsManager.java
@@ -93,6 +93,8 @@ public class EventsManager {
             searchInstructionBuilder.includeHiddenContent(true);
         }
 
+        searchInstructionBuilder.excludeDeprecatedContent(true);
+
         final Map<String, Constants.SortOrder> sortInstructions = Maps.newHashMap();
         if (sortOrder != null && sortOrder.equals("title")) {
             sortInstructions.put(TITLE_FIELDNAME + "." + UNPROCESSED_SEARCH_FIELD_SUFFIX,
@@ -131,6 +133,7 @@ public class EventsManager {
         // This is only used for a staff-only endpoint, so always include nofilter content
         IsaacSearchInstructionBuilder searchInstructionBuilder = this.contentManager.getBaseSearchInstructionBuilder()
                 .includeHiddenContent(true)
+                .excludeDeprecatedContent(true)
                 .includeContentTypes(Collections.singleton(EVENT_TYPE));
 
         final Map<String, Constants.SortOrder> sortInstructions = Maps.newHashMap();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/QuizManager.java
@@ -82,7 +82,7 @@ public class QuizManager {
                                                                  @Nullable final Integer limit, final boolean showNoFilterQuizzes) throws ContentManagerException {
 
         BooleanInstruction searchInstruction = this.contentManager.getBaseSearchInstructionBuilder()
-                .includeHiddenContent(showNoFilterQuizzes).build();
+                .excludeDeprecatedContent(true).includeHiddenContent(showNoFilterQuizzes).build();
 
         searchInstruction.must(new MatchInstruction(TYPE_FIELDNAME, QUIZ_TYPE));
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -345,6 +345,9 @@ public class GitContentManager {
                 // Restrict content types
                 .includeContentTypes(contentTypes)
 
+                // Exclude deprecated content
+                .excludeDeprecatedContent(true)
+
                 // High priority matches on untokenised search string
                 .searchFor(new SearchInField(Constants.ID_FIELDNAME + "."
                         + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX, Collections.singleton(searchString))
@@ -440,6 +443,9 @@ public class GitContentManager {
 
                 // Filter superseded questions if necessary:
                 .excludeSupersededContent(!showSupersededContent)
+
+                // Always exclude deprecated content:
+                .excludeDeprecatedContent(true)
 
                 // Restrict content types
                 .includeContentTypes(contentTypes)

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/IsaacSearchInstructionBuilder.java
@@ -43,6 +43,7 @@ public class IsaacSearchInstructionBuilder {
     private final boolean excludeRegressionTestContent;
     private boolean excludeNofilterContent;
     private boolean excludeSupersededContent;
+    private boolean excludeDeprecatedContent;
     private Constants.EventFilterOption eventFilterOption;
 
     private Set<String> includedContentTypes;
@@ -121,6 +122,7 @@ public class IsaacSearchInstructionBuilder {
         this.excludeNofilterContent = excludeNofilterContent;
         this.eventFilterOption = Constants.EventFilterOption.FUTURE;
         this.excludeSupersededContent = false;
+        this.excludeDeprecatedContent = false;
     }
 
     /**
@@ -131,7 +133,7 @@ public class IsaacSearchInstructionBuilder {
      * @param instruction The existing master instruction to augment with these base instructions.
      * @return The augmented instruction.
      */
-    public BooleanInstruction buildBaseInstructions(final BooleanInstruction instruction) {
+    private BooleanInstruction buildBaseInstructions(final BooleanInstruction instruction) {
         // Exclude unpublished content (based on config)
         if (this.includeOnlyPublishedContent) {
             instruction.must(new MatchInstruction(Constants.PUBLISHED_FIELDNAME, "true"));
@@ -148,7 +150,9 @@ public class IsaacSearchInstructionBuilder {
         }
 
         // Exclude deprecated content
-        instruction.mustNot(new MatchInstruction(Constants.DEPRECATED_FIELDNAME, "true"));
+        if (this.excludeDeprecatedContent) {
+            instruction.mustNot(new MatchInstruction(Constants.DEPRECATED_FIELDNAME, "true"));
+        }
 
         // Exclude superseded content
         if (this.excludeSupersededContent) {
@@ -214,6 +218,17 @@ public class IsaacSearchInstructionBuilder {
 
     public IsaacSearchInstructionBuilder excludeSupersededContent(final boolean excludeSupersededContent) {
         this.excludeSupersededContent = excludeSupersededContent;
+        return this;
+    }
+
+    /**
+     * Sets whether to exclude deprecated content in the results. Defaults to including such content.
+     *
+     * @param excludeDeprecatedContent Whether to include deprecated content in the results.
+     * @return This IsaacSearchInstructionBuilder, to allow chained operations.
+     */
+    public IsaacSearchInstructionBuilder excludeDeprecatedContent(final boolean excludeDeprecatedContent) {
+        this.excludeDeprecatedContent = excludeDeprecatedContent;
         return this;
     }
 


### PR DESCRIPTION
Fixes a regression introduced following https://github.com/isaacphysics/isaac-api/pull/794 that prevents deprecated content from being loaded in places where it should be available.

This changes the base search building instructions to include deprecated content by default. This can then be overridden on a case-by-case basis using the `excludeDeprecatedContent` setter.

Deprecated content is now **included** for:
- `getEventMapData` (it doesn't need to be included here, but we don't use (and plan to remove) the endpoint that calls this anyway)
- Getting DOs/DTOs by ID, which is the case that actually needs to be fixed

Deprecated content remains **excluded** for the following, to match the previous behaviour:
- Question search
    - Note that _superseded_ but not deprecated questions are still shown for teachers+, in keeping with how this worked before
- Site search
- Listing concepts
- Listing events & event overviews
- Listing subject pods
- Listing quizzes

