### PR TITLE
Add content error for empty question pages

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -1009,7 +1009,7 @@ public class ContentIndexer {
         if (content instanceof IsaacQuestionPage qp
                 && flattenContentObjects(content).stream()
                 .allMatch(c -> !(c instanceof Question) || c instanceof IsaacQuickQuestion)) {
-            this.registerContentProblem(content, "Question page: " + qp.getId() + " found without any markable questions."
+            this.registerContentProblem(content, "Question page: " + qp.getId() + " found without any markable questions. "
                     + "Question progress will not be recorded correctly.", indexProblemCache);
         }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -990,6 +990,14 @@ public class ContentIndexer {
                 }
             }
         }
+
+        if (content instanceof IsaacQuestionPage qp
+                && content.getChildren().stream()
+                .allMatch(child -> !(child instanceof Question) || child instanceof IsaacQuickQuestion)) {
+            this.registerContentProblem(content, "Question page: " + qp.getId() + " found without any answerable questions.",
+                    indexProblemCache);
+        }
+
         if (content instanceof Question && content.getId() == null) {
             this.registerContentProblem(content, "Question: " + content.getTitle() + " in " + content.getCanonicalSourceFile()
                     + " found without a unqiue id. " + "This question cannot be logged correctly.", indexProblemCache);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -991,6 +991,21 @@ public class ContentIndexer {
             }
         }
 
+        if (content instanceof EmailTemplate e) {
+            if (e.getPlainTextContent() == null) {
+                this.registerContentProblem(content,
+                        "Email template should always have plain text content field", indexProblemCache);
+            }
+        }
+
+        if (content instanceof IsaacEventPage e) {
+            if (e.getEndDate() == null) {
+                this.registerContentProblem(content, "Event has no end date", indexProblemCache);
+            } else if (e.getEndDate().before(e.getDate())) {
+                this.registerContentProblem(content, "Event has end date before start date", indexProblemCache);
+            }
+        }
+
         if (content instanceof IsaacQuestionPage qp
                 && content.getChildren().stream()
                 .allMatch(child -> !(child instanceof Question) || child instanceof IsaacQuickQuestion)) {
@@ -1022,21 +1037,6 @@ public class ContentIndexer {
                             "Question: " + question.getId() + " found without a correct answer. "
                                     + "This question will always be automatically marked as incorrect", indexProblemCache);
                 }
-            }
-        }
-
-        if (content instanceof EmailTemplate e) {
-            if (e.getPlainTextContent() == null) {
-                this.registerContentProblem(content,
-                        "Email template should always have plain text content field", indexProblemCache);
-            }
-        }
-
-        if (content instanceof IsaacEventPage e) {
-            if (e.getEndDate() == null) {
-                this.registerContentProblem(content, "Event has no end date", indexProblemCache);
-            } else if (e.getEndDate().before(e.getDate())) {
-                this.registerContentProblem(content, "Event has end date before start date", indexProblemCache);
             }
         }
 
@@ -1222,6 +1222,7 @@ public class ContentIndexer {
                     indexProblemCache);
             }
         }
+
         if (content instanceof SkillsApp a) {
             if (null == a.getId()) {
                 this.registerContentProblem(content, "Skill app is missing an id.", indexProblemCache);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -1007,10 +1007,10 @@ public class ContentIndexer {
         }
 
         if (content instanceof IsaacQuestionPage qp
-                && content.getChildren().stream()
-                .allMatch(child -> !(child instanceof Question) || child instanceof IsaacQuickQuestion)) {
-            this.registerContentProblem(content, "Question page: " + qp.getId() + " found without any answerable questions.",
-                    indexProblemCache);
+                && flattenContentObjects(content).stream()
+                .allMatch(c -> !(c instanceof Question) || c instanceof IsaacQuickQuestion)) {
+            this.registerContentProblem(content, "Question page: " + qp.getId() + " found without any markable questions."
+                    + "Question progress will not be recorded correctly.", indexProblemCache);
         }
 
         if (content instanceof Question && content.getId() == null) {


### PR DESCRIPTION
Adds a content error for question pages without any answerable questions, such as [qmp_ch3_q1](https://isaacscience.org/questions/qmp_ch3_q1). These are not valid and so will not behave consistently.

(Also reorders some content errors so that all those related to questions are adjacent and so easier to find)