### PR TITLE
see if adding a tiebreaking sort fixes build

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -449,6 +449,8 @@ public final class Constants {
 
     public static final Integer NO_SEARCH_LIMIT = -1;
 
+    public static final String ES_PSEUDOFIELD_SCORE = "ES_PSEUDOFIELD_SCORE";
+
     // Content model specific stuff
     public static final String ID_FIELDNAME = "id";
     public static final String TITLE_FIELDNAME = "title";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -59,6 +59,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -498,12 +499,20 @@ public class GitContentManager {
             }
         }
 
+        // Use a LinkedHashMap: addSortInstructions() adds a sort clause per entry in iteration order, so insertion
+        // order here determines primary vs. tie-breaking sort key.
+        Map<String, Constants.SortOrder> sortOrder = new LinkedHashMap<>();
         // If no search terms or random seed, sort by ascending alphabetical order of title.
-        Map<String, Constants.SortOrder> sortOrder = null;
         if (searchTerms.isEmpty() && null == randomSeed) {
-            sortOrder = new HashMap<>();
             sortOrder.put(
                     Constants.TITLE_FIELDNAME + "." + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX,
+                    Constants.SortOrder.ASC
+            );
+        // otherwise, order them by the strength of the match, and break ties using the id
+        } else {
+            sortOrder.put("_score", Constants.SortOrder.DESC);
+            sortOrder.put(
+                    Constants.ID_FIELDNAME + "." + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX,
                     Constants.SortOrder.ASC
             );
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -510,7 +510,7 @@ public class GitContentManager {
             );
         // otherwise, order them by the strength of the match, and break ties using the id
         } else {
-            sortOrder.put("_score", Constants.SortOrder.DESC);
+            sortOrder.put(Constants.ES_PSEUDOFIELD_SCORE, Constants.SortOrder.DESC);
             sortOrder.put(
                     Constants.ID_FIELDNAME + "." + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX,
                     Constants.SortOrder.ASC

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
@@ -235,10 +235,16 @@ public class ElasticSearchProvider implements ISearchProvider {
                             ? co.elastic.clients.elasticsearch._types.SortOrder.Asc
                             : co.elastic.clients.elasticsearch._types.SortOrder.Desc;
 
-            requestBuilder.sort(SortOptions.of(s -> s.field(f -> f
-                .field(sortField)
-                .order(clientOrder)
-                .missing("_last"))));
+            if ("_score".equals(sortField)) {
+                // _score is a special pseudo-field: it must use the dedicated score sort variant, which (unlike a
+                // field sort) does not support a "missing" value clause.
+                requestBuilder.sort(SortOptions.of(s -> s.score(sc -> sc.order(clientOrder))));
+            } else {
+                requestBuilder.sort(SortOptions.of(s -> s.field(f -> f
+                    .field(sortField)
+                    .order(clientOrder)
+                    .missing("_last"))));
+            }
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/search/ElasticSearchProvider.java
@@ -235,9 +235,7 @@ public class ElasticSearchProvider implements ISearchProvider {
                             ? co.elastic.clients.elasticsearch._types.SortOrder.Asc
                             : co.elastic.clients.elasticsearch._types.SortOrder.Desc;
 
-            if ("_score".equals(sortField)) {
-                // _score is a special pseudo-field: it must use the dedicated score sort variant, which (unlike a
-                // field sort) does not support a "missing" value clause.
+            if (Constants.ES_PSEUDOFIELD_SCORE.equals(sortField)) {
                 requestBuilder.sort(SortOptions.of(s -> s.score(sc -> sc.order(clientOrder))));
             } else {
                 requestBuilder.sort(SortOptions.of(s -> s.field(f -> f


### PR DESCRIPTION
I suspect `getQuestionList_searchByStringAsStudent_returnsQuestionsWithSimilarTitlesInOrder` has been breaking in the build because there's a tie between two results:
```
[2026-07-24 15:38:02] [WARN ] ElasticSearchProvider:330 - Search hit id=_regression_test_ score=159.95747
[2026-07-24 15:38:02] [WARN ] ElasticSearchProvider:330 - Search hit id=_assignment_test score=86.462524
[2026-07-24 15:38:02] [WARN ] ElasticSearchProvider:330 - Search hit id=_exact_match_test_ score=13.332279
[2026-07-24 15:38:02] [WARN ] ElasticSearchProvider:330 - Search hit id=_fuzzy_match_test_ score=13.332279
```
It's curious the test has been stable so far, and that this has not been a problem locally. Still, I wanted to see if explicitly breaking the tie fixes the problem.

Update: this indeed fixes the build.