### PR TITLE
Endpoint for skills on my progress

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
@@ -12,7 +12,10 @@ import uk.ac.cam.cl.dtg.isaac.dto.AnvilMarkingRequestDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.AnvilPayloadDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.isaac.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.isaac.dto.users.UserSummaryDTO;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
+import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
+import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
 import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserLoggedInException;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
@@ -42,6 +45,8 @@ public class SkillsFacade extends AbstractIsaacFacade {
     private final UserAccountManager userManager;
     private final GitContentManager contentManager;
     private final SkillsAttemptManager skillsAttemptManager;
+    private final UserAssociationManager userAssociationManager;
+
 
     /**
      * Constructor.
@@ -49,11 +54,13 @@ public class SkillsFacade extends AbstractIsaacFacade {
     @Inject
     public SkillsFacade(final AbstractConfigLoader properties, final UserAccountManager userManager,
                         final ILogManager logManager, final GitContentManager contentManager,
-                        final SkillsAttemptManager skillsAttemptManager) {
+                        final SkillsAttemptManager skillsAttemptManager,
+                        final UserAssociationManager userAssociationManager) {
         super(properties, logManager);
         this.userManager = userManager;
         this.contentManager = contentManager;
         this.skillsAttemptManager = skillsAttemptManager;
+        this.userAssociationManager = userAssociationManager;
     }
 
     /**
@@ -115,18 +122,42 @@ public class SkillsFacade extends AbstractIsaacFacade {
         }
     }
 
+    /**
+     * Endpoint to server a user's skill attempt history.
+     *
+     * @param request
+     *            - the servlet request so we can find out if it is a known user.
+     * @param userIdOfInterest
+     *            - the user whose history we're viewing
+     */
     @GET
     @Path("/attempts/{userId}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAttempts(@Context final HttpServletRequest request,
-                                @PathParam("userId") final String appId) {
+                                @PathParam("userId") final Long userIdOfInterest) {
         try {
             RegisteredUserDTO currentUser = userManager.getCurrentRegisteredUser(request);
+            UserSummaryDTO userOfInterestSummaryObject = userManager.convertToUserSummaryObject(
+                userManager.getUserDTOById(userIdOfInterest)
+            );
+
+            // decide if the user is allowed to view this data. If user isn't viewing their own data, user viewing
+            // must have a valid connection with the user of interest and be at least a teacher.
+            if (!currentUser.getId().equals(userIdOfInterest)
+                    && !userAssociationManager.hasTeacherPermission(currentUser, userOfInterestSummaryObject)) {
+                return SegueErrorResponse.getIncorrectRoleResponse();
+            }
 
             return Response.ok("OK").build();
         } catch (final NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
+        } catch (final NoUserException e) {
+            return SegueErrorResponse.getIncorrectRoleResponse();
+        } catch (final SegueDatabaseException e) {
+            var error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Something went wrong.");
+            log.error(error.getErrorMessage());
+            return error.toResponse();
         }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
@@ -154,7 +154,7 @@ public class SkillsFacade extends AbstractIsaacFacade {
 
             HashMap<String, Map<LocalDate, Long>> resultsMap = new HashMap<>();
             resultsMap.put("mental_maths_overall", skillsAttemptManager.getMentalMathsAttempts(
-                LocalDate.now().withDayOfMonth(1).minusMonths(11), LocalDate.now()
+                userIdOfInterest, LocalDate.now().withDayOfMonth(1).minusMonths(11), LocalDate.now()
             ));
             return Response.ok(resultsMap).build();
         } catch (final NoUserLoggedInException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
@@ -22,6 +22,7 @@ import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -111,6 +112,21 @@ public class SkillsFacade extends AbstractIsaacFacade {
             var error = new SegueErrorResponse(Status.NOT_FOUND, "Error locating the version requested.", e);
             log.error(error.getErrorMessage(), e);
             return error.toResponse();
+        }
+    }
+
+    @GET
+    @Path("/attempts/{userId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAttempts(@Context final HttpServletRequest request,
+                                @PathParam("userId") final String appId) {
+        try {
+            RegisteredUserDTO currentUser = userManager.getCurrentRegisteredUser(request);
+
+            return Response.ok("OK").build();
+        } catch (final NoUserLoggedInException e) {
+            return SegueErrorResponse.getNotLoggedInResponse();
         }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
@@ -34,7 +34,10 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /** Skills Facade, supports interaction related to the Isaac Skill Practice apps. */
 @Path("/skills")
@@ -90,13 +93,13 @@ public class SkillsFacade extends AbstractIsaacFacade {
                 return error.toResponse();
             }
 
-            if (!skillsAttemptManager.isHmacValid(markingRequest)) {
+            if (!skillsAttemptManager.isAttemptHmacValid(markingRequest)) {
                 var error = new SegueErrorResponse(Status.BAD_REQUEST, "Invalid HMAC signature.");
                 log.warn(error.getErrorMessage());
                 return error.toResponse();
             }
 
-            List<AnvilPayloadDTO> payloadDTOs = skillsAttemptManager.parsePayload(
+            List<AnvilPayloadDTO> payloadDTOs = skillsAttemptManager.parseAttemptsPayload(
                 markingRequest.getPayload(), currentUser.getId(), appId);
             skillsAttemptManager.recordAttempt(payloadDTOs);
 
@@ -123,7 +126,7 @@ public class SkillsFacade extends AbstractIsaacFacade {
     }
 
     /**
-     * Endpoint to server a user's skill attempt history.
+     * Endpoint to serve a user's skill attempt history. For now, it's hardcoded to just the mental maths app.
      *
      * @param request
      *            - the servlet request so we can find out if it is a known user.
@@ -149,14 +152,18 @@ public class SkillsFacade extends AbstractIsaacFacade {
                 return SegueErrorResponse.getIncorrectRoleResponse();
             }
 
-            return Response.ok("OK").build();
+            HashMap<String, Map<LocalDate, Long>> resultsMap = new HashMap<>();
+            resultsMap.put("mental_maths_overall", skillsAttemptManager.getMentalMathsAttempts(
+                LocalDate.now().minusYears(1), LocalDate.now()
+            ));
+            return Response.ok(resultsMap).build();
         } catch (final NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (final NoUserException e) {
             return SegueErrorResponse.getIncorrectRoleResponse();
         } catch (final SegueDatabaseException e) {
             var error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Something went wrong.");
-            log.error(error.getErrorMessage());
+            log.error(error.getErrorMessage(), e);
             return error.toResponse();
         }
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
@@ -154,7 +154,9 @@ public class SkillsFacade extends AbstractIsaacFacade {
 
             HashMap<String, Map<LocalDate, Long>> resultsMap = new HashMap<>();
             resultsMap.put("mental_maths_overall", skillsAttemptManager.getMentalMathsAttempts(
-                userIdOfInterest, LocalDate.now().withDayOfMonth(1).minusMonths(11), LocalDate.now()
+                userIdOfInterest,
+                LocalDate.now().withDayOfMonth(1).minusMonths(11),
+                LocalDate.now().withDayOfMonth(1).plusMonths(1).minusDays(1)
             ));
             return Response.ok(resultsMap).build();
         } catch (final NoUserLoggedInException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
@@ -154,7 +154,7 @@ public class SkillsFacade extends AbstractIsaacFacade {
 
             HashMap<String, Map<LocalDate, Long>> resultsMap = new HashMap<>();
             resultsMap.put("mental_maths_overall", skillsAttemptManager.getMentalMathsAttempts(
-                LocalDate.now().minusMonths(11), LocalDate.now()
+                LocalDate.now().withDayOfMonth(1).minusMonths(11), LocalDate.now()
             ));
             return Response.ok(resultsMap).build();
         } catch (final NoUserLoggedInException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
@@ -154,7 +154,7 @@ public class SkillsFacade extends AbstractIsaacFacade {
 
             HashMap<String, Map<LocalDate, Long>> resultsMap = new HashMap<>();
             resultsMap.put("mental_maths_overall", skillsAttemptManager.getMentalMathsAttempts(
-                LocalDate.now().minusYears(1), LocalDate.now()
+                LocalDate.now().minusMonths(11), LocalDate.now()
             ));
             return Response.ok(resultsMap).build();
         } catch (final NoUserLoggedInException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
@@ -98,14 +98,14 @@ public class SkillsAttemptManager {
     }
 
     /**
-     * Returns a users attempts in the mental maths skills app.
+     * Returns a user's attempts in the mental maths skills app.
      *
      * @param from - return attempts starting from this date (inclusive)
      *
      * @param to - return attempts until this date (exclusive)
      */
-    public Map<LocalDate, Long> getMentalMathsAttempts(final LocalDate from, final LocalDate to)
+    public Map<LocalDate, Long> getMentalMathsAttempts(final Long userId, final LocalDate from, final LocalDate to)
         throws SegueDatabaseException {
-        return persistence.getMentalMathsAttempts(from, to);
+        return persistence.getMentalMathsAttempts(userId, from, to);
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
@@ -25,7 +25,7 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 public class SkillsAttemptManager {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final int MAX_PAYLOAD_LENGTH = 30 * 1024; // about 30 kilobytes for English payloads, even Unicode
-    public static final long FIVE_MINUTES_IN_MILLIS = 300_000L;
+    public static long FIVE_MINUTES_IN_MILLIS = 300_000L;
 
     private final String hmacSecret;
     private final ISkillsAttemptPersistenceManager persistence;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
@@ -12,8 +12,10 @@ import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.util.AbstractConfigLoader;
 
 import java.security.MessageDigest;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 
@@ -47,7 +49,7 @@ public class SkillsAttemptManager {
      * @param dto - the parsed marking request
      * @return whether the hmac was valid
      */
-    public boolean isHmacValid(final AnvilMarkingRequestDTO dto) {
+    public boolean isAttemptHmacValid(final AnvilMarkingRequestDTO dto) {
         String expected = UserAuthenticationManager.calculateHMAC(hmacSecret, dto.getPayload());
         return MessageDigest.isEqual(expected.getBytes(), dto.getHmac().getBytes());
     }
@@ -60,7 +62,7 @@ public class SkillsAttemptManager {
      * @param appId      - the app ID from the URL, which must match the payload's skill_id
      * @throws InvalidAnvilMarkingRequestException if the payload is malformed or any validation fails
      */
-    public List<AnvilPayloadDTO> parsePayload(
+    public List<AnvilPayloadDTO> parseAttemptsPayload(
         final String payloadStr, final long userId, final String appId
     ) throws InvalidAnvilMarkingRequestException {
         try {
@@ -93,5 +95,17 @@ public class SkillsAttemptManager {
     public void recordAttempt(final List<AnvilPayloadDTO> attempt)
             throws DuplicateSkillsAttemptException, SegueDatabaseException {
         persistence.registerSkillsAttempt(attempt);
+    }
+
+    /**
+     * Returns a users attempts in the mental maths skills app.
+     *
+     * @param from - return attempts starting from this date (inclusive)
+     *
+     * @param to - return attempts until this date (exclusive)
+     */
+    public Map<LocalDate, Long> getMentalMathsAttempts(final LocalDate from, final LocalDate to)
+        throws SegueDatabaseException {
+        return persistence.getMentalMathsAttempts(from, to);
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -66,9 +66,8 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
         throws SegueDatabaseException {
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement("""
-                WITH dates AS (
-                    SELECT gen_date::DATE AS dt
-                    FROM generate_series(date_trunc('month', ?), ?, INTERVAL '1' MONTH) m(gen_date)
+                WITH dates(dt) AS (
+                    SELECT generate_series(?, ?, INTERVAL '1' MONTH)::DATE
                 ), attempts AS (
                     SELECT
                         DATE_TRUNC('month', timestamp::DATE) AS dt,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -73,7 +73,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
                         DATE_TRUNC('month', timestamp::DATE) AS dt,
                         COUNT(1) AS cnt
                     FROM skills_question_attempts AS qa
-                    WHERE user_id = ?
+                    WHERE user_id = ? AND timestamp >= ?
                     GROUP BY dt
                 )
                 SELECT
@@ -87,6 +87,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
             pst.setObject(1, from);
             pst.setObject(2, to);
             pst.setLong(3, userId);
+            pst.setObject(4, from);
             ResultSet results = pst.executeQuery();
             HashMap<LocalDate, Long> resultsMap = new HashMap<>();
             while (results.next()) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -62,7 +62,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
     }
 
     @Override
-    public Map<LocalDate, Long> getMentalMathsAttempts(final LocalDate from, final LocalDate to)
+    public Map<LocalDate, Long> getMentalMathsAttempts(final Long userId, final LocalDate from, final LocalDate to)
         throws SegueDatabaseException {
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement("""
@@ -73,6 +73,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
                         DATE_TRUNC('month', timestamp::DATE) AS dt,
                         COUNT(1) AS cnt
                     FROM skills_question_attempts AS qa
+                    WHERE user_id = ?
                     GROUP BY dt
                 )
                 SELECT
@@ -85,6 +86,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
         ) {
             pst.setObject(1, from);
             pst.setObject(2, to);
+            pst.setLong(3, userId);
             ResultSet results = pst.executeQuery();
             HashMap<LocalDate, Long> resultsMap = new HashMap<>();
             while (results.next()) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -75,7 +75,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
             ResultSet results = pst.executeQuery();
             HashMap<LocalDate, Long> resultsMap = new HashMap<>();
             while (results.next()) {
-                resultsMap.put(LocalDate.parse(results.getString("dt")), results.getLong("cnt"));
+                resultsMap.put(results.getObject("dt", LocalDate.class), results.getLong("cnt"));
             }
             return resultsMap;
         } catch (final SQLException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -68,8 +68,8 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
         throws SegueDatabaseException {
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement("""
-                WITH dates(dt) AS (
-                    SELECT generate_series(?, ?, INTERVAL '1' MONTH)::DATE
+                WITH dates AS (
+                    SELECT generate_series(?, ?, INTERVAL '1' MONTH)::DATE AS dt
                 ), attempts AS (
                     SELECT
                         DATE_TRUNC('month', timestamp::DATE) AS dt,

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -75,7 +75,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
                         DATE_TRUNC('month', timestamp::DATE) AS dt,
                         COUNT(1) AS cnt
                     FROM skills_question_attempts
-                    WHERE user_id = ? AND timestamp >= ? AND skill_id = ?
+                    WHERE user_id = ? AND timestamp >= ? AND skill_id = ? AND LENGTH(question_attempt->>'result') > 0
                     GROUP BY dt
                 )
                 SELECT

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 /** PostgreSQL-backed persistence for Anvil skills question attempts. */
 public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersistenceManager {
+    private static final String MENTAL_MATHS_ID = "app_page_mental_maths_overall|0e184f9d-b619-4225-ac12-3c96d3c74046";
+
     private final PostgresSqlDb database;
 
     @Inject
@@ -72,8 +74,8 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
                     SELECT
                         DATE_TRUNC('month', timestamp::DATE) AS dt,
                         COUNT(1) AS cnt
-                    FROM skills_question_attempts AS qa
-                    WHERE user_id = ? AND timestamp >= ?
+                    FROM skills_question_attempts
+                    WHERE user_id = ? AND timestamp >= ? AND skill_id = ?
                     GROUP BY dt
                 )
                 SELECT
@@ -88,6 +90,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
             pst.setObject(2, to);
             pst.setLong(3, userId);
             pst.setObject(4, from);
+            pst.setString(5, MENTAL_MATHS_ID);
             ResultSet results = pst.executeQuery();
             HashMap<LocalDate, Long> resultsMap = new HashMap<>();
             while (results.next()) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -8,10 +8,15 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ISkillsAttemptPersistenceManager;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /** PostgreSQL-backed persistence for Anvil skills question attempts. */
 public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersistenceManager {
@@ -53,6 +58,28 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
                 throw new DuplicateSkillsAttemptException(null);
             }
             throw new SegueDatabaseException("Something went wrong saving the attempt.");
+        }
+    }
+
+    @Override
+    public Map<LocalDate, Long> getMentalMathsAttempts(final LocalDate from, final LocalDate to)
+        throws SegueDatabaseException {
+        try (Connection conn = database.getDatabaseConnection();
+             PreparedStatement pst = conn.prepareStatement("""
+                SELECT gen_date::DATE AS dt, 0 AS cnt
+                FROM generate_series(date_trunc('month', ?), ?, INTERVAL '1' MONTH) m(gen_date)"""
+             )
+        ) {
+            pst.setObject(1, from);
+            pst.setObject(2, to);
+            ResultSet results = pst.executeQuery();
+            HashMap<LocalDate, Long> resultsMap = new HashMap<>();
+            while (results.next()) {
+                resultsMap.put(LocalDate.parse(results.getString("dt")), results.getLong("cnt"));
+            }
+            return resultsMap;
+        } catch (final SQLException e) {
+            throw new SegueDatabaseException("Something went wrong querying the attempts.", e);
         }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -66,8 +66,22 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
         throws SegueDatabaseException {
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement("""
-                SELECT gen_date::DATE AS dt, 0 AS cnt
-                FROM generate_series(date_trunc('month', ?), ?, INTERVAL '1' MONTH) m(gen_date)"""
+                WITH dates AS (
+                    SELECT gen_date::DATE AS dt
+                    FROM generate_series(date_trunc('month', ?), ?, INTERVAL '1' MONTH) m(gen_date)
+                ), attempts AS (
+                    SELECT
+                        DATE_TRUNC('month', timestamp::DATE) AS dt,
+                        COUNT(1) AS cnt
+                    FROM skills_question_attempts AS qa
+                    GROUP BY dt
+                )
+                SELECT
+                    dates.dt AS dt,
+                    COALESCE(attempts.cnt, 0) AS cnt
+                FROM dates
+                LEFT JOIN attempts USING (dt)
+                """
              )
         ) {
             pst.setObject(1, from);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISkillsAttemptPersistenceManager.java
@@ -4,10 +4,15 @@ import uk.ac.cam.cl.dtg.isaac.api.managers.DuplicateSkillsAttemptException;
 import uk.ac.cam.cl.dtg.isaac.dto.AnvilPayloadDTO;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 /** Persistence interface for recording Anvil skills question attempts. */
 public interface ISkillsAttemptPersistenceManager {
     void registerSkillsAttempt(final List<AnvilPayloadDTO> attempt)
-            throws DuplicateSkillsAttemptException, SegueDatabaseException;
+        throws DuplicateSkillsAttemptException, SegueDatabaseException;
+
+    Map<LocalDate, Long> getMentalMathsAttempts(final LocalDate from, final LocalDate to)
+        throws SegueDatabaseException;
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISkillsAttemptPersistenceManager.java
@@ -13,6 +13,6 @@ public interface ISkillsAttemptPersistenceManager {
     void registerSkillsAttempt(final List<AnvilPayloadDTO> attempt)
         throws DuplicateSkillsAttemptException, SegueDatabaseException;
 
-    Map<LocalDate, Long> getMentalMathsAttempts(final LocalDate from, final LocalDate to)
+    Map<LocalDate, Long> getMentalMathsAttempts(final Long userId, final LocalDate from, final LocalDate to)
         throws SegueDatabaseException;
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ElasticSearchTestHelper.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ElasticSearchTestHelper.java
@@ -43,7 +43,9 @@ public class ElasticSearchTestHelper {
 
     /** Indexes a raw JSON content object with a fixed ID of {@code "i1"} and returns it. */
     public JSONObject persistJSON(final JSONObject contentJSON) throws Exception {
-        contentJSON.put("id", "i1");
+        if (!contentJSON.has("id")) {
+            contentJSON.put("id", "i1");
+        }
         elasticSearchProvider.bulkIndexWithIDs(
             contentManager.getCurrentContentSHA(),
             "content",

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -434,6 +434,38 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             assertPastYearsMonthlyMathsResults(response, ImmutableList.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1));
         }
 
+        @Test
+        public void futureAttemptsWithinMonth_counted() throws Exception {
+            prepare();
+            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            var firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
+            studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                            .put("timestamp",  firstDayOfMonth + "T00:00:00Z")),
+                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                            .put("timestamp", firstDayOfMonth.plusMonths(1).minusDays(1) + "T00:00:00Z")
+                    ))).readEntity(String.class);
+
+            var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
+            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+        }
+
+        @Test
+        public void attemptsInFutureMonth_notCounted() throws Exception {
+            prepare();
+            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            var futureMonth = LocalDate.now().withDayOfMonth(1).plusMonths(1);
+            studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                            .put("timestamp", futureMonth + "T00:00:00Z")),
+                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                            .put("timestamp", futureMonth.minusDays(1) + "T00:00:00Z")
+                    ))).readEntity(String.class);
+
+            var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
+            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+        }
+
         private static void deleteSkillsAttempts() throws SQLException {
             try (var conn = postgresSqlDb.getDatabaseConnection();
                  var pst = conn.prepareStatement("DELETE FROM public.skills_question_attempts WHERE TRUE;")) {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -28,6 +28,8 @@ import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.ALICE_STUDENT_ID;
+import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.BOB_STUDENT_ID;
 import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.REGRESSION_TEST_PAGE_ID;
 import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_STUDENT_ID;
 
@@ -41,7 +43,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         private static final String VALID_APP_ID = VALID_URL.split("/")[2];
         private static final String VALID_PAYLOAD = validPayload(null);
         private static final String VALID_HMAC = sign(HMAC_SECRET, VALID_PAYLOAD, HMAC_SHA_256);
-        private static final JSONObject VALID_BODY = new JSONObject().put("payload", VALID_PAYLOAD).put("hmac", VALID_HMAC);
+        private static final JSONObject VALID_BODY = new JSONObject().put("payload", VALID_PAYLOAD)
+            .put("hmac", VALID_HMAC);
 
         @Test
         public void notLoggedIn_Returns401() throws Exception {
@@ -242,7 +245,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             try (var conn = postgresSqlDb.getDatabaseConnection();
                  var pst = conn.prepareStatement("""
                      SELECT id, user_id, skill_assignment_id, skill_id, subskill_id, question->>'text' AS question_text,
-                            question->>'answer' AS question_answer, question_attempt->>'result' AS result, marks, timestamp
+                            question->>'answer' AS question_answer, question_attempt->>'result' AS result, marks,
+                            timestamp
                      FROM public.skills_question_attempts""");
                  var actualDb = pst.executeQuery()) {
                 actualDb.next();
@@ -252,8 +256,10 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
                 assertEquals(expected.getString("skill_id"), actualDb.getString("skill_id"));
                 assertEquals(expected.get("subskill_id").toString(), actualDb.getString("subskill_id"));
                 assertEquals(expected.getJSONObject("question").getString("text"), actualDb.getString("question_text"));
-                assertEquals(expected.getJSONObject("question").getString("answer"), actualDb.getString("question_answer"));
-                assertEquals(expected.getJSONObject("question_attempt").getString("result"), actualDb.getString("result"));
+                assertEquals(expected.getJSONObject("question").getString("answer"),
+                    actualDb.getString("question_answer"));
+                assertEquals(expected.getJSONObject("question_attempt").getString("result"),
+                    actualDb.getString("result"));
                 assertEquals(expected.getInt("marks"), actualDb.getInt("marks"));
                 assertThat(actualDb.getTimestamp("timestamp").toInstant())
                     .isCloseTo(expected.getString("timestamp"), within(5, ChronoUnit.SECONDS));
@@ -317,21 +323,77 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
 
     @Nested
     class GetAttempts {
+        private static final String NO_PERMISSION_MSG = "You do not have the permissions to complete this action.";
+
         @Nested
-        class RightsCheck {
+        class AuthorisationCheck {
             @Test
             public void notLoggedIn_Returns401() throws Exception {
                 var response = testServer().client().get("/skills/attempts/30");
                 response.assertError("You must be logged in to access this resource.", Response.Status.UNAUTHORIZED);
             }
+
+            @Test void studentViewsOtherStudent_Returns403() throws Exception {
+                var response = testServer().client()
+                        .loginAs(integrationTestUsers.ALICE_STUDENT)
+                        .get(String.format("/skills/attempts/%s", BOB_STUDENT_ID));
+                response.assertError(NO_PERMISSION_MSG, Response.Status.FORBIDDEN);
+            }
+
+            @Test void teacherViewsUnlinkedStudent_Returns403() throws Exception {
+                var response = testServer().client()
+                    .loginAs(integrationTestUsers.DAVE_TEACHER)
+                    .get(String.format("/skills/attempts/%s", ALICE_STUDENT_ID));
+                response.assertError(NO_PERMISSION_MSG, Response.Status.FORBIDDEN);
+            }
+
+            @Test void studentViewsOwn_Returns200() throws Exception {
+                var response = testServer().client()
+                    .loginAs(integrationTestUsers.ALICE_STUDENT)
+                    .get(String.format("/skills/attempts/%s", ALICE_STUDENT_ID));
+                response.assertEntityReturned("OK");
+            }
+
+            @Test void teacherViewsLinkedStudent_Returns200() throws Exception {
+                var response = testServer().client()
+                    .loginAs(integrationTestUsers.DAVE_TEACHER)
+                    .get(String.format("/skills/attempts/%d", BOB_STUDENT_ID));
+                response.assertEntityReturned("OK");
+            }
+        }
+
+        @Nested
+        class UserIdCheck {
+            @Test void nonNumeric_Returns400() throws Exception {
+                var response = testServer().client().get("/skills/attempts/12str");
+                response.assertError("Endpoint not found", Response.Status.NOT_FOUND);
+            }
+
+            @Test void float_Returns400() throws Exception {
+                var response = testServer().client().get("/skills/attempts/12.23");
+                response.assertError("Endpoint not found", Response.Status.NOT_FOUND);
+            }
+
+            @Test void oversized_Returns400() throws Exception {
+                var response = testServer().client().get("/skills/attempts/9223372036854775808"); // Long.MAX_VALUE + 1
+                response.assertError("Endpoint not found", Response.Status.NOT_FOUND);
+            }
+
+            @Test void nonExistentId_Returns403() throws Exception {
+                var response = testServer().client()
+                    .loginAs(integrationTestUsers.DAVE_TEACHER)
+                    .get("/skills/attempts/100");
+                response.assertError(NO_PERMISSION_MSG, Response.Status.FORBIDDEN);
+            }
         }
 
         @Test
         public void happy_happy() throws Exception {
-            var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT).get(String.format("/skills/attempts/{}", TEST_STUDENT_ID));
+            var response = testServer().client()
+                .loginAs(integrationTestUsers.TEST_STUDENT)
+                .get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
             response.assertEntityReturned("OK");
         }
-
     }
 
     private TestServer testServer() throws Exception {
@@ -342,7 +404,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         var sm = new SkillsAttemptManager(properties, new PgSkillsAttemptPersistenceManager(postgresSqlDb));
         return startServer(
             new AuthenticationFacade(properties, userAccountManager, logManager, misuseMonitor),
-            new SkillsFacade(properties, userAccountManager, logManager, cm, sm)
+            new SkillsFacade(properties, userAccountManager, logManager, cm, sm, userAssociationManager)
         );
     }
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -401,10 +401,10 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         }
 
         private void assertPastYearsMonthlyMathsResults(final TestResponse resp, final List<Long> expectations) {
-            var mentalMathsResults = resp.readEntityAsJson().getJSONObject("mental_maths_overall");
+            JSONObject mentalMathsResults = resp.readEntityAsJson().getJSONObject("mental_maths_overall");
             assertEquals(12, mentalMathsResults.keySet().size(), "Expected 12 years worth of mental maths results");
             for (int i = 0; i < expectations.size(); i++) {
-                var key = LocalDate.now().withDayOfMonth(1).minusMonths(i).toString();
+                String key = LocalDate.now().withDayOfMonth(1).minusMonths(i).toString();
                 assertEquals(expectations.get(i), mentalMathsResults.getLong(key), key);
             }
         }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -33,284 +33,288 @@ import static uk.ac.cam.cl.dtg.isaac.api.ITConstants.TEST_STUDENT_ID;
 
 @SuppressWarnings("checkstyle:MissingJavadocType")
 public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
-    private static final String HMAC_SECRET = "integration-test-anvil-hmac-secret";
-    private static final String HMAC_SHA_256 = "HmacSHA256";
-    private static final String VALID_URL = validUrl();
-    private static final String VALID_APP_ID = VALID_URL.split("/")[2];
-    private static final String VALID_PAYLOAD = validPayload(null);
-    private static final String VALID_HMAC = sign(HMAC_SECRET, VALID_PAYLOAD, HMAC_SHA_256);
-    private static final JSONObject VALID_BODY = new JSONObject().put("payload", VALID_PAYLOAD).put("hmac", VALID_HMAC);
-
-    @Test
-    public void notLoggedIn_Returns401() throws Exception {
-        var response = testServer().client().post("/skills/unknown_app/answer", VALID_BODY);
-        response.assertError("You must be logged in to access this resource.", Response.Status.UNAUTHORIZED);
-    }
-
     @Nested
-    class AppIdCheck {
+    class AnswerQuestion {
+        private static final String HMAC_SECRET = "integration-test-anvil-hmac-secret";
+        private static final String HMAC_SHA_256 = "HmacSHA256";
+        private static final String VALID_URL = validUrl();
+        private static final String VALID_APP_ID = VALID_URL.split("/")[2];
+        private static final String VALID_PAYLOAD = validPayload(null);
+        private static final String VALID_HMAC = sign(HMAC_SECRET, VALID_PAYLOAD, HMAC_SHA_256);
+        private static final JSONObject VALID_BODY = new JSONObject().put("payload", VALID_PAYLOAD).put("hmac", VALID_HMAC);
+
         @Test
-        public void elasticsearchUnavailable_Returns404() throws Exception {
-            var client = testServer(brokenContentManager()).client().loginAs(integrationTestUsers.TEST_STUDENT);
-            var response = client.post("/skills/unknown_app/answer", VALID_BODY);
-            response.assertError("Error locating the version requested", Response.Status.NOT_FOUND);
+        public void notLoggedIn_Returns401() throws Exception {
+            var response = testServer().client().post("/skills/unknown_app/answer", VALID_BODY);
+            response.assertError("You must be logged in to access this resource.", Response.Status.UNAUTHORIZED);
+        }
+
+        @Nested
+        class AppIdCheck {
+            @Test
+            public void elasticsearchUnavailable_Returns404() throws Exception {
+                var client = testServer(brokenContentManager()).client().loginAs(integrationTestUsers.TEST_STUDENT);
+                var response = client.post("/skills/unknown_app/answer", VALID_BODY);
+                response.assertError("Error locating the version requested", Response.Status.NOT_FOUND);
+            }
+
+            @Test
+            public void unknownApp_Returns404() throws Exception {
+                var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+                var response = client.post("/skills/unknown_app/answer", VALID_BODY);
+                response.assertError("No skills app found for that id.", Response.Status.NOT_FOUND);
+            }
+
+            @Test
+            public void idMatchesNonApp_Returns404() throws Exception {
+                var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+                var response = client.post("/skills/" + REGRESSION_TEST_PAGE_ID + "/answer", VALID_BODY);
+                response.assertError("No skills app found for that id.", Response.Status.NOT_FOUND);
+            }
+        }
+
+        @Nested
+        class RequestPayloadCheck {
+            @Test
+            public void missingPayload_Returns400() throws Exception {
+                var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+                var response = client.post(VALID_URL, "{}");
+                response.assertError("Invalid JSON provided!", Response.Status.BAD_REQUEST);
+            }
+
+            @Test
+            public void numericPayload_Returns400() throws Exception {
+                var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+                var body = new JSONObject().put("payload", 123).put("hmac", sign(HMAC_SECRET, "123", HMAC_SHA_256));
+                var response = client.post(VALID_URL, body);
+                response.assertError("Invalid payload.", Response.Status.BAD_REQUEST);
+            }
+
+            @Test
+            public void extraAttribute_Returns400() throws Exception {
+                var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+                var body = new JSONObject().put("payload", VALID_PAYLOAD).put("hmac", VALID_HMAC).put("extra", "value");
+                var response = client.post(VALID_URL, body);
+                response.assertError("Invalid JSON provided!", Response.Status.BAD_REQUEST);
+            }
+
+            @Test
+            public void oversizedPayload_Returns400() throws Exception {
+                var large = validPayload(p -> p.put("question_attempt", "x".repeat(30 * 1024 + 1)));
+                var body = new JSONObject().put("payload", large).put("hmac", sign(HMAC_SECRET, large, HMAC_SHA_256));
+                var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT).post(VALID_URL, body);
+                response.assertError("Payload too large.", Response.Status.BAD_REQUEST);
+            }
+        }
+
+        @Nested
+        class HmacVerification {
+            static Stream<Arguments> invalidBodies() {
+                return Stream.of(
+                    Arguments.of("missing hmac", new JSONObject().put("payload", VALID_PAYLOAD),
+                        "Invalid JSON provided!"),
+                    Arguments.of("invalid hmac", new JSONObject().put("payload", VALID_PAYLOAD)
+                        .put("hmac", "not-a-valid-signature"), "Invalid HMAC signature."),
+                    Arguments.of("wrong secret", new JSONObject().put("payload", VALID_PAYLOAD)
+                        .put("hmac", sign("wrong-secret", VALID_PAYLOAD, HMAC_SHA_256)), "Invalid HMAC signature."),
+                    Arguments.of("tampered payload", new JSONObject().put("payload", "tampered_payload")
+                        .put("hmac", VALID_HMAC), "Invalid HMAC signature."),
+                    Arguments.of("wrong algorithm", new JSONObject().put("payload", VALID_PAYLOAD)
+                        .put("hmac", sign(HMAC_SECRET, VALID_PAYLOAD, "HmacMD5")), "Invalid HMAC signature.")
+                );
+            }
+
+            @ParameterizedTest(name = "{0}")
+            @MethodSource("invalidBodies")
+            public void invalidBody_Returns400(
+                final String name, final JSONObject body, final String expectedMessage
+            ) throws Exception {
+                testServer().client()
+                    .loginAs(integrationTestUsers.TEST_STUDENT)
+                    .post(VALID_URL, body)
+                    .assertError(expectedMessage, Response.Status.BAD_REQUEST);
+            }
+        }
+
+        @Nested
+        class PayloadContentCheck {
+            static String MSG_IP = "Invalid payload.";
+
+            static Stream<Arguments> invalidPayloads() {
+                var s = Stream.<Arguments>builder();
+
+                // id
+                addNonEmptyCasesFor("id", s);
+                s.add(Arguments.of("invalid id", validPayload(p -> p.put("id", "not-uuid")), MSG_IP));
+
+                // user_id
+                addNonEmptyCasesFor("user_id", s);
+                s.add(Arguments.of("non-numeric user_id", validPayload(p -> p.put("user_id", "ab")), MSG_IP));
+                s.add(Arguments.of("wrong user_id", validPayload(p -> p.put("user_id", TEST_STUDENT_ID + 1)),
+                    "Payload user_id does not match session"));
+
+                // skill_assignment_id
+                s.add(Arguments.of("missing skill_assignment_id", validPayload(p -> p.remove("skill_assignment_id")),
+                    MSG_IP));
+                s.add(Arguments.of("non-null skill_assignment_id",
+                    validPayload(p -> p.put("skill_assignment_id", "some_id")), MSG_IP));
+
+                // skill_id
+                addNonEmptyCasesFor("skill_id", s);
+                s.add(Arguments.of("wrong skill_id", validPayload(p -> p.put("skill_id", "wrong_skill_id")),
+                    "Payload skill_id does not match app"));
+
+                // subskill_id
+                addNonEmptyCasesFor("subskill_id", s);
+
+                // question
+                addNonEmptyCasesFor("question", s);
+                s.add(Arguments.of("invalid question JSON, str", validPayload(p -> p.put("question", "ab")), MSG_IP));
+                s.add(Arguments.of("invalid question JSON, number", validPayload(p -> p.put("question", 1)), MSG_IP));
+
+                // question_attempt
+                addNonEmptyCasesFor("question_attempt", s);
+                s.add(Arguments.of("invalid attempts JSON", validPayload(p -> p.put("question_attempt", "a")), MSG_IP));
+
+                // marks
+                addNonEmptyCasesFor("marks", s);
+                s.add(Arguments.of("invalid mark 2", validPayload(p -> p.put("marks", 2)), MSG_IP));
+                s.add(Arguments.of("invalid mark -0.4", validPayload(p -> p.put("marks", -0.4)), MSG_IP));
+
+                // timestamp
+                addNonEmptyCasesFor("timestamp", s);
+                s.add(Arguments.of("invalid timestamp", validPayload(p -> p.put("timestamp", "n/d")), MSG_IP));
+                s.add(Arguments.of("expired timestamp", validPayload(p -> p.put("timestamp", "2022-01-01T13:00:00Z")),
+                    "Payload timestamp is outside the allowed window"));
+
+                // other cases
+                s.add(Arguments.of("extra value", validPayload(p -> p.put("extra", "value")), MSG_IP));
+
+                return s.build();
+            }
+
+            @ParameterizedTest(name = "{0}")
+            @MethodSource("invalidPayloads")
+            public void invalidPayload_Returns400(
+                final String name, final String payload, final String expectedMessage
+            ) throws Exception {
+                testServer().client()
+                    .loginAs(integrationTestUsers.TEST_STUDENT)
+                    .post(VALID_URL, new JSONObject()
+                        .put("payload", payload)
+                        .put("hmac", sign(HMAC_SECRET, payload, HMAC_SHA_256)))
+                    .assertError(expectedMessage, Response.Status.BAD_REQUEST);
+            }
+
+            private static void addNonEmptyCasesFor(final String fieldName, final Stream.Builder<Arguments> s) {
+                s.add(Arguments.of("missing " + fieldName, validPayload(p -> p.remove(fieldName)), MSG_IP));
+                s.add(Arguments.of("null " + fieldName, validPayload(p -> p.put(fieldName, JSONObject.NULL)), MSG_IP));
+                s.add(Arguments.of("empty " + fieldName, validPayload(p -> p.put(fieldName, "")), MSG_IP));
+            }
         }
 
         @Test
-        public void unknownApp_Returns404() throws Exception {
+        public void duplicateAttemptId_Returns409() throws Exception {
+            var testP = validPayload(null);
+            var testBody = new JSONObject().put("payload", testP).put("hmac", sign(HMAC_SECRET, testP, HMAC_SHA_256));
             var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-            var response = client.post("/skills/unknown_app/answer", VALID_BODY);
-            response.assertError("No skills app found for that id.", Response.Status.NOT_FOUND);
+            client.post(VALID_URL, testBody).readEntity(String.class);
+            client.post(VALID_URL, testBody).assertError("Duplicate attempt ID.", Response.Status.CONFLICT);
         }
 
         @Test
-        public void idMatchesNonApp_Returns404() throws Exception {
-            var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-            var response = client.post("/skills/" + REGRESSION_TEST_PAGE_ID + "/answer", VALID_BODY);
-            response.assertError("No skills app found for that id.", Response.Status.NOT_FOUND);
-        }
-    }
-
-    @Nested
-    class RequestPayloadCheck {
-        @Test
-        public void missingPayload_Returns400() throws Exception {
-            var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-            var response = client.post(VALID_URL, "{}");
-            response.assertError("Invalid JSON provided!", Response.Status.BAD_REQUEST);
-        }
-
-        @Test
-        public void numericPayload_Returns400() throws Exception {
-            var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-            var body = new JSONObject().put("payload", 123).put("hmac", sign(HMAC_SECRET, "123", HMAC_SHA_256));
-            var response = client.post(VALID_URL, body);
-            response.assertError("Invalid payload.", Response.Status.BAD_REQUEST);
-        }
-
-        @Test
-        public void extraAttribute_Returns400() throws Exception {
-            var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-            var body = new JSONObject().put("payload", VALID_PAYLOAD).put("hmac", VALID_HMAC).put("extra", "value");
-            var response = client.post(VALID_URL, body);
-            response.assertError("Invalid JSON provided!", Response.Status.BAD_REQUEST);
-        }
-
-        @Test
-        public void oversizedPayload_Returns400() throws Exception {
-            var large = validPayload(p -> p.put("question_attempt", "x".repeat(30 * 1024 + 1)));
-            var body = new JSONObject().put("payload", large).put("hmac", sign(HMAC_SECRET, large, HMAC_SHA_256));
-            var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT).post(VALID_URL, body);
-            response.assertError("Payload too large.", Response.Status.BAD_REQUEST);
-        }
-    }
-
-    @Nested
-    class HmacVerification {
-        static Stream<Arguments> invalidBodies() {
-            return Stream.of(
-                Arguments.of("missing hmac", new JSONObject().put("payload", VALID_PAYLOAD),
-                    "Invalid JSON provided!"),
-                Arguments.of("invalid hmac", new JSONObject().put("payload", VALID_PAYLOAD)
-                    .put("hmac", "not-a-valid-signature"), "Invalid HMAC signature."),
-                Arguments.of("wrong secret", new JSONObject().put("payload", VALID_PAYLOAD)
-                    .put("hmac", sign("wrong-secret", VALID_PAYLOAD, HMAC_SHA_256)), "Invalid HMAC signature."),
-                Arguments.of("tampered payload", new JSONObject().put("payload", "tampered_payload")
-                    .put("hmac", VALID_HMAC), "Invalid HMAC signature."),
-                Arguments.of("wrong algorithm", new JSONObject().put("payload", VALID_PAYLOAD)
-                    .put("hmac", sign(HMAC_SECRET, VALID_PAYLOAD, "HmacMD5")), "Invalid HMAC signature.")
-            );
-        }
-
-        @ParameterizedTest(name = "{0}")
-        @MethodSource("invalidBodies")
-        public void invalidBody_Returns400(
-            final String name, final JSONObject body, final String expectedMessage
-        ) throws Exception {
-            testServer().client()
+        public void happy_happy() throws Exception {
+            var expected = new JSONArray(VALID_PAYLOAD).getJSONObject(0);
+            var actualReq = testServer().client()
                 .loginAs(integrationTestUsers.TEST_STUDENT)
-                .post(VALID_URL, body)
-                .assertError(expectedMessage, Response.Status.BAD_REQUEST);
+                .post(VALID_URL, VALID_BODY)
+                .readEntityAsJsonArray().getJSONObject(0);
+
+            // assert there is exactly 1 row in the database
+            try (var conn = postgresSqlDb.getDatabaseConnection();
+                 var pst = conn.prepareStatement("SELECT COUNT(*) FROM public.skills_question_attempts");
+                 var rs = pst.executeQuery()) {
+                rs.next();
+                assertEquals(1, rs.getInt(1));
+            }
+
+            // assert everything has been recorded to the database
+            try (var conn = postgresSqlDb.getDatabaseConnection();
+                 var pst = conn.prepareStatement("""
+                     SELECT id, user_id, skill_assignment_id, skill_id, subskill_id, question->>'text' AS question_text,
+                            question->>'answer' AS question_answer, question_attempt->>'result' AS result, marks, timestamp
+                     FROM public.skills_question_attempts""");
+                 var actualDb = pst.executeQuery()) {
+                actualDb.next();
+                assertEquals(expected.getString("id"), actualDb.getString("id"));
+                assertEquals(expected.getInt("user_id"), actualDb.getInt("user_id"));
+                assertNull(actualDb.getString("skill_assignment_id"));
+                assertEquals(expected.getString("skill_id"), actualDb.getString("skill_id"));
+                assertEquals(expected.get("subskill_id").toString(), actualDb.getString("subskill_id"));
+                assertEquals(expected.getJSONObject("question").getString("text"), actualDb.getString("question_text"));
+                assertEquals(expected.getJSONObject("question").getString("answer"), actualDb.getString("question_answer"));
+                assertEquals(expected.getJSONObject("question_attempt").getString("result"), actualDb.getString("result"));
+                assertEquals(expected.getInt("marks"), actualDb.getInt("marks"));
+                assertThat(actualDb.getTimestamp("timestamp").toInstant())
+                    .isCloseTo(expected.getString("timestamp"), within(5, ChronoUnit.SECONDS));
+            }
+
+            // assert the request echoes back the payload
+            assertEquals(expected.getString("id"), actualReq.getString("id"));
+            assertEquals(expected.getInt("user_id"), actualReq.getInt("user_id"));
+            assertEquals(expected.getString("skill_id"), actualReq.getString("skill_id"));
+            assertEquals(expected.get("subskill_id").toString(), actualReq.getString("subskill_id"));
+            assertEquals(expected.getJSONObject("question").toString(), actualReq.getJSONObject("question").toString());
+            assertEquals(expected.getJSONObject("question_attempt").toString(),
+                actualReq.getJSONObject("question_attempt").toString());
+            assertEquals(expected.getInt("marks"), actualReq.getInt("marks"));
+            assertFalse(actualReq.has("skill_assignment_id"));
+        }
+
+        private static GitContentManager brokenContentManager() throws Exception {
+            var brokenClient = ElasticSearchProvider.getClient("localhost", 1, "elastic", "elastic");
+            var brokenProvider = new ElasticSearchProvider(brokenClient);
+            return new GitContentManager(null, brokenProvider, mainMapper, contentMapper, properties);
+        }
+
+        private static String validUrl() {
+            try {
+                var skillsApp = elasticHelper.persistJSON(new JSONObject().put("type", "skillsApp"));
+                return "/skills/" + skillsApp.getString("id") + "/answer";
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static String validPayload(final Consumer<JSONObject> op) {
+            var defaultPayload = new JSONObject()
+                .put("id", UUID.randomUUID().toString())
+                .put("user_id", TEST_STUDENT_ID)
+                .put("skill_assignment_id", JSONObject.NULL)
+                .put("skill_id", VALID_APP_ID)
+                .put("subskill_id", 21)
+                .put("question", new JSONObject().put("text", "2+2").put("answer", "4"))
+                .put("question_attempt", new JSONObject().put("result", "4"))
+                .put("marks", 1)
+                .put("timestamp", Instant.now().toString());
+            if (op != null) {
+                op.accept(defaultPayload);
+            }
+            return new JSONArray().put(defaultPayload).toString();
+        }
+
+        private static String sign(final String key, final String payload, final String algo) {
+            try {
+                var signingKey = new SecretKeySpec(key.getBytes(), algo);
+                var mac = Mac.getInstance(algo);
+                mac.init(signingKey);
+                return new String(Base64.encodeBase64(mac.doFinal(payload.getBytes())));
+            } catch (final Exception e) {
+                return "NOT_SIGNED";
+            }
         }
     }
 
-    @Nested
-    class PayloadContentCheck {
-        static String MSG_IP = "Invalid payload.";
-
-        static Stream<Arguments> invalidPayloads() {
-            var s = Stream.<Arguments>builder();
-
-            // id
-            addNonEmptyCasesFor("id", s);
-            s.add(Arguments.of("invalid id", validPayload(p -> p.put("id", "not-uuid")), MSG_IP));
-
-            // user_id
-            addNonEmptyCasesFor("user_id", s);
-            s.add(Arguments.of("non-numeric user_id", validPayload(p -> p.put("user_id", "ab")), MSG_IP));
-            s.add(Arguments.of("wrong user_id", validPayload(p -> p.put("user_id", TEST_STUDENT_ID + 1)),
-                "Payload user_id does not match session"));
-
-            // skill_assignment_id
-            s.add(Arguments.of("missing skill_assignment_id", validPayload(p -> p.remove("skill_assignment_id")),
-                MSG_IP));
-            s.add(Arguments.of("non-null skill_assignment_id",
-                validPayload(p -> p.put("skill_assignment_id", "some_id")), MSG_IP));
-
-            // skill_id
-            addNonEmptyCasesFor("skill_id", s);
-            s.add(Arguments.of("wrong skill_id", validPayload(p -> p.put("skill_id", "wrong_skill_id")),
-                "Payload skill_id does not match app"));
-
-            // subskill_id
-            addNonEmptyCasesFor("subskill_id", s);
-
-            // question
-            addNonEmptyCasesFor("question", s);
-            s.add(Arguments.of("invalid question JSON, str", validPayload(p -> p.put("question", "ab")), MSG_IP));
-            s.add(Arguments.of("invalid question JSON, number", validPayload(p -> p.put("question", 1)), MSG_IP));
-
-            // question_attempt
-            addNonEmptyCasesFor("question_attempt", s);
-            s.add(Arguments.of("invalid attempts JSON", validPayload(p -> p.put("question_attempt", "a")), MSG_IP));
-
-            // marks
-            addNonEmptyCasesFor("marks", s);
-            s.add(Arguments.of("invalid mark 2", validPayload(p -> p.put("marks", 2)), MSG_IP));
-            s.add(Arguments.of("invalid mark -0.4", validPayload(p -> p.put("marks", -0.4)), MSG_IP));
-
-            // timestamp
-            addNonEmptyCasesFor("timestamp", s);
-            s.add(Arguments.of("invalid timestamp", validPayload(p -> p.put("timestamp", "n/d")), MSG_IP));
-            s.add(Arguments.of("expired timestamp", validPayload(p -> p.put("timestamp", "2022-01-01T13:00:00Z")),
-                "Payload timestamp is outside the allowed window"));
-
-            // other cases
-            s.add(Arguments.of("extra value", validPayload(p -> p.put("extra", "value")), MSG_IP));
-
-            return s.build();
-        }
-
-        @ParameterizedTest(name = "{0}")
-        @MethodSource("invalidPayloads")
-        public void invalidPayload_Returns400(
-            final String name, final String payload, final String expectedMessage
-        ) throws Exception {
-            testServer().client()
-                .loginAs(integrationTestUsers.TEST_STUDENT)
-                .post(VALID_URL, new JSONObject()
-                    .put("payload", payload)
-                    .put("hmac", sign(HMAC_SECRET, payload, HMAC_SHA_256)))
-                .assertError(expectedMessage, Response.Status.BAD_REQUEST);
-        }
-
-        private static void addNonEmptyCasesFor(final String fieldName, final Stream.Builder<Arguments> s) {
-            s.add(Arguments.of("missing " + fieldName, validPayload(p -> p.remove(fieldName)), MSG_IP));
-            s.add(Arguments.of("null " + fieldName, validPayload(p -> p.put(fieldName, JSONObject.NULL)), MSG_IP));
-            s.add(Arguments.of("empty " + fieldName, validPayload(p -> p.put(fieldName, "")), MSG_IP));
-        }
-    }
-
-    @Test
-    public void duplicateAttemptId_Returns409() throws Exception {
-        var testP = validPayload(null);
-        var testBody = new JSONObject().put("payload", testP).put("hmac", sign(HMAC_SECRET, testP, HMAC_SHA_256));
-        var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-        client.post(VALID_URL, testBody).readEntity(String.class);
-        client.post(VALID_URL, testBody).assertError("Duplicate attempt ID.", Response.Status.CONFLICT);
-    }
-
-    @Test
-    public void happy_happy() throws Exception {
-        var expected = new JSONArray(VALID_PAYLOAD).getJSONObject(0);
-        var actualReq = testServer().client()
-            .loginAs(integrationTestUsers.TEST_STUDENT)
-            .post(VALID_URL, VALID_BODY)
-            .readEntityAsJsonArray().getJSONObject(0);
-
-        // assert there is exactly 1 row in the database
-        try (var conn = postgresSqlDb.getDatabaseConnection();
-             var pst = conn.prepareStatement("SELECT COUNT(*) FROM public.skills_question_attempts");
-             var rs = pst.executeQuery()) {
-            rs.next();
-            assertEquals(1, rs.getInt(1));
-        }
-
-        // assert everything has been recorded to the database
-        try (var conn = postgresSqlDb.getDatabaseConnection();
-             var pst = conn.prepareStatement("""
-                 SELECT id, user_id, skill_assignment_id, skill_id, subskill_id, question->>'text' AS question_text,
-                        question->>'answer' AS question_answer, question_attempt->>'result' AS result, marks, timestamp
-                 FROM public.skills_question_attempts""");
-             var actualDb = pst.executeQuery()) {
-            actualDb.next();
-            assertEquals(expected.getString("id"), actualDb.getString("id"));
-            assertEquals(expected.getInt("user_id"), actualDb.getInt("user_id"));
-            assertNull(actualDb.getString("skill_assignment_id"));
-            assertEquals(expected.getString("skill_id"), actualDb.getString("skill_id"));
-            assertEquals(expected.get("subskill_id").toString(), actualDb.getString("subskill_id"));
-            assertEquals(expected.getJSONObject("question").getString("text"), actualDb.getString("question_text"));
-            assertEquals(expected.getJSONObject("question").getString("answer"), actualDb.getString("question_answer"));
-            assertEquals(expected.getJSONObject("question_attempt").getString("result"), actualDb.getString("result"));
-            assertEquals(expected.getInt("marks"), actualDb.getInt("marks"));
-            assertThat(actualDb.getTimestamp("timestamp").toInstant())
-                .isCloseTo(expected.getString("timestamp"), within(5, ChronoUnit.SECONDS));
-        }
-
-        // assert the request echoes back the payload
-        assertEquals(expected.getString("id"), actualReq.getString("id"));
-        assertEquals(expected.getInt("user_id"), actualReq.getInt("user_id"));
-        assertEquals(expected.getString("skill_id"), actualReq.getString("skill_id"));
-        assertEquals(expected.get("subskill_id").toString(), actualReq.getString("subskill_id"));
-        assertEquals(expected.getJSONObject("question").toString(), actualReq.getJSONObject("question").toString());
-        assertEquals(expected.getJSONObject("question_attempt").toString(),
-            actualReq.getJSONObject("question_attempt").toString());
-        assertEquals(expected.getInt("marks"), actualReq.getInt("marks"));
-        assertFalse(actualReq.has("skill_assignment_id"));
-    }
-
-    private static GitContentManager brokenContentManager() throws Exception {
-        var brokenClient = ElasticSearchProvider.getClient("localhost", 1, "elastic", "elastic");
-        var brokenProvider = new ElasticSearchProvider(brokenClient);
-        return new GitContentManager(null, brokenProvider, mainMapper, contentMapper, properties);
-    }
-
-    private static String validUrl() {
-        try {
-            var skillsApp = elasticHelper.persistJSON(new JSONObject().put("type", "skillsApp"));
-            return "/skills/" + skillsApp.getString("id") + "/answer";
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static String validPayload(final Consumer<JSONObject> op) {
-        var defaultPayload = new JSONObject()
-            .put("id", UUID.randomUUID().toString())
-            .put("user_id", TEST_STUDENT_ID)
-            .put("skill_assignment_id", JSONObject.NULL)
-            .put("skill_id", SkillsFacadeIT.VALID_APP_ID)
-            .put("subskill_id", 21)
-            .put("question", new JSONObject().put("text", "2+2").put("answer", "4"))
-            .put("question_attempt", new JSONObject().put("result", "4"))
-            .put("marks", 1)
-            .put("timestamp", Instant.now().toString());
-        if (op != null) {
-            op.accept(defaultPayload);
-        }
-        return new JSONArray().put(defaultPayload).toString();
-    }
-
-    private static String sign(final String key, final String payload, final String algo) {
-        try {
-            var signingKey = new SecretKeySpec(key.getBytes(), algo);
-            var mac = Mac.getInstance(algo);
-            mac.init(signingKey);
-            return new String(Base64.encodeBase64(mac.doFinal(payload.getBytes())));
-        } catch (final Exception e) {
-            return "NOT_SIGNED";
-        }
-    }
 
     private TestServer testServer() throws Exception {
         return testServer(contentManager);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -315,6 +315,24 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         }
     }
 
+    @Nested
+    class GetAttempts {
+        @Nested
+        class RightsCheck {
+            @Test
+            public void notLoggedIn_Returns401() throws Exception {
+                var response = testServer().client().get("/skills/attempts/30");
+                response.assertError("You must be logged in to access this resource.", Response.Status.UNAUTHORIZED);
+            }
+        }
+
+        @Test
+        public void happy_happy() throws Exception {
+            var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT).get(String.format("/skills/attempts/{}", TEST_STUDENT_ID));
+            response.assertEntityReturned("OK");
+        }
+
+    }
 
     private TestServer testServer() throws Exception {
         return testServer(contentManager);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -440,11 +440,11 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
             var firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
             studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
-                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
-                            .put("timestamp",  firstDayOfMonth + "T00:00:00Z")),
-                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
-                            .put("timestamp", firstDayOfMonth.plusMonths(1).minusDays(1) + "T00:00:00Z")
-                    ))).readEntity(String.class);
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp",  firstDayOfMonth + "T00:00:00Z")),
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp", firstDayOfMonth.plusMonths(1).minusDays(1) + "T00:00:00Z")
+            ))).readEntity(String.class);
 
             var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
             assertPastYearsMonthlyMathsResults(response, ImmutableList.of(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
@@ -456,14 +456,27 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
             var futureMonth = LocalDate.now().withDayOfMonth(1).plusMonths(1);
             studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
-                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
-                            .put("timestamp", futureMonth + "T00:00:00Z")),
-                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
-                            .put("timestamp", futureMonth.minusDays(1) + "T00:00:00Z")
-                    ))).readEntity(String.class);
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp", futureMonth + "T00:00:00Z")),
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp", futureMonth.minusDays(1) + "T00:00:00Z")
+            ))).readEntity(String.class);
 
             var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
             assertPastYearsMonthlyMathsResults(response, ImmutableList.of(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+        }
+
+        @Test public void attemptsByOtherUser_notCounted() throws Exception {
+            prepare();
+            testServer().client().loginAs(integrationTestUsers.ALICE_STUDENT)
+                .post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+                    AnswerQuestion.validAttempt(a -> a.put("user_id", ALICE_STUDENT_ID)
+                        .put("timestamp", LocalDate.now().withDayOfMonth(1) + "T00:00:00Z"))
+                )).readEntity(String.class);
+
+            var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT)
+                .get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
+            assertPastYearsMonthlyMathsResults(response, NO_ATTEMPTS_ANY_MONTH);
         }
 
         private static void deleteSkillsAttempts() throws SQLException {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -501,6 +501,32 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             assertPastYearsMonthlyMathsResults(response, ImmutableList.of(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
         }
 
+        @Test public void emptyAttempts_notCounted() throws Exception {
+            prepare();
+            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            studentClient.post(AnswerQuestion.validUrl(AnswerQuestion.VALID_APP_ID), AnswerQuestion.validBody(
+                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                        .put("timestamp", LocalDate.now() + "T00:00:00Z")
+                        .put("question_attempt", new JSONObject().put("result", "")))
+            )).readEntity(String.class);
+
+            var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
+            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+        }
+
+        @Test public void anomalousAttemptWithoutResult_notCounted() throws Exception {
+            prepare();
+            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            studentClient.post(AnswerQuestion.validUrl(AnswerQuestion.VALID_APP_ID), AnswerQuestion.validBody(
+                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                            .put("timestamp", LocalDate.now() + "T00:00:00Z")
+                            .put("question_attempt", new JSONObject()))
+            )).readEntity(String.class);
+
+            var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
+            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+        }
+
         private static void deleteSkillsAttempts() throws SQLException {
             try (var conn = postgresSqlDb.getDatabaseConnection();
                  var pst = conn.prepareStatement("DELETE FROM public.skills_question_attempts WHERE TRUE;")) {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -330,8 +330,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
     @Nested
     class GetAttempts {
         private static final String NO_PERMISSION_MSG = "You do not have the permissions to complete this action.";
-        private static final List<Long> NO_ATTEMPTS_ANY_MONTH = ImmutableList.of(
-            0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
+        private static final List<Integer> NO_ATTEMPTS_ANY_MONTH = ImmutableList.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
         @Nested
         class AuthorisationCheck {
@@ -404,25 +403,35 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         }
 
         @Test
-        public void twoAttemptsWithinPeriod_returnsBothAttempts() throws Exception {
-            registerCleanup(() -> {
-                deleteSkillsAttempts();
-                SkillsAttemptManager.FIVE_MINUTES_IN_MILLIS = 300_000L;
-            });
-            SkillsAttemptManager.FIVE_MINUTES_IN_MILLIS = 365L * 24 * 60 * 60 * 1000;
+        public void attemptsWithinPeriod_bothCounted() throws Exception {
+            prepare();
             var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
             studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
-                                                  .put("timestamp", Instant.now())),
+                  .put("timestamp", Instant.now())),
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
-                                                  .put("timestamp",
-                                                      LocalDate.now().withDayOfMonth(1).minusMonths(11) + "T00:00:00Z")
+                  .put("timestamp", LocalDate.now().withDayOfMonth(1).minusMonths(11) + "T00:00:00Z")
             ))).readEntity(String.class);
 
             var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
 
-            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(1L, 0L, 0L, 0L, 0L, 0L,
-                0L, 0L, 0L, 0L, 0L, 1L));
+            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1));
+        }
+
+        @Test
+        public void attemptBeforeFirstDayOf12thMonth_notCounted() throws Exception {
+            prepare();
+            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            var firstDayOf12thMonth = LocalDate.now().withDayOfMonth(1).minusMonths(11);
+            studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp",  firstDayOf12thMonth + "T00:00:00Z")),
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp", firstDayOf12thMonth.minusDays(1) + "T00:00:00Z")
+            ))).readEntity(String.class);
+
+            var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
+            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1));
         }
 
         private static void deleteSkillsAttempts() throws SQLException {
@@ -432,16 +441,24 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             }
         }
 
