### PR TITLE
Fix/skills review findings

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacade.java
@@ -44,6 +44,7 @@ import java.util.Map;
 @Tag(name = "SkillsFacade", description = "/skills")
 public class SkillsFacade extends AbstractIsaacFacade {
     private static final Logger log = LoggerFactory.getLogger(SkillsFacade.class);
+    private static final String MENTAL_MATHS_ID = "app_page_mental_maths_overall|0e184f9d-b619-4225-ac12-3c96d3c74046";
 
     private final UserAccountManager userManager;
     private final GitContentManager contentManager;
@@ -153,7 +154,8 @@ public class SkillsFacade extends AbstractIsaacFacade {
             }
 
             HashMap<String, Map<LocalDate, Long>> resultsMap = new HashMap<>();
-            resultsMap.put("mental_maths_overall", skillsAttemptManager.getMentalMathsAttempts(
+            resultsMap.put("mental_maths_overall", skillsAttemptManager.getAppAttempts(
+                MENTAL_MATHS_ID,
                 userIdOfInterest,
                 LocalDate.now().withDayOfMonth(1).minusMonths(11),
                 LocalDate.now().withDayOfMonth(1).plusMonths(1).minusDays(1)

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
@@ -25,13 +25,13 @@ import static uk.ac.cam.cl.dtg.segue.api.Constants.*;
 public class SkillsAttemptManager {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final int MAX_PAYLOAD_LENGTH = 30 * 1024; // about 30 kilobytes for English payloads, even Unicode
-    public static long FIVE_MINUTES_IN_MILLIS = 300_000L;
 
     private final String hmacSecret;
     private final ISkillsAttemptPersistenceManager persistence;
+    private final Long maxTimestampAgeMillis;
 
     /**
-     * Constructor.
+     * Constructor used by Guice for live site.
      *
      * @param properties          - application configuration
      * @param skillsAttemptManager - persistence manager for skills attempts
@@ -39,8 +39,24 @@ public class SkillsAttemptManager {
     @Inject
     public SkillsAttemptManager(
             final AbstractConfigLoader properties, final ISkillsAttemptPersistenceManager skillsAttemptManager) {
+        Long fiveMinutesInMillis = 300_000L;
+        this(properties, skillsAttemptManager, fiveMinutesInMillis);
+    }
+
+    /**
+     * Constructor used for integration tests.
+     *
+     * @param properties          - application configuration
+     * @param skillsAttemptManager - persistence manager for skills attempts
+     * @param maxTimestampAgeMillis - the age, in milliseconds, of the oldest timestamp we should still allow
+     */
+    public SkillsAttemptManager(
+        final AbstractConfigLoader properties, final ISkillsAttemptPersistenceManager skillsAttemptManager,
+        final Long maxTimestampAgeMillis
+    ) {
         this.hmacSecret = properties.getProperty(SKILLS_HMAC_SECRET);
         this.persistence = skillsAttemptManager;
+        this.maxTimestampAgeMillis = maxTimestampAgeMillis;
     }
 
     /**
@@ -75,7 +91,7 @@ public class SkillsAttemptManager {
                 throw new InvalidAnvilMarkingRequestException("Payload user_id does not match session.", null);
             }
             if (dtos.stream().anyMatch(
-                    dto -> dto.getTimestamp().before(new Date(System.currentTimeMillis() - FIVE_MINUTES_IN_MILLIS)))) {
+                    dto -> dto.getTimestamp().before(new Date(System.currentTimeMillis() - maxTimestampAgeMillis)))) {
                 throw new InvalidAnvilMarkingRequestException("Payload timestamp is outside the allowed window.", null);
             }
             if (dtos.stream().anyMatch(dto -> !dto.getSkillId().equals(appId))) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/SkillsAttemptManager.java
@@ -104,8 +104,9 @@ public class SkillsAttemptManager {
      *
      * @param to - return attempts until this date (exclusive)
      */
-    public Map<LocalDate, Long> getMentalMathsAttempts(final Long userId, final LocalDate from, final LocalDate to)
+    public Map<LocalDate, Long> getAppAttempts(
+        final String appId, final Long userId, final LocalDate from, final LocalDate to)
         throws SegueDatabaseException {
-        return persistence.getMentalMathsAttempts(userId, from, to);
+        return persistence.getAppAttempts(appId, userId, from, to);
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgSkillsAttemptPersistenceManager.java
@@ -20,8 +20,6 @@ import java.util.Map;
 
 /** PostgreSQL-backed persistence for Anvil skills question attempts. */
 public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersistenceManager {
-    private static final String MENTAL_MATHS_ID = "app_page_mental_maths_overall|0e184f9d-b619-4225-ac12-3c96d3c74046";
-
     private final PostgresSqlDb database;
 
     @Inject
@@ -64,8 +62,9 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
     }
 
     @Override
-    public Map<LocalDate, Long> getMentalMathsAttempts(final Long userId, final LocalDate from, final LocalDate to)
-        throws SegueDatabaseException {
+    public Map<LocalDate, Long> getAppAttempts(
+        final String appId, final Long userId, final LocalDate from, final LocalDate to
+    ) throws SegueDatabaseException {
         try (Connection conn = database.getDatabaseConnection();
              PreparedStatement pst = conn.prepareStatement("""
                 WITH dates AS (
@@ -90,7 +89,7 @@ public class PgSkillsAttemptPersistenceManager implements ISkillsAttemptPersiste
             pst.setObject(2, to);
             pst.setLong(3, userId);
             pst.setObject(4, from);
-            pst.setString(5, MENTAL_MATHS_ID);
+            pst.setString(5, appId);
             ResultSet results = pst.executeQuery();
             HashMap<LocalDate, Long> resultsMap = new HashMap<>();
             while (results.next()) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISkillsAttemptPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/ISkillsAttemptPersistenceManager.java
@@ -13,6 +13,6 @@ public interface ISkillsAttemptPersistenceManager {
     void registerSkillsAttempt(final List<AnvilPayloadDTO> attempt)
         throws DuplicateSkillsAttemptException, SegueDatabaseException;
 
-    Map<LocalDate, Long> getMentalMathsAttempts(final Long userId, final LocalDate from, final LocalDate to)
+    Map<LocalDate, Long> getAppAttempts(final String appId, final Long userId, final LocalDate from, final LocalDate to)
         throws SegueDatabaseException;
 }

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ElasticSearchTestHelper.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/ElasticSearchTestHelper.java
@@ -41,7 +41,7 @@ public class ElasticSearchTestHelper {
         return content;
     }
 
-    /** Indexes a raw JSON content object with a fixed ID of {@code "i1"} and returns it. */
+    /** Indexes a raw JSON content object and returns it. Unless an id is provided, sets `i1` as the id. */
     public JSONObject persistJSON(final JSONObject contentJSON) throws Exception {
         if (!contentJSON.has("id")) {
             contentJSON.put("id", "i1");

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/SkillsFacadeIT.java
@@ -57,7 +57,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         class AppIdCheck {
             @Test
             public void elasticsearchUnavailable_Returns404() throws Exception {
-                var client = testServer(brokenContentManager()).client().loginAs(integrationTestUsers.TEST_STUDENT);
+                var client = testServer(brokenContentManager(), null).client()
+                    .loginAs(integrationTestUsers.TEST_STUDENT);
                 var response = client.post("/skills/unknown_app/answer", VALID_BODY);
                 response.assertError("Error locating the version requested", Response.Status.NOT_FOUND);
             }
@@ -408,8 +409,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
 
         @Test
         public void attemptsWithinPeriod_bothCounted() throws Exception {
-            prepare();
-            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            registerCleanup(GetAttempts::deleteSkillsAttempts);
+            var studentClient = testServerExtendedAttemptAge().client().loginAs(integrationTestUsers.TEST_STUDENT);
             studentClient.post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
                   .put("timestamp", Instant.now())),
@@ -424,8 +425,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
 
         @Test
         public void attemptBeforeFirstDayOf12thMonth_notCounted() throws Exception {
-            prepare();
-            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            registerCleanup(GetAttempts::deleteSkillsAttempts);
+            var studentClient = testServerExtendedAttemptAge().client().loginAs(integrationTestUsers.TEST_STUDENT);
             var firstDayOf12thMonth = LocalDate.now().withDayOfMonth(1).minusMonths(11);
             studentClient.post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
@@ -440,8 +441,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
 
         @Test
         public void futureAttemptsWithinMonth_counted() throws Exception {
-            prepare();
-            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            registerCleanup(GetAttempts::deleteSkillsAttempts);
+            var studentClient = testServerExtendedAttemptAge().client().loginAs(integrationTestUsers.TEST_STUDENT);
             var firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
             studentClient.post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
@@ -456,8 +457,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
 
         @Test
         public void attemptsInFutureMonth_notCounted() throws Exception {
-            prepare();
-            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            registerCleanup(GetAttempts::deleteSkillsAttempts);
+            var studentClient = testServerExtendedAttemptAge().client().loginAs(integrationTestUsers.TEST_STUDENT);
             var futureMonth = LocalDate.now().withDayOfMonth(1).plusMonths(1);
             studentClient.post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
@@ -471,8 +472,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         }
 
         @Test public void attemptsByOtherUser_notCounted() throws Exception {
-            prepare();
-            testServer().client().loginAs(integrationTestUsers.ALICE_STUDENT)
+            registerCleanup(GetAttempts::deleteSkillsAttempts);
+            testServerExtendedAttemptAge().client().loginAs(integrationTestUsers.ALICE_STUDENT)
                 .post(AnswerQuestion.validUrl(null), AnswerQuestion.validBody(
                     AnswerQuestion.validAttempt(a -> a.put("user_id", ALICE_STUDENT_ID)
                         .put("timestamp", LocalDate.now().withDayOfMonth(1) + "T00:00:00Z"))
@@ -484,8 +485,8 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         }
 
         @Test public void attemptsOtherThanMentalMaths_notCounted() throws Exception {
-            prepare();
-            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            registerCleanup(GetAttempts::deleteSkillsAttempts);
+            var studentClient = testServerExtendedAttemptAge().client().loginAs(integrationTestUsers.TEST_STUDENT);
             studentClient.post(AnswerQuestion.validUrl("irrelevant_app_id"), AnswerQuestion.validBody(
                 AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
                     .put("timestamp", LocalDate.now() + "T00:00:00Z")
@@ -502,12 +503,12 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         }
 
         @Test public void emptyAttempts_notCounted() throws Exception {
-            prepare();
-            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            registerCleanup(GetAttempts::deleteSkillsAttempts);
+            var studentClient = testServerExtendedAttemptAge().client().loginAs(integrationTestUsers.TEST_STUDENT);
             studentClient.post(AnswerQuestion.validUrl(AnswerQuestion.VALID_APP_ID), AnswerQuestion.validBody(
-                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
-                        .put("timestamp", LocalDate.now() + "T00:00:00Z")
-                        .put("question_attempt", new JSONObject().put("result", "")))
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp", LocalDate.now() + "T00:00:00Z")
+                    .put("question_attempt", new JSONObject().put("result", "")))
             )).readEntity(String.class);
 
             var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
@@ -515,12 +516,12 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
         }
 
         @Test public void anomalousAttemptWithoutResult_notCounted() throws Exception {
-            prepare();
-            var studentClient = testServer().client().loginAs(integrationTestUsers.TEST_STUDENT);
+            registerCleanup(GetAttempts::deleteSkillsAttempts);
+            var studentClient = testServerExtendedAttemptAge().client().loginAs(integrationTestUsers.TEST_STUDENT);
             studentClient.post(AnswerQuestion.validUrl(AnswerQuestion.VALID_APP_ID), AnswerQuestion.validBody(
-                    AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
-                            .put("timestamp", LocalDate.now() + "T00:00:00Z")
-                            .put("question_attempt", new JSONObject()))
+                AnswerQuestion.validAttempt(a -> a.put("user_id", TEST_STUDENT_ID)
+                    .put("timestamp", LocalDate.now() + "T00:00:00Z")
+                    .put("question_attempt", new JSONObject()))
             )).readEntity(String.class);
 
             var response = studentClient.get(String.format("/skills/attempts/%s", TEST_STUDENT_ID));
@@ -532,14 +533,6 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
                  var pst = conn.prepareStatement("DELETE FROM public.skills_question_attempts WHERE TRUE;")) {
                 pst.executeUpdate();
             }
-        }
-
-        private void prepare() {
-            registerCleanup(() -> {
-                deleteSkillsAttempts();
-                SkillsAttemptManager.FIVE_MINUTES_IN_MILLIS = 300_000L;
-            });
-            SkillsAttemptManager.FIVE_MINUTES_IN_MILLIS = 365L * 24 * 60 * 60 * 1000;
         }
 
         /*
@@ -557,14 +550,28 @@ public class SkillsFacadeIT extends IsaacIntegrationTestWithREST {
     }
 
     private TestServer testServer() throws Exception {
-        return testServer(contentManager);
+        return testServer(null, null);
     }
 
-    private TestServer testServer(final GitContentManager cm) throws Exception {
-        var sm = new SkillsAttemptManager(properties, new PgSkillsAttemptPersistenceManager(postgresSqlDb));
+    private TestServer testServer(
+        final GitContentManager gitContentManager, final SkillsAttemptManager skillsAttemptManager
+    ) throws Exception {
         return startServer(
             new AuthenticationFacade(properties, userAccountManager, logManager, misuseMonitor),
-            new SkillsFacade(properties, userAccountManager, logManager, cm, sm, userAssociationManager)
+            new SkillsFacade(
+                properties,
+                userAccountManager,
+                logManager,
+                gitContentManager != null ? gitContentManager : contentManager,
+                skillsAttemptManager != null ? skillsAttemptManager : new SkillsAttemptManager(
+                    properties, new PgSkillsAttemptPersistenceManager(postgresSqlDb)),
+                userAssociationManager)
         );
+    }
+
+    private TestServer testServerExtendedAttemptAge() throws Exception {
+        Long oneYearInMillis = 365L * 24 * 60 * 60 * 1000;
+        return testServer(null, new SkillsAttemptManager(properties,
+                new PgSkillsAttemptPersistenceManager(postgresSqlDb), oneYearInMillis));
     }
 }


### PR DESCRIPTION
This addresses the review findings from https://github.com/isaacphysics/isaac-api/pull/808.
- https://github.com/isaacphysics/isaac-api/pull/808#discussion_r3571980239: I've updated the javadoc, 
- https://github.com/isaacphysics/isaac-api/pull/808#discussion_r3571744097: the appId is now hardcoded in the facade,
- https://github.com/isaacphysics/isaac-api/pull/808#discussion_r3571700463: the configuration value is now final and no longer has a misleading name
- https://github.com/isaacphysics/isaac-api/pull/808#discussion_r3571974565: a [separate PR](https://github.com/barna-isaac/skills-app-mental-maths/pull/5) to the anvil app makes sure it's no longer recording empty attempts, but the endpoint won't be enforcing this as we've agreed the `question_attempt` field should be opaque json. once that is merged, we'll be able to clean up the empty attempts and remove `AND LENGTH(question_attempt->>'result') > 0`.