### PR TITLE
Add useSingleList setting to reorder/parsons questions

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacParsonsQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacParsonsQuestion.java
@@ -32,6 +32,7 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 public class IsaacParsonsQuestion extends IsaacItemQuestion {
 
     private Boolean disableIndentation;
+    private Boolean useSingleList;
 
     public Boolean getDisableIndentation() {
         return disableIndentation;
@@ -39,5 +40,13 @@ public class IsaacParsonsQuestion extends IsaacItemQuestion {
 
     public void setDisableIndentation(final Boolean disableIndentation) {
         this.disableIndentation = disableIndentation;
+    }
+
+    public Boolean getUseSingleList() {
+        return useSingleList;
+    }
+
+    public void setUseSingleList(Boolean useSingleList) {
+        this.useSingleList = useSingleList;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacReorderQuestion.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacReorderQuestion.java
@@ -30,4 +30,14 @@ import uk.ac.cam.cl.dtg.isaac.quiz.ValidatesWith;
 @JsonContentType("isaacReorderQuestion")
 @ValidatesWith(IsaacReorderValidator.class)
 public class IsaacReorderQuestion extends IsaacItemQuestion {
+
+    private Boolean useSingleList;
+
+    public Boolean getUseSingleList() {
+        return useSingleList;
+    }
+
+    public void setUseSingleList(Boolean useSingleList) {
+        this.useSingleList = useSingleList;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacParsonsQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacParsonsQuestionDTO.java
@@ -25,6 +25,7 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
 public class IsaacParsonsQuestionDTO extends IsaacItemQuestionDTO {
 
     private Boolean disableIndentation;
+    private Boolean useSingleList;
 
     public Boolean getDisableIndentation() {
         return disableIndentation;
@@ -32,5 +33,13 @@ public class IsaacParsonsQuestionDTO extends IsaacItemQuestionDTO {
 
     public void setDisableIndentation(final Boolean disableIndentation) {
         this.disableIndentation = disableIndentation;
+    }
+
+    public Boolean getUseSingleList() {
+        return useSingleList;
+    }
+
+    public void setUseSingleList(Boolean useSingleList) {
+        this.useSingleList = useSingleList;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacReorderQuestionDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacReorderQuestionDTO.java
@@ -23,4 +23,14 @@ import uk.ac.cam.cl.dtg.isaac.dos.content.JsonContentType;
  */
 @JsonContentType("isaacReorderQuestion")
 public class IsaacReorderQuestionDTO extends IsaacItemQuestionDTO {
+
+    private Boolean useSingleList;
+
+    public Boolean getUseSingleList() {
+        return useSingleList;
+    }
+
+    public void setUseSingleList(Boolean useSingleList) {
+        this.useSingleList = useSingleList;
+    }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacParsonsValidator.java
@@ -78,7 +78,11 @@ public class IsaacParsonsValidator implements IValidator {
         // STEP 1: Did they provide a valid answer?
 
         if (null == feedback && (null == submittedChoice.getItems() || submittedChoice.getItems().isEmpty())) {
-            feedback = new Content(FEEDBACK_NO_ANSWER_PROVIDED);
+            if (null != parsonsQuestion.getUseSingleList() && parsonsQuestion.getUseSingleList()) {
+                feedback = new Content(FEEDBACK_NO_ANSWER_PROVIDED);
+            } else {
+                feedback = new Content("You did not provide an answer. Remember to move items from the available items to your answer.");
+            }
         }
 
         Set<String> submittedItemIdSet = null;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacReorderValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacReorderValidator.java
@@ -80,7 +80,11 @@ public class IsaacReorderValidator implements IValidator {
 
         if (null == feedback) {
             if (null == submittedChoice.getItems() || submittedChoice.getItems().isEmpty()) {
-                feedback = new Content(FEEDBACK_NO_ANSWER_PROVIDED);
+                if (null != reorderQuestion.getUseSingleList() && reorderQuestion.getUseSingleList()) {
+                    feedback = new Content(FEEDBACK_NO_ANSWER_PROVIDED);
+                    } else {
+                    feedback = new Content("You did not provide an answer. Remember to move items from the available items to your answer.");
+                }
             } else if (submittedChoice.getItems().stream().anyMatch(i -> i.getClass() != Item.class)) {
                 feedback = new Content(FEEDBACK_UNRECOGNISED_FORMAT);
             } else {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -1177,6 +1177,27 @@ public class ContentIndexer {
             }
         }
 
+        if (content instanceof IsaacReorderQuestion q || content instanceof IsaacParsonsQuestion) {
+            IsaacReorderQuestion q = (IsaacReorderQuestion) content;
+
+            if (q.getUseSingleList()) {
+                boolean allItemsMatch = q.getChoices().stream()
+                    .map(choice -> (ItemChoice) choice)
+                    .filter(ItemChoice::isCorrect)
+                    .allMatch(choice ->
+                            choice.getItems().size() == q.getItems().size()
+                                    && q.getItems().stream().allMatch(item ->
+                                    choice.getItems().stream()
+                                            .anyMatch(choiceItem -> Objects.equals(choiceItem.getId(), item.getId()))
+                            )
+                    );
+                if (!allItemsMatch) {
+                    this.registerContentProblem(content, "Reorder Question: " + q.getId() + " has useSingleList"
+                            + " and contains a correct answer with missing items.", indexProblemCache);
+                }
+            }
+        }
+
         if (content instanceof IsaacCoordinateQuestion q) {
 
             if (null == q.getSignificantFiguresMin() ^ null == q.getSignificantFiguresMax()) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -1189,10 +1189,10 @@ public class ContentIndexer {
 
         if (content instanceof IsaacParsonsQuestion q) {
             if (q.getUseSingleList()) {
-                if (q.getChoices().stream().map(ItemChoice.class::cast).filter(c -> !c.isAllowSubsetMatch())
+                if (q.getChoices().stream().map(ItemChoice.class::cast)
                         .allMatch(choice -> choice.getItems().size() == q.getItems().size())) {
                     this.registerContentProblem(content, "Parsons Question: " + q.getId() + " has useSingleList"
-                            + " and contains a non wildcard-matched answer with missing items.", indexProblemCache);
+                            + " and contains an answer with missing items.", indexProblemCache);
                 }
             }
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -1179,20 +1179,20 @@ public class ContentIndexer {
 
         if (content instanceof IsaacReorderQuestion q) {
             if (q.getUseSingleList()) {
-                if (q.getChoices().stream().map(ItemChoice.class::cast).filter(ItemChoice::isCorrect)
+                if (q.getChoices().stream().map(ItemChoice.class::cast).filter(c -> !c.isAllowSubsetMatch())
                         .allMatch(choice -> choice.getItems().size() == q.getItems().size())) {
                     this.registerContentProblem(content, "Reorder Question: " + q.getId() + " has useSingleList"
-                            + " and contains a correct answer with missing items.", indexProblemCache);
+                            + " and contains a non wildcard-matched answer with missing items.", indexProblemCache);
                 }
             }
         }
 
         if (content instanceof IsaacParsonsQuestion q) {
             if (q.getUseSingleList()) {
-                if (q.getChoices().stream().map(ItemChoice.class::cast).filter(ItemChoice::isCorrect)
+                if (q.getChoices().stream().map(ItemChoice.class::cast).filter(c -> !c.isAllowSubsetMatch())
                         .allMatch(choice -> choice.getItems().size() == q.getItems().size())) {
                     this.registerContentProblem(content, "Parsons Question: " + q.getId() + " has useSingleList"
-                            + " and contains a correct answer with missing items.", indexProblemCache);
+                            + " and contains a non wildcard-matched answer with missing items.", indexProblemCache);
                 }
             }
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/etl/ContentIndexer.java
@@ -1177,22 +1177,21 @@ public class ContentIndexer {
             }
         }
 
-        if (content instanceof IsaacReorderQuestion q || content instanceof IsaacParsonsQuestion) {
-            IsaacReorderQuestion q = (IsaacReorderQuestion) content;
-
+        if (content instanceof IsaacReorderQuestion q) {
             if (q.getUseSingleList()) {
-                boolean allItemsMatch = q.getChoices().stream()
-                    .map(choice -> (ItemChoice) choice)
-                    .filter(ItemChoice::isCorrect)
-                    .allMatch(choice ->
-                            choice.getItems().size() == q.getItems().size()
-                                    && q.getItems().stream().allMatch(item ->
-                                    choice.getItems().stream()
-                                            .anyMatch(choiceItem -> Objects.equals(choiceItem.getId(), item.getId()))
-                            )
-                    );
-                if (!allItemsMatch) {
+                if (q.getChoices().stream().map(ItemChoice.class::cast).filter(ItemChoice::isCorrect)
+                        .allMatch(choice -> choice.getItems().size() == q.getItems().size())) {
                     this.registerContentProblem(content, "Reorder Question: " + q.getId() + " has useSingleList"
+                            + " and contains a correct answer with missing items.", indexProblemCache);
+                }
+            }
+        }
+
+        if (content instanceof IsaacParsonsQuestion q) {
+            if (q.getUseSingleList()) {
+                if (q.getChoices().stream().map(ItemChoice.class::cast).filter(ItemChoice::isCorrect)
+                        .allMatch(choice -> choice.getItems().size() == q.getItems().size())) {
+                    this.registerContentProblem(content, "Parsons Question: " + q.getId() + " has useSingleList"
                             + " and contains a correct answer with missing items.", indexProblemCache);
                 }
             }


### PR DESCRIPTION
`useSingleList` is a boolean value to enable reordering reorder/parsons questions in-place rather than between lists.

All items must be required in answers for a single list to work (except when using subset matching, which only reorder questions support), so this adds a corresponding content error for both question types.

Also clarifies wording for questions not using `useSingleList` to help users understand that they must move items into the answer list.