### PR TITLE
Include user linked info for user's set boards

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -295,6 +295,8 @@ public class AssignmentFacade extends AbstractIsaacFacade {
                 List<AssignmentDTO> assignments = this.assignmentManager.getAllAssignmentsForSpecificGroups(allGroupsOwnedAndManagedByUser, true);
                 Set<String> gameboardIds = assignments.stream().map(AssignmentDTO::getGameboardId).collect(Collectors.toSet());
                 List<GameboardDTO> liteGameboards = this.gameManager.getLiteGameboards(gameboardIds);
+                gameManager.augmentGameboardsWithLinkedToUserInformation(currentlyLoggedInUser, liteGameboards);
+
                 // Remove unneeded data from the gameboards - very messy but not as messy as feasible alternatives
                 liteGameboards.forEach(g -> {
                     g.setContents(null);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -149,8 +149,8 @@ public class GameboardsFacade extends AbstractIsaacFacade {
 
             AbstractSegueUserDTO randomUser = this.userManager.getCurrentUser(httpServletRequest);
 
-            GameboardDTO unAugmentedGameboard = gameManager.getLiteGameboard(gameboardId);
-            if (null == unAugmentedGameboard) {
+            GameboardDTO gameboardWithoutAttemptInfo = gameManager.getLiteGameboard(gameboardId);
+            if (null == gameboardWithoutAttemptInfo) {
                 return new SegueErrorResponse(Status.NOT_FOUND, "No Gameboard found for the id specified.")
                         .toResponse();
             }
@@ -160,15 +160,14 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             if (randomUser instanceof AnonymousUserDTO) {
                 userQuestionAttempts = this.questionManager.getQuestionAttemptsByUser(randomUser);
             } else {
-                List<String> gameboardPageIds = unAugmentedGameboard.getContents().stream().map(GameboardItem::getId).collect(Collectors.toList());
+                List<String> gameboardPageIds = gameboardWithoutAttemptInfo.getContents().stream().map(GameboardItem::getId).collect(Collectors.toList());
                 userQuestionAttempts = this.questionManager.getMatchingLightweightQuestionAttempts((RegisteredUserDTO) randomUser, gameboardPageIds);
-                isLinked = gameManager.isBoardLinkedToUser((RegisteredUserDTO) randomUser, unAugmentedGameboard.getId());
+                gameManager.augmentGameboardsWithLinkedToUserInformation((RegisteredUserDTO) randomUser, Collections.singletonList(gameboardWithoutAttemptInfo));
             }
 
             // Calculate the ETag
-            EntityTag etag = new EntityTag(unAugmentedGameboard.toString().hashCode()
+            EntityTag etag = new EntityTag(gameboardWithoutAttemptInfo.toString().hashCode()
                     + userQuestionAttempts.toString().hashCode()
-                    + Boolean.hashCode(isLinked)
                     + ""
             );
 
@@ -178,7 +177,6 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             }
 
             // attempt to augment the gameboard with user information.
-            // FIXME isBoardLinkedToUser gets called a second time here
             gameboard = gameManager.getGameboard(gameboardId, randomUser, userQuestionAttempts);
 
             // We decided not to log this on the backend as the front end uses this lots.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -177,6 +177,7 @@ public class GameboardsFacade extends AbstractIsaacFacade {
             }
 
             // attempt to augment the gameboard with user information.
+            // FIXME augmentGameboardsWithLinkedToUserInformation gets called a second time here
             gameboard = gameManager.getGameboard(gameboardId, randomUser, userQuestionAttempts);
 
             // We decided not to log this on the backend as the front end uses this lots.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -335,7 +335,7 @@ public class GameManager {
 
         // we need to augment the DTO with whether this gameboard is in a users my boards list.
         if (user instanceof RegisteredUserDTO registeredUser) {
-            gameboard.setSavedToCurrentUser(isBoardLinkedToUser(registeredUser, gameboardId));
+            augmentGameboardsWithLinkedToUserInformation(registeredUser, Collections.singletonList(gameboard));
         }
 
         return gameboard;
@@ -865,17 +865,21 @@ public class GameManager {
      * 
      * @param user
      *            to check
-     * @param gameboardId
-     *            to look up
-     * @return true if it is false if not
+     * @param gameboards
+     *            to augment
      * @throws SegueDatabaseException
      *             if there is a database error
      */
-    public boolean isBoardLinkedToUser(final RegisteredUserDTO user, final String gameboardId)
+
+    public void augmentGameboardsWithLinkedToUserInformation(final RegisteredUserDTO user, final Collection<GameboardDTO> gameboards)
             throws SegueDatabaseException {
-        Set<String> linkedIds = this.gameboardPersistenceManager
-                .getGameboardIdsLinkedToUser(user.getId(), Collections.singleton(gameboardId));
-        return linkedIds.contains(gameboardId);
+        Set<String> linkedIds = this.gameboardPersistenceManager.getGameboardIdsLinkedToUser(
+                user.getId(),
+                gameboards.stream().map(GameboardDTO::getId).collect(Collectors.toSet())
+        );
+        gameboards.forEach(gameboard -> gameboard.setSavedToCurrentUser(
+                linkedIds.contains(gameboard.getId())
+        ));
     }
     
     /**


### PR DESCRIPTION
Modifies `isBoardLinkedToUser` to instead augment a provided list of boards with this information. Tidies up some related code surrounding the old method.