+        private void prepare() {
+            registerCleanup(() -> {
+                deleteSkillsAttempts();
+                SkillsAttemptManager.FIVE_MINUTES_IN_MILLIS = 300_000L;
+            });
+            SkillsAttemptManager.FIVE_MINUTES_IN_MILLIS = 365L * 24 * 60 * 60 * 1000;
+        }
+
         /*
          * On "2026-07-10", assertPastYearsMonthlyMathsResults(resp, [0, 0, ..., 0]) checks that the response is
          * { "mental_maths_overall": { "2026-07-01: 0, 2026-06-01: 0, ... 2025-08-01: 0" } }
          */
-        private void assertPastYearsMonthlyMathsResults(final TestResponse resp, final List<Long> expectations) {
+        private void assertPastYearsMonthlyMathsResults(final TestResponse resp, final List<Integer> expectations) {
             JSONObject mentalMathsResults = resp.readEntityAsJson().getJSONObject("mental_maths_overall");
             assertEquals(12, mentalMathsResults.keySet().size(), "Expected 12 years worth of mental maths results");
             for (int i = 0; i < expectations.size(); i++) {
                 String key = LocalDate.now().withDayOfMonth(1).minusMonths(i).toString();
-                assertEquals(expectations.get(i), mentalMathsResults.getLong(key), key);
+                assertEquals(expectations.get(i), mentalMathsResults.getInt(key), key);
             }
         }
     }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 import uk.ac.cam.cl.dtg.isaac.api.managers.SkillsAttemptManager;
 import uk.ac.cam.cl.dtg.isaac.dao.PgSkillsAttemptPersistenceManager;
 import uk.ac.cam.cl.dtg.segue.api.AuthenticationFacade;
@@ -16,7 +17,9 @@ import uk.ac.cam.cl.dtg.segue.search.ElasticSearchProvider;
 
 import jakarta.ws.rs.core.Response;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -324,6 +327,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
     @Nested
     class GetAttempts {
         private static final String NO_PERMISSION_MSG = "You do not have the permissions to complete this action.";
+        private static final List<Long> NO_ATTEMPTS_ANY_MONTH = ImmutableList.of(
+            0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
 
         @Nested
         class AuthorisationCheck {
@@ -351,14 +356,14 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
                 var response = testServer().client()
                     .loginAs(integrationTestUsers.ALICE_STUDENT)
                     .get(String.format("/skills/attempts/%s", ALICE_STUDENT_ID));
-                response.assertEntityReturned("OK");
+                assertPastYearsMonthlyMathsResults(response, NO_ATTEMPTS_ANY_MONTH);
             }
 
             @Test void teacherViewsLinkedStudent_Returns200() throws Exception {
                 var response = testServer().client()
                     .loginAs(integrationTestUsers.DAVE_TEACHER)
                     .get(String.format("/skills/attempts/%d", BOB_STUDENT_ID));
-                response.assertEntityReturned("OK");
+                assertPastYearsMonthlyMathsResults(response, NO_ATTEMPTS_ANY_MONTH);
             }
         }
 
@@ -388,11 +393,19 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         }
 
         @Test
-        public void happy_happy() throws Exception {
+        public void noAttempts_returnsPaddedMathsPracticeForPastYear() throws Exception {
             var response = testServer().client()
                 .loginAs(integrationTestUsers.TEST_STUDENT)
                 .get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
-            response.assertEntityReturned("OK");
+            assertPastYearsMonthlyMathsResults(response, NO_ATTEMPTS_ANY_MONTH);
+        }
+
+        private void assertPastYearsMonthlyMathsResults(final TestResponse resp, final List<Long> expectations) {
+            var mentalMathsResults = resp.readEntityAsJson().getJSONObject("mental_maths_overall");
+            for (int i = 0; i < expectations.size(); i++) {
+                var key = LocalDate.now().withDayOfMonth(1).minusMonths(i).toString();
+                assertEquals(expectations.get(i), mentalMathsResults.getLong(key), key);
+            }
         }
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -43,7 +43,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
     class AnswerQuestion {
         private static final String HMAC_SECRET = "integration-test-anvil-hmac-secret";
         private static final String HMAC_SHA_256 = "HmacSHA256";
-        private static final String VALID_APP_ID = validUrl().split("/")[2];
+        private static final String VALID_APP_ID = "app_page_mental_maths_overall|0e184f9d-b619-4225-ac12-3c96d3c74046";
         private static final String VALID_PAYLOAD = new JSONArray().put(validAttempt(null)).toString();
         private static final String VALID_BODY = validBody(validAttempt(null));
 
@@ -82,7 +82,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             @Test
             public void missingPayload_Returns400() throws Exception {
                 var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-                var response = client.post(validUrl(), "{}");
+                var response = client.post(validUrl(null), "{}");
                 response.assertError("Invalid JSON provided!", Response.Status.BAD_REQUEST);
             }
 
@@ -90,7 +90,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             public void numericPayload_Returns400() throws Exception {
                 var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
                 var body = new JSONObject().put("payload", 123).put("hmac", sign(HMAC_SECRET, "123", HMAC_SHA_256));
-                var response = client.post(validUrl(), body);
+                var response = client.post(validUrl(null), body);
                 response.assertError("Invalid payload.", Response.Status.BAD_REQUEST);
             }
 
@@ -98,7 +98,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             public void extraAttribute_Returns400() throws Exception {
                 var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
                 var body = new JSONObject(validBody(validAttempt(null))).put("extra", "value");
-                var response = client.post(validUrl(), body);
+                var response = client.post(validUrl(null), body);
                 response.assertError("Invalid JSON provided!", Response.Status.BAD_REQUEST);
             }
 
@@ -106,7 +106,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             public void oversizedPayload_Returns400() throws Exception {
                 var large = validAttempt(p -> p.put("question_attempt", "x".repeat(30 * 1024 + 1)));
                 var body = validBody(large);
-                var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT).post(validUrl(), body);
+                var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT)
+                    .post(validUrl(null), body);
                 response.assertError("Payload too large.", Response.Status.BAD_REQUEST);
             }
         }
@@ -135,7 +136,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             ) throws Exception {
                 testServer().client()
                     .loginAs(integrationTestUsers.TEST_STUDENT)
-                    .post(validUrl(), body)
+                    .post(validUrl(null), body)
                     .assertError(expectedMessage, Response.Status.BAD_REQUEST);
             }
         }
@@ -204,7 +205,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             ) throws Exception {
                 testServer().client()
                     .loginAs(integrationTestUsers.TEST_STUDENT)
-                    .post(validUrl(), validBody(payload))
+                    .post(validUrl(null), validBody(payload))
                     .assertError(expectedMessage, Response.Status.BAD_REQUEST);
             }
 
@@ -219,8 +220,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         public void duplicateAttemptId_Returns409() throws Exception {
             var testBody = validBody(validAttempt(null));
             var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-            client.post(validUrl(), testBody).readEntity(String.class);
-            client.post(validUrl(), testBody).assertError("Duplicate attempt ID.", Response.Status.CONFLICT);
+            client.post(validUrl(null), testBody).readEntity(String.class);
+            client.post(validUrl(null), testBody).assertError("Duplicate attempt ID.", Response.Status.CONFLICT);
         }
 
         @Test
@@ -228,7 +229,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             var expectedAttempt = validAttempt(null);
             var actualReq = testServer().client()
                 .loginAs(integrationTestUsers.TEST_STUDENT)
-                .post(validUrl(), validBody(expectedAttempt))
+                .post(validUrl(null), validBody(expectedAttempt))
                 .readEntityAsJsonArray().getJSONObject(0);
 
             // assert there is exactly 1 row in the database
@@ -283,9 +284,12 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             return new GitContentManager(null, brokenProvider, mainMapper, contentMapper, properties);
         }
 
-        private static String validUrl() {
+        private static String validUrl(final String skillId) {
             try {
-                var skillsApp = elasticHelper.persistJSON(new JSONObject().put("type", "skillsApp"));
+                var skillsApp = elasticHelper.persistJSON(new JSONObject()
+                    .put("type", "skillsApp")
+                    .put("id", skillId == null ? VALID_APP_ID : skillId)
+                );
                 return "/skills/" + skillsApp.getString("id") + "/answer";
             } catch (final Exception e) {
                 throw new RuntimeException(e);
@@ -406,7 +410,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         public void attemptsWithinPeriod_bothCounted() throws Exception {
             prepare();
             var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-            studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+            studentClient.post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
                   .put("timestamp", Instant.now())),
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
@@ -423,7 +427,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             prepare();
             var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
             var firstDayOf12thMonth = LocalDate.now().withDayOfMonth(1).minusMonths(11);
-            studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+            studentClient.post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
                     .put("timestamp",  firstDayOf12thMonth + "T00:00:00Z")),
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
@@ -439,7 +443,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             prepare();
             var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
             var firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
-            studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+            studentClient.post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
                     .put("timestamp",  firstDayOfMonth + "T00:00:00Z")),
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
@@ -455,7 +459,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             prepare();
             var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
             var futureMonth = LocalDate.now().withDayOfMonth(1).plusMonths(1);
-            studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+            studentClient.post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
                     .put("timestamp", futureMonth + "T00:00:00Z")),
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
@@ -469,7 +473,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         @Test public void attemptsByOtherUser_notCounted() throws Exception {
             prepare();
             testServer().client().loginAs(integrationTestUsers.ALICE_STUDENT)
-                .post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+                .post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                     AnswerQuestion.validAttempt(a -> a.put("user_id", ALICE_STUDENT_ID)
                         .put("timestamp", LocalDate.now().withDayOfMonth(1) + "T00:00:00Z"))
                 )).readEntity(String.class);
@@ -477,6 +481,24 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT)
                 .get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
             assertPastYearsMonthlyMathsResults(response, NO_ATTEMPTS_ANY_MONTH);
+        }
+
+        @Test public void attemptsOtherThanMentalMaths_notCounted() throws Exception {
+            prepare();
+            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            studentClient.post(AnswerQuestion.validUrl("irrelevant_app_id"), AnswerQuestion.validBody(
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp", LocalDate.now() + "T00:00:00Z")
+                    .put("skill_id", "irrelevant_app_id"))
+            )).readEntity(String.class);
+            studentClient.post(AnswerQuestion.validUrl(AnswerQuestion.VALID_APP_ID), AnswerQuestion.validBody(
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp", LocalDate.now() + "T00:00:00Z")
+                    .put("skill_id", AnswerQuestion.VALID_APP_ID))
+            )).readEntity(String.class);
+
+            var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
+            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
         }
 
         private static void deleteSkillsAttempts() throws SQLException {

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -402,6 +402,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
 
         private void assertPastYearsMonthlyMathsResults(final TestResponse resp, final List<Long> expectations) {
             var mentalMathsResults = resp.readEntityAsJson().getJSONObject("mental_maths_overall");
+            assertEquals(12, mentalMathsResults.keySet().size(), "Expected 12 years worth of mental maths results");
             for (int i = 0; i < expectations.size(); i++) {
                 var key = LocalDate.now().withDayOfMonth(1).minusMonths(i).toString();
                 assertEquals(expectations.get(i), mentalMathsResults.getLong(key), key);

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -16,6 +16,7 @@ import uk.ac.cam.cl.dtg.segue.dao.content.GitContentManager;
 import uk.ac.cam.cl.dtg.segue.search.ElasticSearchProvider;
 
 import jakarta.ws.rs.core.Response;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -42,12 +43,9 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
     class AnswerQuestion {
         private static final String HMAC_SECRET = "integration-test-anvil-hmac-secret";
         private static final String HMAC_SHA_256 = "HmacSHA256";
-        private static final String VALID_URL = validUrl();
-        private static final String VALID_APP_ID = VALID_URL.split("/")[2];
-        private static final String VALID_PAYLOAD = validPayload(null);
-        private static final String VALID_HMAC = sign(HMAC_SECRET, VALID_PAYLOAD, HMAC_SHA_256);
-        private static final JSONObject VALID_BODY = new JSONObject().put("payload", VALID_PAYLOAD)
-            .put("hmac", VALID_HMAC);
+        private static final String VALID_APP_ID = validUrl().split("/")[2];
+        private static final String VALID_PAYLOAD = new JSONArray().put(validAttempt(null)).toString();
+        private static final String VALID_BODY = validBody(validAttempt(null));
 
         @Test
         public void notLoggedIn_Returns401() throws Exception {
@@ -84,7 +82,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             @Test
             public void missingPayload_Returns400() throws Exception {
                 var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-                var response = client.post(VALID_URL, "{}");
+                var response = client.post(validUrl(), "{}");
                 response.assertError("Invalid JSON provided!", Response.Status.BAD_REQUEST);
             }
 
@@ -92,23 +90,23 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             public void numericPayload_Returns400() throws Exception {
                 var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
                 var body = new JSONObject().put("payload", 123).put("hmac", sign(HMAC_SECRET, "123", HMAC_SHA_256));
-                var response = client.post(VALID_URL, body);
+                var response = client.post(validUrl(), body);
                 response.assertError("Invalid payload.", Response.Status.BAD_REQUEST);
             }
 
             @Test
             public void extraAttribute_Returns400() throws Exception {
                 var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-                var body = new JSONObject().put("payload", VALID_PAYLOAD).put("hmac", VALID_HMAC).put("extra", "value");
-                var response = client.post(VALID_URL, body);
+                var body = new JSONObject(validBody(validAttempt(null))).put("extra", "value");
+                var response = client.post(validUrl(), body);
                 response.assertError("Invalid JSON provided!", Response.Status.BAD_REQUEST);
             }
 
             @Test
             public void oversizedPayload_Returns400() throws Exception {
-                var large = validPayload(p -> p.put("question_attempt", "x".repeat(30 * 1024 + 1)));
-                var body = new JSONObject().put("payload", large).put("hmac", sign(HMAC_SECRET, large, HMAC_SHA_256));
-                var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT).post(VALID_URL, body);
+                var large = validAttempt(p -> p.put("question_attempt", "x".repeat(30 * 1024 + 1)));
+                var body = validBody(large);
+                var response = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT).post(validUrl(), body);
                 response.assertError("Payload too large.", Response.Status.BAD_REQUEST);
             }
         }
@@ -122,9 +120,9 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
                     Arguments.of("invalid hmac", new JSONObject().put("payload", VALID_PAYLOAD)
                         .put("hmac", "not-a-valid-signature"), "Invalid HMAC signature."),
                     Arguments.of("wrong secret", new JSONObject().put("payload", VALID_PAYLOAD)
-                        .put("hmac", sign("wrong-secret", VALID_PAYLOAD, HMAC_SHA_256)), "Invalid HMAC signature."),
+                        .put("hmac", sign("wrong-secret", VALID_PAYLOAD, HMAC_SHA_256)), "Invalid HMAC signature"),
                     Arguments.of("tampered payload", new JSONObject().put("payload", "tampered_payload")
-                        .put("hmac", VALID_HMAC), "Invalid HMAC signature."),
+                        .put("hmac", sign(HMAC_SECRET, VALID_PAYLOAD, HMAC_SHA_256)), "Invalid HMAC signature."),
                     Arguments.of("wrong algorithm", new JSONObject().put("payload", VALID_PAYLOAD)
                         .put("hmac", sign(HMAC_SECRET, VALID_PAYLOAD, "HmacMD5")), "Invalid HMAC signature.")
                 );
@@ -137,7 +135,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             ) throws Exception {
                 testServer().client()
                     .loginAs(integrationTestUsers.TEST_STUDENT)
-                    .post(VALID_URL, body)
+                    .post(validUrl(), body)
                     .assertError(expectedMessage, Response.Status.BAD_REQUEST);
             }
         }
@@ -151,23 +149,23 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
 
                 // id
                 addNonEmptyCasesFor("id", s);
-                s.add(Arguments.of("invalid id", validPayload(p -> p.put("id", "not-uuid")), MSG_IP));
+                s.add(Arguments.of("invalid id", validAttempt(p -> p.put("id", "not-uuid")), MSG_IP));
 
                 // user_id
                 addNonEmptyCasesFor("user_id", s);
-                s.add(Arguments.of("non-numeric user_id", validPayload(p -> p.put("user_id", "ab")), MSG_IP));
-                s.add(Arguments.of("wrong user_id", validPayload(p -> p.put("user_id", TEST_STUDENT_ID + 1)),
+                s.add(Arguments.of("non-numeric user_id", validAttempt(p -> p.put("user_id", "ab")), MSG_IP));
+                s.add(Arguments.of("wrong user_id", validAttempt(p -> p.put("user_id", TEST_STUDENT_ID + 1)),
                     "Payload user_id does not match session"));
 
                 // skill_assignment_id
-                s.add(Arguments.of("missing skill_assignment_id", validPayload(p -> p.remove("skill_assignment_id")),
+                s.add(Arguments.of("missing skill_assignment_id", validAttempt(p -> p.remove("skill_assignment_id")),
                     MSG_IP));
                 s.add(Arguments.of("non-null skill_assignment_id",
-                    validPayload(p -> p.put("skill_assignment_id", "some_id")), MSG_IP));
+                    validAttempt(p -> p.put("skill_assignment_id", "some_id")), MSG_IP));
 
                 // skill_id
                 addNonEmptyCasesFor("skill_id", s);
-                s.add(Arguments.of("wrong skill_id", validPayload(p -> p.put("skill_id", "wrong_skill_id")),
+                s.add(Arguments.of("wrong skill_id", validAttempt(p -> p.put("skill_id", "wrong_skill_id")),
                     "Payload skill_id does not match app"));
 
                 // subskill_id
@@ -175,26 +173,26 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
 
                 // question
                 addNonEmptyCasesFor("question", s);
-                s.add(Arguments.of("invalid question JSON, str", validPayload(p -> p.put("question", "ab")), MSG_IP));
-                s.add(Arguments.of("invalid question JSON, number", validPayload(p -> p.put("question", 1)), MSG_IP));
+                s.add(Arguments.of("invalid question JSON, str", validAttempt(p -> p.put("question", "ab")), MSG_IP));
+                s.add(Arguments.of("invalid question JSON, number", validAttempt(p -> p.put("question", 1)), MSG_IP));
 
                 // question_attempt
                 addNonEmptyCasesFor("question_attempt", s);
-                s.add(Arguments.of("invalid attempts JSON", validPayload(p -> p.put("question_attempt", "a")), MSG_IP));
+                s.add(Arguments.of("invalid attempts JSON", validAttempt(p -> p.put("question_attempt", "a")), MSG_IP));
 
                 // marks
                 addNonEmptyCasesFor("marks", s);
-                s.add(Arguments.of("invalid mark 2", validPayload(p -> p.put("marks", 2)), MSG_IP));
-                s.add(Arguments.of("invalid mark -0.4", validPayload(p -> p.put("marks", -0.4)), MSG_IP));
+                s.add(Arguments.of("invalid mark 2", validAttempt(p -> p.put("marks", 2)), MSG_IP));
+                s.add(Arguments.of("invalid mark -0.4", validAttempt(p -> p.put("marks", -0.4)), MSG_IP));
 
                 // timestamp
                 addNonEmptyCasesFor("timestamp", s);
-                s.add(Arguments.of("invalid timestamp", validPayload(p -> p.put("timestamp", "n/d")), MSG_IP));
-                s.add(Arguments.of("expired timestamp", validPayload(p -> p.put("timestamp", "2022-01-01T13:00:00Z")),
+                s.add(Arguments.of("invalid timestamp", validAttempt(p -> p.put("timestamp", "n/d")), MSG_IP));
+                s.add(Arguments.of("expired timestamp", validAttempt(p -> p.put("timestamp", "2022-01-01T13:00:00Z")),
                     "Payload timestamp is outside the allowed window"));
 
                 // other cases
-                s.add(Arguments.of("extra value", validPayload(p -> p.put("extra", "value")), MSG_IP));
+                s.add(Arguments.of("extra value", validAttempt(p -> p.put("extra", "value")), MSG_IP));
 
                 return s.build();
             }
@@ -202,38 +200,35 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             @ParameterizedTest(name = "{0}")
             @MethodSource("invalidPayloads")
             public void invalidPayload_Returns400(
-                final String name, final String payload, final String expectedMessage
+                final String name, final JSONObject payload, final String expectedMessage
             ) throws Exception {
                 testServer().client()
                     .loginAs(integrationTestUsers.TEST_STUDENT)
-                    .post(VALID_URL, new JSONObject()
-                        .put("payload", payload)
-                        .put("hmac", sign(HMAC_SECRET, payload, HMAC_SHA_256)))
+                    .post(validUrl(), validBody(payload))
                     .assertError(expectedMessage, Response.Status.BAD_REQUEST);
             }
 
             private static void addNonEmptyCasesFor(final String fieldName, final Stream.Builder<Arguments> s) {
-                s.add(Arguments.of("missing " + fieldName, validPayload(p -> p.remove(fieldName)), MSG_IP));
-                s.add(Arguments.of("null " + fieldName, validPayload(p -> p.put(fieldName, JSONObject.NULL)), MSG_IP));
-                s.add(Arguments.of("empty " + fieldName, validPayload(p -> p.put(fieldName, "")), MSG_IP));
+                s.add(Arguments.of("missing " + fieldName, validAttempt(p -> p.remove(fieldName)), MSG_IP));
+                s.add(Arguments.of("null " + fieldName, validAttempt(p -> p.put(fieldName, JSONObject.NULL)), MSG_IP));
+                s.add(Arguments.of("empty " + fieldName, validAttempt(p -> p.put(fieldName, "")), MSG_IP));
             }
         }
 
         @Test
         public void duplicateAttemptId_Returns409() throws Exception {
-            var testP = validPayload(null);
-            var testBody = new JSONObject().put("payload", testP).put("hmac", sign(HMAC_SECRET, testP, HMAC_SHA_256));
+            var testBody = validBody(validAttempt(null));
             var client = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
-            client.post(VALID_URL, testBody).readEntity(String.class);
-            client.post(VALID_URL, testBody).assertError("Duplicate attempt ID.", Response.Status.CONFLICT);
+            client.post(validUrl(), testBody).readEntity(String.class);
+            client.post(validUrl(), testBody).assertError("Duplicate attempt ID.", Response.Status.CONFLICT);
         }
 
         @Test
         public void happy_happy() throws Exception {
-            var expected = new JSONArray(VALID_PAYLOAD).getJSONObject(0);
+            var expectedAttempt = validAttempt(null);
             var actualReq = testServer().client()
                 .loginAs(integrationTestUsers.TEST_STUDENT)
-                .post(VALID_URL, VALID_BODY)
+                .post(validUrl(), validBody(expectedAttempt))
                 .readEntityAsJsonArray().getJSONObject(0);
 
             // assert there is exactly 1 row in the database
@@ -253,30 +248,32 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
                      FROM public.skills_question_attempts""");
                  var actualDb = pst.executeQuery()) {
                 actualDb.next();
-                assertEquals(expected.getString("id"), actualDb.getString("id"));
-                assertEquals(expected.getInt("user_id"), actualDb.getInt("user_id"));
+                assertEquals(expectedAttempt.getString("id"), actualDb.getString("id"));
+                assertEquals(expectedAttempt.getInt("user_id"), actualDb.getInt("user_id"));
                 assertNull(actualDb.getString("skill_assignment_id"));
-                assertEquals(expected.getString("skill_id"), actualDb.getString("skill_id"));
-                assertEquals(expected.get("subskill_id").toString(), actualDb.getString("subskill_id"));
-                assertEquals(expected.getJSONObject("question").getString("text"), actualDb.getString("question_text"));
-                assertEquals(expected.getJSONObject("question").getString("answer"),
+                assertEquals(expectedAttempt.getString("skill_id"), actualDb.getString("skill_id"));
+                assertEquals(expectedAttempt.get("subskill_id").toString(), actualDb.getString("subskill_id"));
+                assertEquals(expectedAttempt.getJSONObject("question").getString("text"),
+                    actualDb.getString("question_text"));
+                assertEquals(expectedAttempt.getJSONObject("question").getString("answer"),
                     actualDb.getString("question_answer"));
-                assertEquals(expected.getJSONObject("question_attempt").getString("result"),
+                assertEquals(expectedAttempt.getJSONObject("question_attempt").getString("result"),
                     actualDb.getString("result"));
-                assertEquals(expected.getInt("marks"), actualDb.getInt("marks"));
+                assertEquals(expectedAttempt.getInt("marks"), actualDb.getInt("marks"));
                 assertThat(actualDb.getTimestamp("timestamp").toInstant())
-                    .isCloseTo(expected.getString("timestamp"), within(5, ChronoUnit.SECONDS));
+                    .isCloseTo(expectedAttempt.getString("timestamp"), within(5, ChronoUnit.SECONDS));
             }
 
             // assert the request echoes back the payload
-            assertEquals(expected.getString("id"), actualReq.getString("id"));
-            assertEquals(expected.getInt("user_id"), actualReq.getInt("user_id"));
-            assertEquals(expected.getString("skill_id"), actualReq.getString("skill_id"));
-            assertEquals(expected.get("subskill_id").toString(), actualReq.getString("subskill_id"));
-            assertEquals(expected.getJSONObject("question").toString(), actualReq.getJSONObject("question").toString());
-            assertEquals(expected.getJSONObject("question_attempt").toString(),
+            assertEquals(expectedAttempt.getString("id"), actualReq.getString("id"));
+            assertEquals(expectedAttempt.getInt("user_id"), actualReq.getInt("user_id"));
+            assertEquals(expectedAttempt.getString("skill_id"), actualReq.getString("skill_id"));
+            assertEquals(expectedAttempt.get("subskill_id").toString(), actualReq.getString("subskill_id"));
+            assertEquals(expectedAttempt.getJSONObject("question").toString(),
+                actualReq.getJSONObject("question").toString());
+            assertEquals(expectedAttempt.getJSONObject("question_attempt").toString(),
                 actualReq.getJSONObject("question_attempt").toString());
-            assertEquals(expected.getInt("marks"), actualReq.getInt("marks"));
+            assertEquals(expectedAttempt.getInt("marks"), actualReq.getInt("marks"));
             assertFalse(actualReq.has("skill_assignment_id"));
         }
 
@@ -295,7 +292,7 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             }
         }
 
-        private static String validPayload(final Consumer<JSONObject> op) {
+        private static JSONObject validAttempt(final Consumer<JSONObject> op) {
             var defaultPayload = new JSONObject()
                 .put("id", UUID.randomUUID().toString())
                 .put("user_id", TEST_STUDENT_ID)
@@ -309,7 +306,13 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             if (op != null) {
                 op.accept(defaultPayload);
             }
-            return new JSONArray().put(defaultPayload).toString();
+            return defaultPayload;
+        }
+
+        private static String validBody(final JSONObject... attempts) {
+            var payload = new JSONArray(attempts);
+            var hmac = sign(AnswerQuestion.HMAC_SECRET, payload.toString(), AnswerQuestion.HMAC_SHA_256);
+            return new JSONObject().put("payload", payload.toString()).put("hmac", hmac).toString();
         }
 
         private static String sign(final String key, final String payload, final String algo) {
@@ -400,6 +403,39 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
             assertPastYearsMonthlyMathsResults(response, NO_ATTEMPTS_ANY_MONTH);
         }
 
+        @Test
+        public void twoAttemptsWithinPeriod_returnsBothAttempts() throws Exception {
+            registerCleanup(() -> {
+                deleteSkillsAttempts();
+                SkillsAttemptManager.FIVE_MINUTES_IN_MILLIS = 300_000L;
+            });
+            SkillsAttemptManager.FIVE_MINUTES_IN_MILLIS = 365L * 24 * 60 * 60 * 1000;
+            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            studentClient.post(AnswerQuestion.validUrl(), AnswerQuestion.validBody(
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                                                  .put("timestamp", Instant.now())),
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                                                  .put("timestamp",
+                                                      LocalDate.now().withDayOfMonth(1).minusMonths(11) + "T00:00:00Z")
+            ))).readEntity(String.class);
+
+            var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
+
+            assertPastYearsMonthlyMathsResults(response, ImmutableList.of(1L, 0L, 0L, 0L, 0L, 0L,
+                0L, 0L, 0L, 0L, 0L, 1L));
+        }
+
+        private static void deleteSkillsAttempts() throws SQLException {
+            try (var conn = postgresSqlDb.getDatabaseConnection();
+                 var pst = conn.prepareStatement("DELETE FROM public.skills_question_attempts WHERE TRUE;")) {
+                pst.executeUpdate();
+            }
+        }
+
+        /*
+         * On "2026-07-10", assertPastYearsMonthlyMathsResults(resp, [0, 0, ..., 0]) checks that the response is
+         * { "mental_maths_overall": { "2026-07-01: 0, 2026-06-01: 0, ... 2025-08-01: 0" } }
+         */
         private void assertPastYearsMonthlyMathsResults(final TestResponse resp, final List<Long> expectations) {
             JSONObject mentalMathsResults = resp.readEntityAsJson().getJSONObject("mental_maths_overall");
             assertEquals(12, mentalMathsResults.keySet().size(), "Expected 12 years worth of mental maths results");


### PR DESCRIPTION
This adds an endpoint to show skills on My Progress.

It's just the one app for now, and given how close the symposium is, the following are hardcoded:
- this only ever shows attempts from the Mental Maths Practice App. The UI is hardcoded to only show this (we don't have app discovery yet), but I thought it might be a privacy concern having the endpoint return more data than is visible to users on the UI. In the privacy policy, we tell users to expect their teachers seeing the contents of their My Progress page, so I thought it important that this data is indeed what's accessible to a teacher.
- for now, always shows results from the past year. In the future, these will probably be parameters, but I didn't want to introduce them just yet (it'd be extra work validating these)
- For now, this is not cached, but if @jsharkey13 thinks this would important, I can get it done quickly!
- Not a concern for now as there's just the one app, but I wondered if @jsharkey13 has a preference whether to always return results from all apps, or for the app to be a parameter and return results just for the requested app. The second is simpler, while the first might be more performant.
---

**Pull Request Check List**
- [x] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [] Security - Data Exposure - Test any altered or created endpoints using [swagger](http://localhost:8080/isaac-api/api-docs/)
- [x] Security - Access Control - Check authorisation on every new endpoint
- ~[ ] Security - New dependency - configured sensibly not relying on defaults
- ~[ ] Security - New dependency - Searched for any know vulnerabilities
- ~[ ] Security - New dependency - Signed up team to mailing list
- ~[ ] Security - New dependency - Added to dependency list
- ~[ ] DB schema changes - postgres-rutherford-create-script updated
- ~[ ] DB schema changes - upgrade script created matching create script
- ~[ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [x] Peer-Reviewed
